### PR TITLE
refactor(core,types): bump ark-serde-compat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,7 +589,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -768,7 +768,7 @@ checksum = "5ce599598ef8ebe067f3627509358d9faaa1ef94f77f834a7783cd44209ef55c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "reqwest",
  "serde_json",
  "tower",
@@ -2701,7 +2701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4079,7 +4079,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4757,7 +4757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -4845,7 +4845,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5290,7 +5290,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6122,9 +6122,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-ark-serde-compat"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07528b4dd1a0c9e49ef352f96219c611af0aa2f7cbd97ddb7276dcf3c2cf8dd0"
+checksum = "18fcd6f55fec9dd131019bdc0319db2271915056607b75bf8b8bc0a6ec496347"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -6137,9 +6137,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-circom-types"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677eb3ed8275b2f179d4b1a93126a51c5b4f409c5ea9d7bc50398b13e517e30b"
+checksum = "89503f8dbe863abfc191d56e2ff578bb3c9e8039d37c1f8ece2ae89e9aea5147"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -6540,7 +6540,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7559,7 +7559,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ark-bn254 = { version = "0.5" }
 ark-ec = "0.5"
 ark-ff = "0.5"
 ark-groth16 = "0.5"
-ark-serde-compat = { package = "taceo-ark-serde-compat", version = "0.4.1", default-features = false }
+ark-serde-compat = { package = "taceo-ark-serde-compat", version = "0.5", default-features = false }
 ark-serialize = "0.5"
 async-trait = "0.1"
 axum = "0.8"

--- a/oprf-core/src/ddlog_equality.rs
+++ b/oprf-core/src/ddlog_equality.rs
@@ -39,23 +39,18 @@ const FROST_2_NONCE_COMBINER_LABEL: &[u8] = b"FROST_2_NONCE_COMBINER";
 /// Each party sends these commitments, which consist of a split of the actual response and two nonce splits, for aggregation and creation of the global challenge hash.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PartialDLogEqualityCommitments {
-    #[serde(serialize_with = "babyjubjub::serialize_affine")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_affine")]
+    #[serde(with = "babyjubjub::affine")]
     pub(crate) c: Affine, // The share of the actual result C=B*x
-    #[serde(serialize_with = "babyjubjub::serialize_affine")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_affine")]
+    #[serde(with = "babyjubjub::affine")]
     /// The share of G*d1, the first part of the two-nonce commitment to the randomness r1 = d1 + e1*b
     pub(crate) d1: Affine,
-    #[serde(serialize_with = "babyjubjub::serialize_affine")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_affine")]
+    #[serde(with = "babyjubjub::affine")]
     /// The share of G*d2, the first part of the two-nonce commitment to the randomness r2 = d2 + e2*b
     pub(crate) d2: Affine,
-    #[serde(serialize_with = "babyjubjub::serialize_affine")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_affine")]
+    #[serde(with = "babyjubjub::affine")]
     /// The share of G*e1, the second part of the two-nonce commitment to the randomness r1 = d1 + e1*b
     pub(crate) e1: Affine,
-    #[serde(serialize_with = "babyjubjub::serialize_affine")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_affine")]
+    #[serde(with = "babyjubjub::affine")]
     /// The share of G*e2, the second part of the two-nonce commitment to the randomness r2 = d2 + e2*b
     pub(crate) e2: Affine,
 }
