### PR TITLE
chore: added output to grype result

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -239,7 +239,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ARCHIVE_ROLE }}
           aws-region: eu-central-1
 
-      - name: Download a single artifact
+      - name: Download SBOM artifacts
         uses: actions/download-artifact@v8
         with:
           path: ${{ runner.temp }}/sboms

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -124,6 +124,7 @@ jobs:
         with:
           sbom: ${{ runner.temp }}/${{ matrix.arch }}-sbom.spdx.json
           fail-build: true
+          output-format: table
           severity-cutoff: critical
 
       - name: Push image tags


### PR DESCRIPTION
- **added output to grype result**
- **better name for step**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk GitHub Actions workflow-only change that affects CI output formatting and step naming, not build/push logic.
> 
> **Overview**
> Updates `.github/workflows/build-and-push.yml` to output `anchore/scan-action@v7` (Grype) vulnerability scan results in a human-readable `table` format while keeping the existing *fail-on-critical* behavior.
> 
> Renames the `upload-sbom` artifact download step to **"Download SBOM artifacts"** to better reflect that it pulls all `*.spdx.json` artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee5a8b751058d7faf095575a01f9e5b4b4aba823. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->