### PR TITLE
build(oprf): pin concrete min versions for umbrella

### DIFF
--- a/oprf/Cargo.toml
+++ b/oprf/Cargo.toml
@@ -12,11 +12,11 @@ keywords = ["cryptography", "mpc", "oprf"]
 publish = true
 
 [dependencies]
-oprf-client = { package = "taceo-oprf-client", path = "../oprf-client", version = "0.9", optional = true }
-oprf-core = { package = "taceo-oprf-core", path = "../oprf-core", version = "0.5", optional = true }
-oprf-dev-client = { package = "taceo-oprf-dev-client", path = "../oprf-dev-client", version = "0.9", optional = true }
-oprf-service = { package = "taceo-oprf-service", path = "../oprf-service", version = "0.13", optional = true }
-oprf-types = { package = "taceo-oprf-types", path = "../oprf-types", version = "0.12", optional = true }
+oprf-client = { package = "taceo-oprf-client", path = "../oprf-client", version = "0.9.3", optional = true }
+oprf-core = { package = "taceo-oprf-core", path = "../oprf-core", version = "0.5.2", optional = true }
+oprf-dev-client = { package = "taceo-oprf-dev-client", path = "../oprf-dev-client", version = "0.9.1", optional = true }
+oprf-service = { package = "taceo-oprf-service", path = "../oprf-service", version = "0.13.1", optional = true }
+oprf-types = { package = "taceo-oprf-types", path = "../oprf-types", version = "0.12.1", optional = true }
 
 [features]
 default = ["full"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk build/packaging change that only tightens dependency version constraints; main risk is unexpected resolver behavior if downstream relied on looser versions.
> 
> **Overview**
> Pins the `taceo-oprf` umbrella crate’s optional workspace dependencies (`taceo-oprf-client/core/dev-client/service/types`) to specific patch versions (e.g., `0.9` → `0.9.3`) instead of broad minor versions.
> 
> This makes the published crate declare concrete minimum versions for its component crates to improve dependency resolution/reproducibility without changing runtime code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 520d9e02a6cd2a30f506b9e80f4969584f80c007. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->