### PR TITLE
refactor(dev-client)!: config now uses NonZeroUsize for threshold

### DIFF
--- a/oprf-dev-client/src/config.rs
+++ b/oprf-dev-client/src/config.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{num::NonZeroUsize, time::Duration};
 
 use alloy::primitives::Address;
 use clap::{Parser, Subcommand};
@@ -55,7 +55,7 @@ pub struct DevClientConfig {
 
     /// The threshold of services that need to respond
     #[clap(long, env = "OPRF_DEV_CLIENT_THRESHOLD", default_value = "2")]
-    pub threshold: usize,
+    pub threshold: NonZeroUsize,
 
     /// The Address of the OprfKeyRegistry contract.
     #[clap(long, env = "OPRF_DEV_CLIENT_OPRF_KEY_REGISTRY_CONTRACT")]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Low behavioral risk but medium integration risk because this is a breaking config type change that can cause compile failures or missed conversions at call sites.
> 
> **Overview**
> Updates `DevClientConfig.threshold` in `oprf-dev-client/src/config.rs` from `usize` to `NonZeroUsize`, ensuring the CLI/env-configured threshold cannot be `0` at parse time.
> 
> This is a *breaking* type change for any call sites expecting a plain `usize` (e.g., passing `config.threshold` into functions), requiring explicit conversion via `.get()`/`usize::from` where used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c05f0c0eefd3aa4dcc7ce1b415db93893133cd83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->