@@ -65,23 +60,18 @@ pub struct PartialDLogEqualityCommitments {
 /// This struct aggregates the per-party commitment shares, to be used as the challenge hash input, and to verify against the full proof after all shares are combined.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DLogEqualityCommitments {
-    #[serde(serialize_with = "babyjubjub::serialize_affine")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_affine")]
+    #[serde(with = "babyjubjub::affine")]
     pub(crate) c: Affine,
-    #[serde(serialize_with = "babyjubjub::serialize_affine")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_affine")]
+    #[serde(with = "babyjubjub::affine")]
     /// The aggregated G*d1.
     pub(crate) d1: Affine,
-    #[serde(serialize_with = "babyjubjub::serialize_affine")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_affine")]
+    #[serde(with = "babyjubjub::affine")]
     /// The aggregated G*d2.
     pub(crate) d2: Affine,
-    #[serde(serialize_with = "babyjubjub::serialize_affine")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_affine")]
+    #[serde(with = "babyjubjub::affine")]
     /// The aggregated G*e1.
     pub(crate) e1: Affine,
-    #[serde(serialize_with = "babyjubjub::serialize_affine")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_affine")]
+    #[serde(with = "babyjubjub::affine")]
     /// The aggregated G*e2.
     pub(crate) e2: Affine,
     /// The parties that contributed to this commitment.
@@ -94,9 +84,7 @@ pub struct DLogEqualityCommitments {
 #[serde(transparent)]
 pub(crate) struct DLogEqualityProofShare(
     // The share of the response s
-    #[serde(serialize_with = "babyjubjub::serialize_fr")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_fr")]
-    pub(crate) ScalarField,
+    #[serde(with = "ark_serde_compat::field")] pub(crate) ScalarField,
 );
 
 /// The internal storage of a party in a distributed `DlogEqualityProof` protocol.

--- a/oprf-core/src/ddlog_equality/additive.rs
+++ b/oprf-core/src/ddlog_equality/additive.rs
@@ -26,7 +26,6 @@ use crate::{
 };
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::Zero;
-use ark_serde_compat::babyjubjub;
 use rand::{CryptoRng, Rng};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -39,11 +38,7 @@ use zeroize::ZeroizeOnDrop;
 ///
 #[derive(Clone, Serialize, Deserialize, ZeroizeOnDrop)]
 #[serde(transparent)]
-pub struct DLogShareAdditive(
-    #[serde(serialize_with = "babyjubjub::serialize_fr")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_fr")]
-    ScalarField,
-);
+pub struct DLogShareAdditive(#[serde(with = "ark_serde_compat::field")] ScalarField);
 
 /// Wrapper for the internal `DLogEquality` session state in the additive sharing variant.
 ///

--- a/oprf-core/src/ddlog_equality/shamir.rs
+++ b/oprf-core/src/ddlog_equality/shamir.rs
@@ -24,7 +24,6 @@ use crate::dlog_equality::DLogEqualityProof;
 use ark_ec::CurveGroup;
 use ark_ec::{AffineRepr, VariableBaseMSM};
 use ark_ff::Zero;
-use ark_serde_compat::babyjubjub;
 use ark_serialize::CanonicalDeserialize;
 use ark_serialize::CanonicalSerialize;
 use rand::{CryptoRng, Rng};
@@ -45,11 +44,7 @@ type Projective = ark_babyjubjub::EdwardsProjective;
     Clone, Serialize, Deserialize, ZeroizeOnDrop, CanonicalSerialize, CanonicalDeserialize,
 )]
 #[serde(transparent)]
-pub struct DLogShareShamir(
-    #[serde(serialize_with = "babyjubjub::serialize_fr")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_fr")]
-    ScalarField,
-);
+pub struct DLogShareShamir(#[serde(with = "ark_serde_compat::field")] ScalarField);
 
 /// Wrapper for the internal `DLogEquality` session state in the Shamir-sharing variant.
 ///

--- a/oprf-types/src/api.rs
+++ b/oprf-types/src/api.rs
@@ -201,8 +201,7 @@ pub struct OprfRequest<OprfRequestAuth> {
     /// Unique ID of the request (used to correlate responses).
     pub request_id: Uuid,
     /// Input point `B` of the OPRF, serialized as a `BabyJubJub` affine point.
-    #[serde(serialize_with = "babyjubjub::serialize_affine")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_affine")]
+    #[serde(with = "babyjubjub::affine")]
     pub blinded_query: ark_babyjubjub::EdwardsAffine,
     /// The additional authentication info for this request
     pub auth: OprfRequestAuth,

--- a/oprf-types/src/crypto.rs
+++ b/oprf-types/src/crypto.rs
@@ -32,9 +32,7 @@ pub struct PartyId(pub u16);
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Hash, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct EphemeralEncryptionPublicKey(
-    #[serde(serialize_with = "babyjubjub::serialize_affine")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_affine")]
-    ark_babyjubjub::EdwardsAffine,
+    #[serde(with = "babyjubjub::affine")] ark_babyjubjub::EdwardsAffine,
 );
 
 /// The OPRF public-key.
@@ -53,11 +51,7 @@ pub struct EphemeralEncryptionPublicKey(
     CanonicalDeserialize,
 )]
 #[serde(transparent)]
-pub struct OprfPublicKey(
-    #[serde(serialize_with = "babyjubjub::serialize_affine")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_affine")]
-    ark_babyjubjub::EdwardsAffine,
-);
+pub struct OprfPublicKey(#[serde(with = "babyjubjub::affine")] ark_babyjubjub::EdwardsAffine);
 
 /// The public contribution of one OPRF node for the first round of the OPRF-nullifier generation protocol.
 ///
@@ -70,12 +64,10 @@ pub struct OprfPublicKey(
 /// for more information about the OPRF-nullifier generation protocol.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SecretGenCommitment {
-    #[serde(serialize_with = "babyjubjub::serialize_affine")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_affine")]
+    #[serde(with = "babyjubjub::affine")]
     /// The commitment to the random value sampled by the node.
     pub comm_share: ark_babyjubjub::EdwardsAffine,
-    #[serde(serialize_with = "babyjubjub::serialize_fq")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_fq")]
+    #[serde(with = "ark_serde_compat::field")]
     /// The commitment to the polynomial used to hide the sampled secret.
     pub comm_coeffs: ark_babyjubjub::Fq,
     /// The ephemeral public key for this key generation.
@@ -100,16 +92,13 @@ pub struct SecretGenCiphertexts {
 /// Contains the [`EphemeralEncryptionPublicKey`] of the sender, the ciphertext itself, and a nonce.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SecretGenCiphertext {
-    #[serde(serialize_with = "babyjubjub::serialize_fq")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_fq")]
+    #[serde(with = "ark_serde_compat::field")]
     /// The nonce used during encryption.
     pub nonce: ark_babyjubjub::Fq,
-    #[serde(serialize_with = "babyjubjub::serialize_fq")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_fq")]
+    #[serde(with = "ark_serde_compat::field")]
     /// The ciphertext.
     pub cipher: ark_babyjubjub::Fq,
-    #[serde(serialize_with = "babyjubjub::serialize_affine")]
-    #[serde(deserialize_with = "babyjubjub::deserialize_affine")]
+    #[serde(with = "babyjubjub::affine")]
     /// The commitment to the encrypted value. Computed as xG, where x
     /// is the plaintext and G the generator of `BabyJubJub`.
     pub commitment: ark_babyjubjub::EdwardsAffine,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates serialization helpers for curve points/fields and bumps crypto-related deps; this can change on-the-wire or persisted encodings and break compatibility if consumers expect the old format.
> 
> **Overview**
> Bumps `taceo-ark-serde-compat` to `0.5` and refreshes lockfile deps (notably `itertools` and `windows-sys`).
> 
> Refactors serde (de)serialization across `oprf-core` and `oprf-types` to use `#[serde(with = ...)]` modules (e.g., `babyjubjub::affine` and `ark_serde_compat::field`) instead of per-field `serialize_with`/`deserialize_with`, covering OPRF requests/keys, secret-sharing shares, commitments, and ciphertext fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a720e36188afa8ea05dbd2fcb885efdbafbf3fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->