### PR TITLE
feat: add docker vulnerability scan

### DIFF
--- a/.github/workflows/build-and-push-oprf-key-gen.yml
+++ b/.github/workflows/build-and-push-oprf-key-gen.yml
@@ -10,7 +10,6 @@ on:
   push:
     branches:
       - main
-      - sg/docker_vuln
     tags:
       - 'oprf-key-gen-v*'
 

--- a/.github/workflows/build-and-push-oprf-key-gen.yml
+++ b/.github/workflows/build-and-push-oprf-key-gen.yml
@@ -1,10 +1,16 @@
 name: Build and Push (oprf-key-gen)
 
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
 on:
   workflow_dispatch:
   push:
     branches:
       - main
+      - sg/docker_vuln
     tags:
       - 'oprf-key-gen-v*'
 
@@ -14,4 +20,6 @@ jobs:
     with:
       image-name: oprf-key-gen
       dockerfile: build/Dockerfile.oprf-key-gen
-
+    secrets:
+      S3_ACCOUNT_ID: ${{ secrets.S3_ACCOUNT_ID }}
+      AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}

--- a/.github/workflows/build-and-push-oprf-key-gen.yml
+++ b/.github/workflows/build-and-push-oprf-key-gen.yml
@@ -1,7 +1,7 @@
 name: Build and Push (oprf-key-gen)
 
 permissions:
-  contents: write
+  contents: read
   packages: write
   id-token: write
 
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - main
+      - sg/docker_vuln
     tags:
       - 'oprf-key-gen-v*'
 
@@ -20,5 +21,5 @@ jobs:
       image-name: oprf-key-gen
       dockerfile: build/Dockerfile.oprf-key-gen
     secrets:
-      S3_ACCOUNT_ID: ${{ secrets.S3_ACCOUNT_ID }}
+      AWS_ARCHIVE_ROLE: ${{ secrets.AWS_ARCHIVE_ROLE }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}

--- a/.github/workflows/build-and-push-oprf-key-gen.yml
+++ b/.github/workflows/build-and-push-oprf-key-gen.yml
@@ -10,11 +10,11 @@ on:
       - 'oprf-key-gen-v*'
 
 jobs:
-  permissions:
-    contents: read
-    packages: write
-    id-token: write
   workflow:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     uses: ./.github/workflows/build-and-push.yml
     with:
       image-name: oprf-key-gen

--- a/.github/workflows/build-and-push-oprf-key-gen.yml
+++ b/.github/workflows/build-and-push-oprf-key-gen.yml
@@ -1,9 +1,5 @@
 name: Build and Push (oprf-key-gen)
 
-permissions:
-  contents: read
-  packages: write
-  id-token: write
 
 on:
   workflow_dispatch:
@@ -14,6 +10,10 @@ on:
       - 'oprf-key-gen-v*'
 
 jobs:
+  permissions:
+    contents: read
+    packages: write
+    id-token: write
   workflow:
     uses: ./.github/workflows/build-and-push.yml
     with:

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -12,8 +12,8 @@ on:
         required: true
         type: string
     secrets:
-      S3_ACCOUNT_ID:
-        description: 'AWS account ID used for the SBOM upload role assumption'
+      AWS_ARCHIVE_ROLE:
+        description: 'AWS role used for the SBOM upload role assumption'
         required: true
       AWS_S3_BUCKET:
         description: 'S3 bucket name used for SBOM uploads'
@@ -23,13 +23,12 @@ env:
   REGISTRY: ghcr.io
   BUILDX_NO_DEFAULT_ATTESTATIONS: 1
 
-permissions:
-  contents: write
-  packages: write
-  id-token: write
 
 jobs:
   build:
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -118,7 +117,6 @@ jobs:
           format: spdx-json
           artifact-name: ${{ inputs.image-name }}-${{ matrix.arch }}-sbom.spdx.json
           output-file: ${{ runner.temp }}/${{ matrix.arch }}-sbom.spdx.json
-          dependency-snapshot: true
           upload-artifact: true
 
       - name: Run vulnerability scan
@@ -167,6 +165,8 @@ jobs:
           retention-days: 1
 
   merge:
+    permissions:
+      packages: write
     runs-on: ubuntu-latest
     needs:
       - build
