### PR TITLE
build: reverted the change that we fail on inspect image, it seems to work now

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -159,4 +159,3 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ steps.meta.outputs.tags }}
-        continue-on-error: true


### PR DESCRIPTION
We introduced this as it was strange behaviour on some builds. 
Error does not seem to appear anymore, and we dont want to get in the habit of ignoring errors