### PR TITLE
ci: fix RUSTSEC-2026-0099

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2701,7 +2701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5290,7 +5290,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5333,9 +5333,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -6540,7 +6540,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/oprf-key-gen/src/config.rs
+++ b/oprf-key-gen/src/config.rs
@@ -140,7 +140,7 @@ pub struct OprfKeyGenServiceConfigMandatoryValues {
 impl OprfKeyGenServiceConfig {
     /// Default max wait time for transaction confirmation (`300 s`).
     fn default_max_wait_time_transaction_confirmation() -> Duration {
-        Duration::from_secs(300) // 5min
+        Duration::from_mins(5) // 5min
     }
 
     /// Default max gas per transaction (`8_000_000`).
@@ -155,7 +155,7 @@ impl OprfKeyGenServiceConfig {
 
     /// Default I-am-alive interval (`60 s`).
     fn default_i_am_alive_interval() -> Duration {
-        Duration::from_secs(60)
+        Duration::from_mins(1)
     }
 
     /// Construct with all default values except required fields.

--- a/oprf-service/src/config.rs
+++ b/oprf-service/src/config.rs
@@ -107,12 +107,12 @@ impl OprfNodeServiceConfig {
 
     /// Default get oprf key material timeout (`10 min`).
     fn default_get_oprf_key_material_timeout() -> Duration {
-        Duration::from_secs(10 * 60)
+        Duration::from_mins(10)
     }
 
     /// Default I-am-alive interval (`60 s`).
     fn default_i_am_alive_interval() -> Duration {
-        Duration::from_secs(60)
+        Duration::from_mins(1)
     }
 
     /// Construct with all default values except required fields.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Primarily a dependency/lockfile update that can subtly change TLS/Windows behavior or build compatibility, though the service code changes are non-functional refactors of duration constructors.
> 
> **Overview**
> Updates `Cargo.lock` to newer dependency versions, including bumping `rustls-webpki` and moving several crates from `windows-sys 0.52.0` to `0.59.0` (via transitive deps like `errno`, `rustix`, and `tempfile`).
> 
> Refactors default timeout/interval constructors in `oprf-key-gen` and `oprf-service` configs to use `Duration::from_mins(...)` instead of `from_secs(...)`, keeping the same effective values (5 min, 10 min, 1 min).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fc6ebeb313d2ee1a0194f7417ce3a02375471c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->