### PR TITLE
feat: add binary that converts a circom `ZKey` to arkworks `ConstraintMatrices` and `ProvingKey`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4753,7 +4753,9 @@ dependencies = [
  "ark-ec 0.5.0",
  "ark-ff 0.5.0",
  "ark-serde-compat",
+ "ark-serialize 0.5.0",
  "circom-types",
+ "clap",
  "eddsa-babyjubjub",
  "eyre",
  "futures",
@@ -4769,6 +4771,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tracing",
+ "tracing-subscriber 0.3.20",
  "uuid",
  "witness",
 ]

--- a/oprf-client/Cargo.toml
+++ b/oprf-client/Cargo.toml
@@ -16,7 +16,9 @@ ark-bn254 = { workspace = true }
 ark-ec = { workspace = true }
 ark-ff = { workspace = true }
 ark-serde-compat = { workspace = true }
+ark-serialize = { workspace = true }
 circom-types.workspace = true
+clap = { workspace = true, features = ["derive"], optional = true }
 eddsa-babyjubjub = { workspace = true }
 eyre.workspace = true
 futures.workspace = true
@@ -29,7 +31,18 @@ rand.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, optional = true, features = ["net", "rt-multi-thread", "signal", "sync", "time", "tokio-macros"] }
+tokio = { workspace = true, optional = true, features = [
+    "net",
+    "rt-multi-thread",
+    "signal",
+    "sync",
+    "time",
+    "macros",
+] }
+tracing-subscriber = { workspace = true, features = [
+    "env-filter",
+    "fmt",
+], optional = true }
 tracing.workspace = true
 uuid = { workspace = true, features = ["serde", "v4"] }
 witness = { workspace = true }
@@ -37,8 +50,15 @@ witness = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 
+
 [features]
 default = ["tokio"]
 tokio = ["dep:tokio"]
 rustls = ["reqwest/rustls-tls"]
 native-tls = ["reqwest/native-tls"]
+bin = ["dep:tracing-subscriber", "dep:clap"]
+
+[[bin]]
+name = "convert_zkey_to_ark"
+path = "src/bin/convert_zkey_to_ark.rs"
+required-features = ["bin"]

--- a/oprf-client/src/bin/convert_zkey_to_ark.rs
+++ b/oprf-client/src/bin/convert_zkey_to_ark.rs
@@ -1,0 +1,89 @@
+use std::{
+    fs::File,
+    io::{BufReader, BufWriter},
+    path::PathBuf,
+};
+
+use ark_bn254::Bn254;
+use ark_serialize::CanonicalSerialize;
+use circom_types::{groth16::ZKey, traits::CheckElement};
+use clap::Parser;
+use oprf_client::ConstraintMatricesWrapper;
+
+fn install_tracing() {
+    use tracing_subscriber::prelude::*;
+    use tracing_subscriber::{
+        EnvFilter,
+        fmt::{self},
+    };
+
+    let fmt_layer = fmt::layer().with_target(false).with_line_number(false);
+    let filter_layer = EnvFilter::try_from_default_env()
+        .or_else(|_| EnvFilter::try_new("info"))
+        .unwrap();
+
+    tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(fmt_layer)
+        .init();
+}
+
+/// The configuration for the ZKey Conversion functionality.
+///
+/// It can be configured via environment variables or command line arguments using `clap`.
+#[derive(Parser, Debug)]
+pub struct ZKeyConvertConfig {
+    /// Path to the zkey.
+    #[clap(long, env = "ZKEY_PATH")]
+    pub zkey_path: PathBuf,
+
+    /// Output path to the matrices file.
+    #[clap(long, env = "MATRICES_PATH")]
+    pub matrices_path: PathBuf,
+
+    /// Output path to the proving key file.
+    #[clap(long, env = "PROVING_KEY_PATH")]
+    pub proving_key_path: PathBuf,
+
+    /// Use uncompressed serialization
+    #[clap(long, env = "UNCOMPRESSED")]
+    pub uncompressed: bool,
+}
+
+fn main() -> eyre::Result<()> {
+    install_tracing();
+    let config = ZKeyConvertConfig::parse();
+    tracing::info!("Converting zkey at {}", config.zkey_path.display());
+    let zkey = ZKey::<Bn254>::from_reader(
+        BufReader::new(File::open(config.zkey_path)?),
+        CheckElement::No,
+    )?;
+    tracing::info!("Loaded zkey");
+    let (query_matrices, query_pk) = zkey.into();
+    tracing::info!("Converted zkey");
+
+    ConstraintMatricesWrapper(query_matrices).serialize_with_mode(
+        BufWriter::new(File::create(&config.matrices_path)?),
+        if config.uncompressed {
+            ark_serialize::Compress::No
+        } else {
+            ark_serialize::Compress::Yes
+        },
+    )?;
+    tracing::info!("Serialized matrices to {}", config.matrices_path.display());
+
+    query_pk.serialize_with_mode(
+        File::create(&config.proving_key_path)?,
+        if config.uncompressed {
+            ark_serialize::Compress::No
+        } else {
+            ark_serialize::Compress::Yes
+        },
+    )?;
+    tracing::info!(
+        "Serialized proving key to {}",
+        config.proving_key_path.display()
+    );
+
+    Ok(())
+}

