### PR TITLE
chore: add RUSTSEC-2026-0097 to ignore

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -74,6 +74,7 @@ ignore = [
     { id = "RUSTSEC-2024-0388", reason = "derivative crate is unmaintained, but arkworks is still using it." },
     { id = "RUSTSEC-2025-0055", reason = "ark-relations is using v0.2 of tracing-subscriber still, we do not use this functionality so it is not exploitable." },
     { id = "RUSTSEC-2026-0066", reason = "can't be upgraded with current version of testcontainers" },
+    { id = "RUSTSEC-2026-0097", reason = "can't upgrade due to transative deps. Doesn't affect us because we don't enable the log feature" },
 
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates security auditing configuration to suppress a RustSec advisory, which could mask a real vulnerability if assumptions about unused features or dependency paths change.
> 
> **Overview**
> Adds `RUSTSEC-2026-0097` to `deny.toml`’s `advisories.ignore` list, documenting that the advisory can’t currently be remediated due to transitive dependencies and is considered non-impacting because the affected `log` feature isn’t enabled.
> 
> This changes CI/security-audit behavior by **suppressing failures/warnings for that specific RustSec advisory** until dependencies can be upgraded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 012ff7d88f697bd7c56dc310cc1fb71feadfde8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->