### PR TITLE
Docker image to ghcro.io

### DIFF
--- a/.github/workflows/build-and-push-oprf-service.yml
+++ b/.github/workflows/build-and-push-oprf-service.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - sg/ghcr
     tags:
       - 'oprf-service-v*'
 


### PR DESCRIPTION
Pushes the docker image to ghcr.io instead of the private ecr