### PR TITLE
audits/april 26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6934,6 +6934,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # OPRF Service
 
+[![CI](https://github.com/TaceoLabs/oprf-service/actions/workflows/rust_test.yml/badge.svg)](https://github.com/TaceoLabs/oprf-service/actions/workflows/rust_test.yml)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](LICENSE)
+[![Rust](https://img.shields.io/badge/rust-1.91%2B-orange.svg)](https://www.rust-lang.org)
+
 This is a monorepo containing:
 
 * `circom`: A collection of Circom circuits and test vectors for them.
 * `contracts`: An implementation of the required smart contracts.
 * `docs`: A typst document serving as a writeup of the overall scheme.
 * `noir`: A collection of Noir circuits.
+* `oprf`: A meta-crate (`taceo-oprf`) that re-exports all other crates for convenience.
 * `oprf-client`: A crate implementing a client lib for the OPRF service.
 * `oprf-core`: A crate implementing a verifiable OPRF based on the TwoHashDH OPRF construction + a threshold variant of it.
 * `oprf-dev-client`: A crate implementing common dev client functionality.
@@ -17,8 +22,9 @@ This is a monorepo containing:
 ## Dev Dependencies
 
 * [just](https://github.com/casey/just?tab=readme-ov-file#installation)
-* docker-compose
+* docker compose (for running `anvil` and `postgres` containers)
 * anvil and forge, install with [foundryup](https://getfoundry.sh/introduction/installation/)
+* PostgreSQL (provided via Docker in the local setup)
 
 ## Setup
 
@@ -46,12 +52,12 @@ just run-setup
 
 This command does multiple things in order:
 
-1. start `localstack` and `anvil` docker containers
-2. create private keys for OPRF nodes and store them in AWS secrets manager
-3. deploy the `OprfKeyRegistry` smart contract
-4. register the OPRF nodes at the `OprfKeyRegistry` contract
-5. start 3 OPRF nodes
-6. start 3 OPRF key-gen instances
+1. start `anvil` and `postgres` docker containers
+2. deploy the `OprfKeyRegistry` smart contract
+3. register the OPRF participants at the `OprfKeyRegistry` contract
+4. build the workspace
+5. start 3 OPRF key-gen instances
+6. start 3 OPRF service nodes
 
 Log files for all processes can be found in the created `logs` directory.
 You can kill the setup with `Ctrl+C`, which kills all processes and stops all docker containers.
@@ -63,19 +69,13 @@ just run-dev-client test
 
 ## Secret Management
 
-The OPRF service supports different secret manager backends for storing OPRF key shares.
-
-### Postgres Secret Manager (Default)
-
-The Postgres backend stores OPRF key shares in a PostgreSQL database while using AWS Secrets Manager only for the wallet private key. This is the recommended approach for production deployments, especially when managing many OPRF keys.
+OPRF key shares are stored in a PostgreSQL database.
 
 **Required environment variables:**
 
 * `TACEO_OPRF_NODE__POSTGRES__CONNECTION_STRING` – PostgreSQL connection string (e.g., `postgres://user:password@host:5432/dbname`)
 * `TACEO_OPRF_NODE__POSTGRES__SCHEMA` – Database schema to use
-* Standard AWS credentials (for wallet key retrieval)
-
-**Database setup:**
+* `TACEO_OPRF_NODE__SERVICE__WALLET_PRIVATE_KEY` – Wallet private key for the node
 
 The Postgres secret manager automatically runs migrations on startup to create the required tables:
 
@@ -87,4 +87,26 @@ The Postgres secret manager automatically runs migrations on startup to create t
 * The connection string contains credentials and should be treated as a secret
 * Use SSL/TLS connections in production (`?sslmode=require`)
 * Ensure the database is not publicly accessible
-* The wallet private key is always stored in AWS Secrets Manager for additional security
+* The wallet private key should be provided securely (e.g., via a secrets manager in your deployment environment)
+
+## Configuration
+
+Both the OPRF service and key-gen are configured via environment variables using a hierarchical prefix scheme:
+
+* **OPRF service:** `TACEO_OPRF_NODE__*` (e.g., `TACEO_OPRF_NODE__BIND_ADDR`, `TACEO_OPRF_NODE__SERVICE__ENVIRONMENT`)
+* **Key generation:** `TACEO_OPRF_KEY_GEN__*` (e.g., `TACEO_OPRF_KEY_GEN__BIND_ADDR`, `TACEO_OPRF_KEY_GEN__SERVICE__WALLET_PRIVATE_KEY`)
+
+See `run-setup.sh` for a complete example of all required environment variables.
+
+## Architecture
+
+For a detailed description of the OPRF scheme, see [`docs/oprf.pdf`](docs/oprf.pdf).
+
+## License
+
+This project is licensed under either of
+
+* [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+* [MIT License](http://opensource.org/licenses/MIT)
+
+at your option.

--- a/oprf-client/src/ws/native.rs
+++ b/oprf-client/src/ws/native.rs
@@ -106,9 +106,9 @@ impl WebSocketSession {
                 return Err(err.into());
             }
             None => {
-                return Err(NodeError::UnexpectedMessage {
-                    reason: "Server closed connection".into(),
-                });
+                return Err(NodeError::WsError(Box::new(tungstenite::Error::Io(
+                    std::io::Error::other("server closed connection without sending close-frame"),
+                ))));
             }
         };
 
@@ -131,9 +131,11 @@ impl WebSocketSession {
                         kind: oprf_types::api::OprfErrorKind::from(u16::from(frame.code)),
                     }))
                 } else {
-                    Err(NodeError::UnexpectedMessage {
-                        reason: "Server closed websocket".into(),
-                    })
+                    Err(NodeError::WsError(Box::new(tungstenite::Error::Io(
+                        std::io::Error::other(
+                            "Server closed websocket without finishing protocol - EOF",
+                        ),
+                    ))))
                 }
             }
 

--- a/oprf-client/src/ws/native.rs
+++ b/oprf-client/src/ws/native.rs
@@ -52,6 +52,16 @@ impl WebSocketSession {
         }
     }
 
+    /// Tries to close the websocket on a best effort basis without sending a close-frame to the server and initiating tear down.
+    async fn silent_close(&mut self) {
+        if let Err(err) = self.inner.close(None).await {
+            tracing::trace!(
+                "Received an error when trying to best effort close {}: {err:?}",
+                self.service
+            );
+        }
+    }
+
     /// Calls [`Self::best_effort_close`] and returns an [`NodeError::UnexpectedMessage`] with the provided reason.
     async fn protocol_error<T>(&mut self, reason: T) -> NodeError
     where
@@ -121,7 +131,7 @@ impl WebSocketSession {
             },
 
             tungstenite::Message::Close(frame) => {
-                self.best_effort_close(CloseCode::Normal, "").await;
+                self.silent_close().await;
 
                 if let Some(frame) = frame
                     && frame.code != CloseCode::Normal

--- a/oprf-client/src/ws/native.rs
+++ b/oprf-client/src/ws/native.rs
@@ -113,11 +113,12 @@ impl WebSocketSession {
         };
 
         match msg {
-            tungstenite::Message::Binary(bytes) => {
-                ciborium::from_reader(bytes.as_ref()).map_err(|_| NodeError::UnexpectedMessage {
-                    reason: "could not parse message from server".into(),
-                })
-            }
+            tungstenite::Message::Binary(bytes) => match ciborium::from_reader(bytes.as_ref()) {
+                Ok(msg) => Ok(msg),
+                Err(_) => Err(self
+                    .protocol_error("could not parse message from server")
+                    .await),
+            },
 
             tungstenite::Message::Close(frame) => {
                 self.best_effort_close(CloseCode::Normal, "").await;

--- a/oprf-client/src/ws/wasm.rs
+++ b/oprf-client/src/ws/wasm.rs
@@ -31,6 +31,16 @@ pub(crate) struct WebSocketSession {
 }
 
 impl WebSocketSession {
+    /// Tries to close the sink on a best effort basis.
+    async fn silent_close(&mut self) {
+        if let Err(err) = self.write.close().await {
+            tracing::trace!(
+                "Received an error when trying to best effort close {}: {err:?}",
+                self.service
+            );
+        }
+    }
+
     /// Creates a new session at the provided endpoint.
     ///
     /// Expects a valid `ws://` or `wss://` URI  
@@ -65,42 +75,47 @@ impl WebSocketSession {
     }
 
     /// Attempts to send the provided message to the web-socket.
+    ///
+    /// On error tries to close the sink.
     pub(crate) async fn send<Msg: Serialize>(&mut self, msg: Msg) -> Result<(), NodeError> {
         let mut buf = Vec::new();
         ciborium::into_writer(&msg, &mut buf).expect("Can serialize msg");
-        self.write.send(Message::Bytes(buf)).await.map_err(|e| {
-            NodeError::WsError(Box::new(std::io::Error::other(format!(
-                "send failed: {e:?}"
+        if let Err(e) = self.write.send(Message::Bytes(buf)).await {
+            self.silent_close().await;
+            Err(NodeError::WsError(Box::new(std::io::Error::other(
+                format!("send failed: {e:?}"),
             ))))
-        })?;
-        Ok(())
+        } else {
+            Ok(())
+        }
     }
 
     /// Attempts to read the provided message from the web-socket.
     pub(crate) async fn read<Msg: for<'de> Deserialize<'de>>(&mut self) -> Result<Msg, NodeError> {
         match self.read.next().await {
             Some(Ok(Message::Bytes(bytes))) => {
-                if let Ok(response) = ciborium::from_reader::<Msg, _>(bytes.as_slice()) {
-                    Ok(response)
+                if let Ok(msg) = ciborium::from_reader::<Msg, _>(bytes.as_slice()) {
+                    Ok(msg)
                 } else {
-                    tracing::trace!("could not parse message...");
+                    self.silent_close().await;
                     Err(NodeError::UnexpectedMessage {
                         reason: "could not parse message from server".to_owned(),
                     })
                 }
             }
             Some(Ok(Message::Text(_))) => {
-                tracing::trace!("did get text instead of binary...");
+                self.silent_close().await;
                 Err(NodeError::UnexpectedMessage {
                     reason: "text frame received".to_owned(),
                 })
             }
             Some(Err(WebSocketError::ConnectionClose(event))) => {
                 tracing::trace!("did get close frame: code={}", event.code);
+                self.silent_close().await;
                 if event.code == CLOSE_CODE_NORMAL {
-                    Err(NodeError::UnexpectedMessage {
-                        reason: "Server closed websocket".to_owned(),
-                    })
+                    Err(NodeError::WsError(Box::new(std::io::Error::other(
+                        "Server closed websocket without finishing protocol - EOF",
+                    ))))
                 } else {
                     Err(NodeError::ServiceError(ServiceError {
                         error_code: event.code,
@@ -109,12 +124,15 @@ impl WebSocketSession {
                     }))
                 }
             }
-            Some(Err(e)) => Err(NodeError::WsError(Box::new(std::io::Error::other(
-                format!("read failed: {e:?}"),
+            Some(Err(e)) => {
+                self.silent_close().await;
+                Err(NodeError::WsError(Box::new(std::io::Error::other(
+                    format!("read failed: {e:?}"),
+                ))))
+            }
+            None => Err(NodeError::WsError(Box::new(std::io::Error::other(
+                "server closed connection without sending close-frame",
             )))),
-            None => Err(NodeError::UnexpectedMessage {
-                reason: "Server closed connection".to_owned(),
-            }),
         }
     }
 

--- a/oprf-key-gen/src/services/key_event_watcher.rs
+++ b/oprf-key-gen/src/services/key_event_watcher.rs
@@ -237,10 +237,11 @@ async fn key_gen_event(
             .await
         }
         Some(&OprfKeyRegistry::SecretGenRound2::SIGNATURE_HASH) => {
-            let log = log
+            let OprfKeyRegistry::SecretGenRound2 { oprfKeyId, epoch } = log
                 .log_decode()
-                .context("while decoding key-gen round2 event")?;
-            let OprfKeyRegistry::SecretGenRound2 { oprfKeyId, epoch } = log.inner.data;
+                .context("while decoding key-gen round2 event")?
+                .inner
+                .data;
             let handle_span = tracing::Span::current();
             handle_span.record("oprf_key_id", oprfKeyId.to_string());
             handle_span.record("epoch", epoch.to_string());

--- a/oprf-service/Cargo.toml
+++ b/oprf-service/Cargo.toml
@@ -55,7 +55,7 @@ tokio = { workspace = true, features = [
   "tokio-macros",
 ] }
 tokio-util = { workspace = true }
-tower-http = { workspace = true, features = ["set-header", "trace"] }
+tower-http = { workspace = true, features = ["set-header", "timeout", "trace"] }
 tracing.workspace = true
 tungstenite = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }

--- a/oprf-service/src/config.rs
+++ b/oprf-service/src/config.rs
@@ -49,12 +49,21 @@ pub struct OprfNodeServiceConfig {
     pub ws_max_message_size: usize,
     /// Max time a created session is valid.
     ///
-    /// This interval specifies how long a websocket connection is kept alive after a user initiates a session.
+    /// This interval specifies how long a websocket connection is kept alive after a user initiates a session. This time starts ticking after the peers finish the web-socket upgrade protocol.
     ///
     /// Defaults to `30 s`.
     #[serde(default = "OprfNodeServiceConfig::default_session_lifetime")]
     #[serde(with = "humantime_serde")]
     pub session_lifetime: Duration,
+
+    /// Max time for HTTP requests.
+    ///
+    /// In contrast to `session_lifetime`, this timeout addresses HTTP requests, e.g. `health`, `info` routes but also the web-socket upgrade requests.
+    ///
+    /// Defaults to `20 s`.
+    #[serde(default = "OprfNodeServiceConfig::default_http_request_timeout")]
+    #[serde(with = "humantime_serde")]
+    pub http_request_timeout: Duration,
     /// Max time to wait for oprf key material secret retrieval from secret manager during key-event processing.
     ///
     /// Defaults to `10 min`.
@@ -91,6 +100,11 @@ impl OprfNodeServiceConfig {
         Duration::from_secs(30)
     }
 
+    /// Default http request timeout (`20 s`).
+    fn default_http_request_timeout() -> Duration {
+        Duration::from_secs(20)
+    }
+
     /// Default get oprf key material timeout (`10 min`).
     fn default_get_oprf_key_material_timeout() -> Duration {
         Duration::from_secs(10 * 60)
@@ -115,6 +129,7 @@ impl OprfNodeServiceConfig {
             ws_max_message_size: Self::default_ws_max_message_size(),
             session_lifetime: Self::default_session_lifetime(),
             get_oprf_key_material_timeout: Self::default_get_oprf_key_material_timeout(),
+            http_request_timeout: Self::default_http_request_timeout(),
             start_block: None,
             i_am_alive_interval: Self::default_i_am_alive_interval(),
         }

--- a/oprf-service/src/lib.rs
+++ b/oprf-service/src/lib.rs
@@ -57,11 +57,13 @@ use crate::services::oprf_key_material_store::OprfKeyMaterialStore;
 use crate::{config::OprfNodeServiceConfig, services::secret_manager::SecretManagerService};
 use axum::Router;
 use eyre::Context as _;
+use http::StatusCode;
 use oprf_types::api::OprfRequestAuthService;
 use oprf_types::chain::OprfKeyRegistry;
 use oprf_types::crypto::PartyId;
 use serde::Deserialize;
 use tokio_util::sync::CancellationToken;
+use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::TraceLayer;
 
 pub(crate) mod api;
@@ -258,6 +260,10 @@ impl OprfServiceBuilder {
         (
             self.root
                 .nest("/api", self.api)
+                .layer(TimeoutLayer::with_status_code(
+                    StatusCode::REQUEST_TIMEOUT,
+                    self.config.http_request_timeout,
+                ))
                 .layer(TraceLayer::new_for_http()),
             self.key_event_watcher,
         )


### PR DESCRIPTION
- **feat(node): add http level request timeout**
- **chore: updated readme**
- **refactor(client): changed error type for certain EOF events**
- **chore(client): add best effort close when receiving invalid binary**
- **chore(client): send no CloseFrame on unexpected Close from server**
- **refactor(client): send best effort closes and mirror errors from native**
- **chore(key-gen): log decode in one-line**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces an HTTP-level timeout layer for all service routes and changes client websocket close/error semantics, which can alter request cancellation behavior and downstream error handling/metrics.
> 
> **Overview**
> Adds a configurable **HTTP request timeout** (`http_request_timeout`, default `20s`) to `taceo-oprf-service`, wiring `tower-http`'s `TimeoutLayer` into the `/api` router and enabling the `timeout` feature.
> 
> Refines `oprf-client` websocket session behavior (native + WASM): unexpected EOF/close cases are now surfaced as `NodeError::WsError` (instead of `UnexpectedMessage`), invalid/unsupported frames trigger best-effort shutdown, and server-sent close frames are handled without initiating a new close handshake (`silent_close`).
> 
> Updates docs to reflect the current local setup (anvil+postgres), configuration env var prefixes, and licensing metadata; includes small refactors/lockfile updates (e.g., `tokio` dependency for `tower-http`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72daa73378885b3fdcb6bded1d94b7e30985a8b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->