@@ -225,6 +225,8 @@ jobs:
 
 
   upload-sbom:
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     needs:
       - build
@@ -235,7 +237,7 @@ jobs:
       - name: Configure AWS Credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v6.1.0
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.S3_ACCOUNT_ID }}:role/oidc/github-actions-s3-role
+          role-to-assume: ${{ secrets.AWS_ARCHIVE_ROLE }}
           aws-region: eu-central-1
 
       - name: Download a single artifact
@@ -249,7 +251,7 @@ jobs:
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
         run: |
-          # Rename file to include date
+          # Rename file to include short git sha
           PREFIX="$(echo ${{ github.sha }} | cut -c1-7)"
 
           cd ${{ runner.temp }}/sboms

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -256,4 +256,4 @@ jobs:
           for file in *; do
             [ -f "$file" ] && mv "$file" "${PREFIX}_${file}"
           done
-          aws s3 sync "${{ runner.temp }}/sboms" "s3://${AWS_S3_BUCKET}/oprf-service/"
+          aws s3 sync "${{ runner.temp }}/sboms" "s3://${AWS_S3_BUCKET}/${{ inputs.image-name }}/"

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -227,6 +227,7 @@ jobs:
   upload-sbom:
     permissions:
       id-token: write
+      contents: read
     runs-on: ubuntu-latest
     needs:
       - build

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -232,9 +232,6 @@ jobs:
     needs:
       - build
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
       - name: Configure AWS Credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v6.1.0
         with:

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -11,15 +11,22 @@ on:
         description: 'Path to the Dockerfile'
         required: true
         type: string
+    secrets:
+      S3_ACCOUNT_ID:
+        description: 'AWS account ID used for the SBOM upload role assumption'
+        required: true
+      AWS_S3_BUCKET:
+        description: 'S3 bucket name used for SBOM uploads'
+        required: true
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}/${{ inputs.image-name }}
   BUILDX_NO_DEFAULT_ATTESTATIONS: 1
 
 permissions:
-  contents: read # Required for the checkout action
+  contents: write
   packages: write
+  id-token: write
 
 jobs:
   build:
@@ -37,6 +44,8 @@ jobs:
         run: |
           platform=${{ matrix.arch }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          image_name="${GITHUB_REPOSITORY,,}/${{ inputs.image-name }}"
+          echo "IMAGE_NAME=${image_name,,}" >> "$GITHUB_ENV"
 
       - name: Checkout code
         uses: actions/checkout@v6
@@ -77,25 +86,76 @@ jobs:
             org.opencontainers.image.description=Docker image for ${{ inputs.image-name }} from ${{ github.repository_owner }}/${{ github.repository }}
             org.opencontainers.image.vendor=${{ github.repository_owner }}
 
-      - name: Build and push
+      - name: Build image
         id: build
         uses: docker/build-push-action@v7
         with:
           context: .
-          push: true
+          load: true
           file: ${{ inputs.dockerfile }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name-canonical=true
           cache-from: type=gha,scope=${{ github.repository }}-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ github.repository }}-${{ matrix.arch }}
           build-args: |
             GIT_HASH=${{ github.sha }}
 
+      - name: Select scan image
+        id: scan-image
+        shell: bash
+        run: |
+          scan_image="$(printf '%s\n' '${{ steps.meta.outputs.tags }}' | head -n1)"
+          if [[ -z "$scan_image" ]]; then
+            echo "No Docker tags were generated" >&2
+            exit 1
+          fi
+          echo "image=$scan_image" >> "$GITHUB_OUTPUT"
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ steps.scan-image.outputs.image }}
+          format: spdx-json
+          artifact-name: ${{ inputs.image-name }}-${{ matrix.arch }}-sbom.spdx.json
+          output-file: ${{ runner.temp }}/${{ matrix.arch }}-sbom.spdx.json
+          dependency-snapshot: true
+          upload-artifact: true
+
+      - name: Run vulnerability scan
+        uses: anchore/scan-action@v7
+        with:
+          sbom: ${{ runner.temp }}/${{ matrix.arch }}-sbom.spdx.json
+          fail-build: true
+          severity-cutoff: critical
+
+      - name: Push image tags
+        id: push-image
+        shell: bash
+        run: |
+          digest=""
+          while IFS= read -r tag; do
+            [[ -n "$tag" ]] || continue
+            push_output="$(docker push "$tag" 2>&1)"
+            printf '%s\n' "$push_output"
+            if [[ -z "$digest" ]]; then
+              digest="$(printf '%s\n' "$push_output" | sed -n 's/^.*digest: \(sha256:[[:xdigit:]]\{64\}\).*$/\1/p' | tail -n1)"
+            fi
+          done <<< '${{ steps.meta.outputs.tags }}'
+          if [[ -z "$digest" ]]; then
+            echo "Unable to determine pushed digest from docker push output" >&2
+            exit 1
+          fi
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
       - name: Export digest
