### PR TITLE
chore: relax regex dep versioning & expose test types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ parking_lot = "0.12"
 poseidon2 = { package = "taceo-poseidon2", version = "0.1" }
 rand = { version = "0.8" }
 rand_chacha = { version = "0.3" }
-regex = "1.12.2"
+regex = "1"
 reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
     "json",

--- a/oprf-test/src/lib.rs
+++ b/oprf-test/src/lib.rs
@@ -3,6 +3,8 @@ use std::{path::PathBuf, sync::LazyLock, time::Duration};
 use alloy::primitives::{Address, address};
 use oprf_service::config::{Environment, OprfPeerConfig};
 
+pub use oprf_service::rp_registry::{RpRegistry, Types::EcDsaPubkeyCompressed};
+
 pub mod credentials;
 pub mod rp_registry_scripts;
 pub mod test_setup_utils;

--- a/oprf-test/src/rp_registry_scripts.rs
+++ b/oprf-test/src/rp_registry_scripts.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, path::PathBuf, process::Command, str::FromStr as _};
 
+use crate::EcDsaPubkeyCompressed;
 use alloy::primitives::Address;
-use oprf_service::rp_registry::Types;
 use oprf_types::RpId;
 use regex::Regex;
 
@@ -44,7 +44,7 @@ pub fn deploy_test_setup(
 pub fn init_key_gen(
     rpc_url: &str,
     key_gen_contract: Address,
-    ecdsa_key: Types::EcDsaPubkeyCompressed,
+    ecdsa_key: EcDsaPubkeyCompressed,
     taceo_admin_private_key: &str,
 ) -> eyre::Result<RpId> {
     let pk_x = ecdsa_key.x.to_string();

--- a/oprf-test/tests/tests.rs
+++ b/oprf-test/tests/tests.rs
@@ -14,8 +14,9 @@ use eyre::Context as _;
 use groth16::Groth16;
 use oprf_client::{NullifierArgs, OprfQuery};
 use oprf_service::rp_registry::CredentialSchemaIssuerRegistry::Pubkey;
-use oprf_service::rp_registry::{RpRegistry, Types};
+use oprf_service::rp_registry::Types;
 use oprf_test::world_id_protocol_mock::Authenticator;
+use oprf_test::{EcDsaPubkeyCompressed, RpRegistry};
 use oprf_test::{MOCK_RP_SECRET_KEY, TACEO_ADMIN_PRIVATE_KEY, test_setup_utils};
 use oprf_test::{
     credentials,
@@ -64,7 +65,7 @@ async fn nullifier_e2e_test() -> eyre::Result<()> {
     )
     .await;
 
-    let rp_pk = Types::EcDsaPubkeyCompressed::try_from(MOCK_RP_SECRET_KEY.public_key())?;
+    let rp_pk = EcDsaPubkeyCompressed::try_from(MOCK_RP_SECRET_KEY.public_key())?;
     let rp_id = rp_registry_scripts::init_key_gen(
         &anvil.ws_endpoint(),
         rp_registry_contract,
@@ -217,7 +218,7 @@ async fn nullifier_e2e_test() -> eyre::Result<()> {
     assert!(result, "on-chain verification failed");
 
     let elapsed = time.elapsed();
-    println!("Success! Completed in {:?}", elapsed);
+    println!("Success! Completed in {elapsed:?}");
     println!("Produced nullifier: {nullifier}");
     Ok(())
 }


### PR DESCRIPTION
- Relaxes `regex` workspace dep to maximize compatibility with other libraries.
- Exposes some types in the `oprf-test` crate to be able to use them for testing.