### PR TITLE
Deps/alloy minimal features

### DIFF
--- a/oprf-dev-client/Cargo.toml
+++ b/oprf-dev-client/Cargo.toml
@@ -12,7 +12,12 @@ keywords = ["client", "development", "mpc", "oprf"]
 publish = true
 
 [dependencies]
-alloy = { workspace = true, features = ["full", "rpc", "rpc-client-ws"] }
+alloy = { workspace = true, features = [
+  "contract",
+  "provider-http",
+  "provider-ws",
+  "signer-local"
+] }
 ark-babyjubjub.workspace = true
 ark-ff.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }

--- a/oprf-key-gen/Cargo.toml
+++ b/oprf-key-gen/Cargo.toml
@@ -13,10 +13,12 @@ publish = true
 
 [dependencies]
 alloy = { workspace = true, features = [
-  "full",
-  "reqwest",
-  "rpc",
-  "rpc-client-ws"
+  "contract",
+  "provider-http",
+  "provider-ws",
+  "rpc-types-eth",
+  "signer-local",
+  "sol-types"
 ] }
 ark-babyjubjub = { workspace = true }
 ark-bn254.workspace = true

--- a/oprf-service/Cargo.toml
+++ b/oprf-service/Cargo.toml
@@ -12,7 +12,13 @@ keywords = ["cryptography", "mpc", "oprf"]
 publish = true
 
 [dependencies]
-alloy = { workspace = true, features = ["full", "rpc", "rpc-client-ws"] }
+alloy = { workspace = true, features = [
+  "contract",
+  "provider-http",
+  "provider-ws",
+  "rpc-types-eth",
+  "sol-types"
+] }
 ark-babyjubjub = { workspace = true }
 ark-serialize.workspace = true
 async-trait = { workspace = true }

--- a/oprf-test-utils/Cargo.toml
+++ b/oprf-test-utils/Cargo.toml
@@ -71,6 +71,7 @@ generate-test-transcript = [
   "dep:askama",
   "dep:clap",
   "dep:groth16-material",
+  "groth16-material/circom",
   "dep:groth16-sol",
   "dep:nodes-observability"
 ]

--- a/oprf-test-utils/Cargo.toml
+++ b/oprf-test-utils/Cargo.toml
@@ -18,10 +18,13 @@ required-features = ["generate-test-transcript"]
 
 [dependencies]
 alloy = { workspace = true, features = [
-  "full",
+  "contract",
   "node-bindings",
-  "rpc",
-  "rpc-client-ws"
+  "provider-http",
+  "provider-ws",
+  "rpc-types-eth",
+  "signer-local",
+  "sol-types"
 ] }
 ark-babyjubjub = { workspace = true }
 ark-bn254 = { workspace = true, optional = true }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: dependency feature-flag changes only, but may cause build/CI failures if any code path relied on previously enabled `alloy` feature sets.
> 
> **Overview**
> Switches several crates from broad `alloy` feature bundles (e.g., `full`, `rpc`, `rpc-client-ws`) to an explicit minimal set of `alloy` features needed for contracts/providers/signing (and related `rpc-types-eth`/`sol-types` where applicable).
> 
> Also updates `oprf-test-utils` so the `generate-test-transcript` feature explicitly enables `groth16-material/circom`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ead33c48136c10423c1e164d7475286025ed75f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->