--- a/oprf-client/src/lib.rs
+++ b/oprf-client/src/lib.rs
@@ -59,9 +59,11 @@ pub use oprf_core::proof_input_gen::query::MAX_PUBLIC_KEYS;
 use crate::zk::{Groth16Error, Groth16Material};
 
 pub mod nonblocking;
+mod serialization;
 mod types;
 pub mod zk;
 
+pub use serialization::ConstraintMatricesWrapper;
 pub use types::CredentialsSignature;
 pub use types::MerkleMembership;
 pub use types::OprfQuery;

--- a/oprf-client/src/serialization.rs
+++ b/oprf-client/src/serialization.rs
@@ -1,0 +1,100 @@
+use ark_ff::PrimeField;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Valid};
+use groth16::ConstraintMatrices;
+
+/// A helper to enable [ConstraintMatrices] to be able to be serialized using [ark-serialize].
+pub struct ConstraintMatricesWrapper<F: PrimeField>(pub ConstraintMatrices<F>);
+
+impl<F: PrimeField> CanonicalSerialize for ConstraintMatricesWrapper<F> {
+    fn serialize_with_mode<W: std::io::Write>(
+        &self,
+        mut writer: W,
+        compress: ark_serialize::Compress,
+    ) -> Result<(), ark_serialize::SerializationError> {
+        self.0.a.serialize_with_mode(&mut writer, compress)?;
+        self.0.b.serialize_with_mode(&mut writer, compress)?;
+        self.0.c.serialize_with_mode(&mut writer, compress)?;
+        self.0
+            .a_num_non_zero
+            .serialize_with_mode(&mut writer, compress)?;
+        self.0
+            .b_num_non_zero
+            .serialize_with_mode(&mut writer, compress)?;
+        self.0
+            .c_num_non_zero
+            .serialize_with_mode(&mut writer, compress)?;
+        self.0
+            .num_instance_variables
+            .serialize_with_mode(&mut writer, compress)?;
+        self.0
+            .num_witness_variables
+            .serialize_with_mode(&mut writer, compress)?;
+        self.0
+            .num_constraints
+            .serialize_with_mode(&mut writer, compress)?;
+        Ok(())
+    }
+
+    fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
+        self.0.a.serialized_size(compress)
+            + self.0.b.serialized_size(compress)
+            + self.0.c.serialized_size(compress)
+            + self.0.a_num_non_zero.serialized_size(compress)
+            + self.0.b_num_non_zero.serialized_size(compress)
+            + self.0.c_num_non_zero.serialized_size(compress)
+            + self.0.num_instance_variables.serialized_size(compress)
+            + self.0.num_witness_variables.serialized_size(compress)
+            + self.0.num_constraints.serialized_size(compress)
+    }
+}
+
+impl<F: PrimeField> Valid for ConstraintMatricesWrapper<F> {
+    fn check(&self) -> Result<(), ark_serialize::SerializationError> {
+        self.0.a.check()?;
+        self.0.b.check()?;
+        self.0.c.check()?;
+        self.0.a_num_non_zero.check()?;
+        self.0.b_num_non_zero.check()?;
+        self.0.c_num_non_zero.check()?;
+        self.0.num_instance_variables.check()?;
+        self.0.num_witness_variables.check()?;
+        self.0.num_constraints.check()?;
+        Ok(())
+    }
+}
+
+impl<F: PrimeField> CanonicalDeserialize for ConstraintMatricesWrapper<F> {
+    fn deserialize_with_mode<R: std::io::Read>(
+        mut reader: R,
+        compress: ark_serialize::Compress,
+        validate: ark_serialize::Validate,
+    ) -> Result<Self, ark_serialize::SerializationError> {
+        let a = CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?;
+        let b = CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?;
+        let c = CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?;
+        let a_num_non_zero =
+            CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?;
+        let b_num_non_zero =
+            CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?;
+        let c_num_non_zero =
+            CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?;
+        let num_instance_variables =
+            CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?;
+        let num_witness_variables =
+            CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?;
+        let num_constraints =
+            CanonicalDeserialize::deserialize_with_mode(&mut reader, compress, validate)?;
+
+        Ok(ConstraintMatricesWrapper(ConstraintMatrices {
+            a,
+            b,
+            c,
+            a_num_non_zero,
+            b_num_non_zero,
+            c_num_non_zero,
+            num_instance_variables,
+            num_witness_variables,
+            num_constraints,
+        }))
+    }
+}


### PR DESCRIPTION
Main advantage is that the points in the ProvingKey are compressed, which saves about 1/3 of the zkey size. Also, loading arkworks structs is usually faster than ZkeyParsing.