+        shell: bash
         run: |
           mkdir -p ${{ runner.temp }}/digests
-          digest="${{ steps.build.outputs.digest }}"
+          digest='${{ steps.push-image.outputs.digest }}'
+          if [[ -z "$digest" || "$digest" == "null" ]]; then
+            echo "Unable to determine pushed digest for ${{ steps.scan-image.outputs.image }}" >&2
+            exit 1
+          fi
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
@@ -111,6 +171,11 @@ jobs:
     needs:
       - build
     steps:
+      - name: Prepare image name
+        run: |
+          image_name="${GITHUB_REPOSITORY,,}/${{ inputs.image-name }}"
+          echo "IMAGE_NAME=${image_name,,}" >> "$GITHUB_ENV"
+
       - name: Download digests
         uses: actions/download-artifact@v8
         with:
@@ -156,4 +221,39 @@ jobs:
             --annotation "index:org.opencontainers.image.title=${{ inputs.image-name }}" \
             --annotation "index:org.opencontainers.image.description=Docker image for ${{ inputs.image-name }} from ${{ github.repository_owner }}/${{ github.repository }}" \
             --annotation "index:org.opencontainers.image.vendor=${{ github.repository_owner }}" \
-            $(printf '${{ env.REGISTRY }}/${{ steps.meta.outputs.tags }}@sha256:%s ' *)
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+
+  upload-sbom:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6.1.0
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.S3_ACCOUNT_ID }}:role/oidc/github-actions-s3-role
+          aws-region: eu-central-1
+
+      - name: Download a single artifact
+        uses: actions/download-artifact@v8
+        with:
+          path: ${{ runner.temp }}/sboms
+          pattern: "*.spdx.json"
+          merge-multiple: true
+      
+      - name: Upload file to S3
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        run: |
+          # Rename file to include date
+          PREFIX="$(echo ${{ github.sha }} | cut -c1-7)"
+
+          cd ${{ runner.temp }}/sboms
+          for file in *; do
+            [ -f "$file" ] && mv "$file" "${PREFIX}_${file}"
+          done
+          aws s3 sync "${{ runner.temp }}/sboms" "s3://${AWS_S3_BUCKET}/oprf-service/"

--- a/build/Dockerfile.oprf-key-gen
+++ b/build/Dockerfile.oprf-key-gen
@@ -22,7 +22,7 @@ FROM rust:1.91-bookworm AS healthcheck-builder
 RUN cargo install simple-web-healthcheck
 
 
-FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
+FROM gcr.io/distroless/cc-debian13:nonroot AS runtime
 ARG GIT_HASH
 LABEL org.opencontainers.image.revision=$GIT_HASH
 LABEL org.opencontainers.image.vendor=TACEO


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> CI now gates Docker image publishing on a critical-severity vulnerability scan and adds AWS OIDC-based SBOM uploads to S3, which can affect release reliability and permissions/secrets configuration.
> 
> **Overview**
> Adds supply-chain checks to the reusable `build-and-push` workflow: builds images locally, generates an SPDX SBOM, runs an Anchore vulnerability scan (fails on *critical*), then pushes tags and derives the pushed digest for manifest creation.
> 
> Introduces a new `upload-sbom` job that uses AWS OIDC to assume `AWS_ARCHIVE_ROLE` and sync per-arch SBOM artifacts to `AWS_S3_BUCKET`, and updates the `oprf-key-gen` caller workflow to pass these secrets and required permissions.
> 
> Updates the `oprf-key-gen` runtime base image from `distroless/cc-debian12` to `distroless/cc-debian13`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94e48633a304dd156ef05ee51cb0e0b0df8cedb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->