### PR TITLE
feat: add additional retries for null responses

### DIFF
--- a/oprf-key-gen/src/config.rs
+++ b/oprf-key-gen/src/config.rs
@@ -19,6 +19,8 @@
 //! | `max_wait_time_transaction_confirmation` | 300 s       |
 //! | `max_gas_per_transaction`                | 8 000 000   |
 //! | `confirmations_for_transaction`          | 5           |
+//! | `max_tries_fetching_receipt`             | 5           |
+//! | `sleep_between_get_receipt`              | 5 s         |
 //! | `i_am_alive_interval`                    | 60 s        |
 
 use std::num::NonZeroU16;

--- a/oprf-key-gen/src/config.rs
+++ b/oprf-key-gen/src/config.rs
@@ -87,6 +87,19 @@ pub struct OprfKeyGenServiceConfig {
     #[serde(default = "OprfKeyGenServiceConfig::default_confirmations_for_transaction")]
     pub confirmations_for_transaction: u64,
 
+    /// Number of times we try to fetch the receipt after a confirmed transaction with `eth_getTransactionReceipt`.
+    ///
+    /// Defaults to `5`.
+    #[serde(default = "OprfKeyGenServiceConfig::default_max_tries_fetching_receipt")]
+    pub max_tries_fetching_receipt: usize,
+
+    /// Time to sleep between `eth_getTransactionReceipt` calls when getting a `NullResponse` on a confirmed transaction.
+    ///
+    /// Defaults to `5s`.
+    #[serde(default = "OprfKeyGenServiceConfig::default_sleep_between_get_receipt")]
+    #[serde(with = "humantime_serde")]
+    pub sleep_between_get_receipt: Duration,
+
     /// Interval in which we emit "I am alive" metric.
     ///
     /// Defaults to `60 s`.
@@ -153,6 +166,16 @@ impl OprfKeyGenServiceConfig {
         5
     }
 
+    /// Default max tries for fetching receipt after confirmed transaction (`5`).
+    fn default_max_tries_fetching_receipt() -> usize {
+        5
+    }
+
+    /// Default time we sleep between trying to fetch receipt of a confirmed transaction (`5s`).
+    fn default_sleep_between_get_receipt() -> Duration {
+        Duration::from_secs(5)
+    }
+
     /// Default I-am-alive interval (`60 s`).
     fn default_i_am_alive_interval() -> Duration {
         Duration::from_mins(1)
@@ -186,6 +209,8 @@ impl OprfKeyGenServiceConfig {
             max_gas_per_transaction: Self::default_max_gas_per_transaction(),
             confirmations_for_transaction: Self::default_confirmations_for_transaction(),
             i_am_alive_interval: Self::default_i_am_alive_interval(),
+            max_tries_fetching_receipt: Self::default_max_tries_fetching_receipt(),
+            sleep_between_get_receipt: Self::default_sleep_between_get_receipt(),
         }
     }
 }

--- a/oprf-key-gen/src/lib.rs
+++ b/oprf-key-gen/src/lib.rs
@@ -33,8 +33,10 @@ use crate::{
         METRICS_ATTRID_WALLET_ADDRESS, METRICS_ID_I_AM_ALIVE, METRICS_ID_KEY_GEN_WALLET_BALANCE,
     },
     services::{
-        key_event_watcher::KeyEventWatcherTaskConfig, secret_gen::DLogSecretGenService,
-        secret_manager::SecretManagerService, transaction_handler::TransactionHandler,
+        key_event_watcher::KeyEventWatcherTaskConfig,
+        secret_gen::DLogSecretGenService,
+        secret_manager::SecretManagerService,
+        transaction_handler::{TransactionHandler, TransactionHandlerArgs},
     },
 };
 use alloy::{
@@ -206,13 +208,15 @@ pub async fn start(
     .context("while joining build groth16 task")?
     .context("while building groth16 material")?;
     let dlog_secret_gen_service = DLogSecretGenService::init(key_gen_material);
-    let transaction_handler = TransactionHandler::new(
-        config.max_wait_time_transaction_confirmation,
-        config.max_gas_per_transaction,
-        config.confirmations_for_transaction,
-        rpc_provider.clone(),
-        address,
-    );
+    let transaction_handler = TransactionHandler::new(TransactionHandlerArgs {
+        max_wait_time_watch_transaction: config.max_wait_time_transaction_confirmation,
+        confirmations_for_transaction: config.confirmations_for_transaction,
+        sleep_between_get_receipt: config.sleep_between_get_receipt,
+        max_tries_fetching_receipt: config.max_tries_fetching_receipt,
+        max_gas_per_transaction: config.max_gas_per_transaction,
+        rpc_provider: rpc_provider.clone(),
+        wallet_address: address,
+    });
 
     tracing::info!("spawning key event watcher..");
     let key_event_watcher = tokio::spawn({

--- a/oprf-key-gen/src/services/key_event_watcher/tests.rs
+++ b/oprf-key-gen/src/services/key_event_watcher/tests.rs
@@ -22,7 +22,7 @@ use crate::{
             TransactionError, handle_abort, handle_delete, handle_not_enough_producers,
         },
         secret_gen::DLogSecretGenService,
-        transaction_handler::TransactionHandler,
+        transaction_handler::{TransactionHandler, TransactionHandlerArgs},
     },
 };
 
@@ -51,13 +51,15 @@ async fn test_config(setup: &TestSetup) -> (CircomGroth16Material, TransactionHa
     .await
     .expect("can build RPC providers");
 
-    let transaction_handler = TransactionHandler::new(
-        Duration::from_secs(10),
-        10_000_000,
-        1,
+    let transaction_handler = TransactionHandler::new(TransactionHandlerArgs {
+        max_wait_time_watch_transaction: Duration::from_secs(10),
+        confirmations_for_transaction: 1,
+        sleep_between_get_receipt: Duration::from_millis(500),
+        max_tries_fetching_receipt: 5,
+        max_gas_per_transaction: 10_000_000,
         rpc_provider,
-        PEER_ADDRESSES[0],
-    );
+        wallet_address: PEER_ADDRESSES[0],
+    });
 
     (key_gen_material(setup.setup), transaction_handler)
 }

--- a/oprf-key-gen/src/services/transaction_handler.rs
+++ b/oprf-key-gen/src/services/transaction_handler.rs
@@ -4,7 +4,7 @@ use alloy::{
     contract::{CallBuilder, CallDecoder},
     network::{Network, ReceiptResponse},
     primitives::Address,
-    providers::Provider,
+    providers::{PendingTransactionError, Provider},
     transports::TransportError,
 };
 use backon::{BackoffBuilder as _, ConstantBackoff, ConstantBuilder, Retryable as _};
@@ -28,8 +28,8 @@ use crate::{
 pub(crate) struct TransactionHandler {
     max_wait_time_watch_transaction: Duration,
     confirmations_for_transaction: u64,
-    sleep_between_null_get_receipt: Duration,
-    max_tries_null_get_receipt: usize,
+    sleep_between_get_receipt: Duration,
+    max_tries_fetching_receipt: usize,
     max_gas_per_transaction: u64,
     rpc_provider: web3::RpcProvider,
     wallet_address: Address,
@@ -50,8 +50,8 @@ impl From<TransactionHandlerArgs> for TransactionHandler {
         let TransactionHandlerArgs {
             max_wait_time_watch_transaction,
             confirmations_for_transaction,
-            sleep_between_get_receipt: sleep_between_null_get_receipt,
-            max_tries_fetching_receipt: max_tries_null_get_receipt,
+            sleep_between_get_receipt,
+            max_tries_fetching_receipt,
             max_gas_per_transaction,
             rpc_provider,
             wallet_address,
@@ -59,8 +59,8 @@ impl From<TransactionHandlerArgs> for TransactionHandler {
         Self {
             max_wait_time_watch_transaction,
             confirmations_for_transaction,
-            sleep_between_null_get_receipt,
-            max_tries_null_get_receipt,
+            sleep_between_get_receipt,
+            max_tries_fetching_receipt,
             max_gas_per_transaction,
             rpc_provider,
             wallet_address,
@@ -75,8 +75,8 @@ impl TransactionHandler {
 
     fn backoff_strategy(&self) -> ConstantBackoff {
         ConstantBuilder::new()
-            .with_delay(self.sleep_between_null_get_receipt)
-            .with_max_times(self.max_tries_null_get_receipt)
+            .with_delay(self.sleep_between_get_receipt)
+            .with_max_times(self.max_tries_fetching_receipt)
             .build()
     }
 
@@ -111,16 +111,16 @@ impl TransactionHandler {
         N: Network,
         F: Fn() -> CallBuilder<P, D, N>,
     {
-        let tx_hash = transaction()
+        let pending_transaction = transaction()
             .gas(self.max_gas_per_transaction)
             .send()
             .await
             .context("while broadcasting to network")?
             .with_required_confirmations(self.confirmations_for_transaction)
-            .with_timeout(Some(self.max_wait_time_watch_transaction))
-            .watch()
-            .await
-            .context("while waiting for confirmation")?;
+            .with_timeout(Some(self.max_wait_time_watch_transaction));
+        let tx_hash = pending_transaction.tx_hash().to_owned();
+        let receipt_result = pending_transaction.get_receipt().await;
+
         tracing::trace!("transaction with hash: {tx_hash} confirmed");
 
         if let Ok(balance) = self
@@ -136,32 +136,51 @@ impl TransactionHandler {
         } else {
             tracing::warn!("could not fetch current wallet balance");
         }
-        let receipt = (|| async {
-            self.rpc_provider
-                .http()
-                .get_transaction_receipt(tx_hash)
-                .await?
-                .ok_or(TransportError::NullResp)
-        })
-        .retry(self.backoff_strategy())
-        .sleep(tokio::time::sleep)
-        .when(|e| matches!(e, TransportError::NullResp))
-        .notify(|_e, duration| {
-            tracing::warn!("Retrying getTransactionReceipt due to NullResp after {duration:?}");
-        })
-        .await
-        .context("while fetching getReceipt")?;
-        if receipt.status() {
-            handle_success_receipt(&receipt);
-            Ok(())
-        } else {
-            tracing::debug!("could not send transaction - do a call to get revert data");
-            transaction().call().await?;
-            // if we are here the call afterwards succeeded - we don't really know why the receipt failed so just return the wrapped receipt
-            Err(TransactionError::Rpc(eyre::eyre!(
-                "cannot finish transaction for unknown reason: {receipt:?}"
-            )))
+        match receipt_result {
+            Ok(receipt) => check_receipt(transaction, &receipt).await,
+            Err(PendingTransactionError::TransportError(TransportError::NullResp)) => {
+                let receipt = (|| async {
+                    self.rpc_provider
+                        .http()
+                        .get_transaction_receipt(tx_hash)
+                        .await?
+                        .ok_or(TransportError::NullResp)
+                })
+                .retry(self.backoff_strategy())
+                .sleep(tokio::time::sleep)
+                .when(|e| matches!(e, TransportError::NullResp))
+                .notify(|_e, duration| {
+                    tracing::warn!(
+                        "Retrying eth_getTransactionReceipt in {duration:?} due to NullResp"
+                    );
+                })
+                .await
+                .context("while fetching getReceipt")?;
+                check_receipt(transaction, &receipt).await
+            }
+            Err(err) => Err(TransactionError::Rpc(eyre::Report::from(err))),
         }
+    }
+}
+
+async fn check_receipt<P, D, N, F, R>(transaction: F, receipt: &R) -> Result<(), TransactionError>
+where
+    P: Provider<N>,
+    D: CallDecoder + Unpin,
+    N: Network,
+    F: Fn() -> CallBuilder<P, D, N>,
+    R: ReceiptResponse + std::fmt::Debug,
+{
+    if receipt.status() {
+        handle_success_receipt(receipt);
+        Ok(())
+    } else {
+        tracing::debug!("could not send transaction - do a call to get revert data");
+        transaction().call().await?;
+        // if we are here the call afterwards succeeded - we don't really know why the receipt failed so just return the wrapped receipt
+        Err(TransactionError::Rpc(eyre::eyre!(
+            "cannot finish transaction for unknown reason: {receipt:?}"
+        )))
     }
 }
 

--- a/oprf-key-gen/src/services/transaction_handler.rs
+++ b/oprf-key-gen/src/services/transaction_handler.rs
@@ -4,9 +4,10 @@ use alloy::{
     contract::{CallBuilder, CallDecoder},
     network::{Network, ReceiptResponse},
     primitives::Address,
-    providers::{PendingTransactionError, Provider},
-    transports::RpcError,
+    providers::Provider,
+    transports::TransportError,
 };
+use backon::{BackoffBuilder as _, ConstantBackoff, ConstantBuilder, Retryable as _};
 use eyre::Context as _;
 use nodes_common::web3;
 use tracing::instrument;
@@ -25,28 +26,58 @@ use crate::{
 /// performing a static call to extract revert data for diagnostics.
 #[derive(Clone)]
 pub(crate) struct TransactionHandler {
-    max_wait_time: Duration,
-    max_gas_per_transaction: u64,
+    max_wait_time_watch_transaction: Duration,
     confirmations_for_transaction: u64,
+    sleep_between_null_get_receipt: Duration,
+    max_tries_null_get_receipt: usize,
+    max_gas_per_transaction: u64,
     rpc_provider: web3::RpcProvider,
     wallet_address: Address,
 }
 
-impl TransactionHandler {
-    pub(crate) fn new(
-        max_wait_time: Duration,
-        max_gas_per_transaction: u64,
-        confirmations_for_transaction: u64,
-        rpc_provider: web3::RpcProvider,
-        wallet_address: Address,
-    ) -> Self {
-        Self {
-            max_wait_time,
-            max_gas_per_transaction,
+pub(crate) struct TransactionHandlerArgs {
+    pub(crate) max_wait_time_watch_transaction: Duration,
+    pub(crate) confirmations_for_transaction: u64,
+    pub(crate) sleep_between_get_receipt: Duration,
+    pub(crate) max_tries_fetching_receipt: usize,
+    pub(crate) max_gas_per_transaction: u64,
+    pub(crate) rpc_provider: web3::RpcProvider,
+    pub(crate) wallet_address: Address,
+}
+
+impl From<TransactionHandlerArgs> for TransactionHandler {
+    fn from(value: TransactionHandlerArgs) -> Self {
+        let TransactionHandlerArgs {
+            max_wait_time_watch_transaction,
             confirmations_for_transaction,
+            sleep_between_get_receipt: sleep_between_null_get_receipt,
+            max_tries_fetching_receipt: max_tries_null_get_receipt,
+            max_gas_per_transaction,
+            rpc_provider,
+            wallet_address,
+        } = value;
+        Self {
+            max_wait_time_watch_transaction,
+            confirmations_for_transaction,
+            sleep_between_null_get_receipt,
+            max_tries_null_get_receipt,
+            max_gas_per_transaction,
             rpc_provider,
             wallet_address,
         }
+    }
+}
+
+impl TransactionHandler {
+    pub(crate) fn new(args: TransactionHandlerArgs) -> Self {
+        Self::from(args)
+    }
+
+    fn backoff_strategy(&self) -> ConstantBackoff {
+        ConstantBuilder::new()
+            .with_delay(self.sleep_between_null_get_receipt)
+            .with_max_times(self.max_tries_null_get_receipt)
+            .build()
     }
 
     /// Attempts to send a transaction and waits for the receipt.
@@ -80,19 +111,18 @@ impl TransactionHandler {
         N: Network,
         F: Fn() -> CallBuilder<P, D, N>,
     {
-        let pending_tx = transaction()
+        let tx_hash = transaction()
             .gas(self.max_gas_per_transaction)
             .send()
             .await
-            .context("while broadcasting to network")?;
-
-        let pending_tx_hash = pending_tx.tx_hash().to_owned();
-
-        let transaction_result = pending_tx
+            .context("while broadcasting to network")?
             .with_required_confirmations(self.confirmations_for_transaction)
-            .with_timeout(Some(self.max_wait_time))
-            .get_receipt()
-            .await;
+            .with_timeout(Some(self.max_wait_time_watch_transaction))
+            .watch()
+            .await
+            .context("while waiting for confirmation")?;
+        tracing::trace!("transaction with hash: {tx_hash} confirmed");
+
         if let Ok(balance) = self
             .rpc_provider
             .http()
@@ -106,78 +136,32 @@ impl TransactionHandler {
         } else {
             tracing::warn!("could not fetch current wallet balance");
         }
-        match transaction_result {
-            Ok(receipt) => {
-                return check_receipt(transaction, &receipt).await;
-            }
-            Err(err) => {
-                if matches!(
-                    err,
-                    PendingTransactionError::TransportError(RpcError::NullResp)
-                ) {
-                    // we got a null response. This can mean the transaction was accepted but the provider failed to return a proper responser.
-                    let mut tries = 0;
-                    loop {
-                        tries += 1;
-                        if tries > 5 {
-                            return Err(TransactionError::Rpc(eyre::eyre!(
-                                "transaction might have been accepted but could not get receipt after multiple tries: {pending_tx_hash}, last error: {err:?}"
-                            )));
-                        }
-
-                        let maybe_receipt = self
-                            .rpc_provider
-                            .http()
-                            .get_transaction_receipt(pending_tx_hash)
-                            .await;
-
-                        match maybe_receipt {
-                            Ok(Some(receipt)) => {
-                                tracing::debug!(
-                                    "got receipt for transaction after null response error, additional tries: {tries}"
-                                );
-                                return check_receipt(transaction, &receipt).await;
-                            }
-                            Ok(None) => {
-                                tracing::debug!(
-                                    "transaction receipt not available yet after null response error, additional tries: {tries}"
-                                );
-                                tokio::time::sleep(Duration::from_secs(2)).await;
-                            }
-                            Err(err) => {
-                                tracing::debug!(
-                                    "error while fetching receipt for transaction after null response error, additional tries: {tries}, error: {err:?}"
-                                );
-                                tokio::time::sleep(Duration::from_secs(2)).await;
-                            }
-                        }
-                    }
-                }
-                return Err(TransactionError::Rpc(eyre::Report::from(err)));
-            }
+        let receipt = (|| async {
+            self.rpc_provider
+                .http()
+                .get_transaction_receipt(tx_hash)
+                .await?
+                .ok_or(TransportError::NullResp)
+        })
+        .retry(self.backoff_strategy())
+        .sleep(tokio::time::sleep)
+        .when(|e| matches!(e, TransportError::NullResp))
+        .notify(|_e, duration| {
+            tracing::warn!("Retrying getTransactionReceipt due to NullResp after {duration:?}");
+        })
+        .await
+        .context("while fetching getReceipt")?;
+        if receipt.status() {
+            handle_success_receipt(&receipt);
+            Ok(())
+        } else {
+            tracing::debug!("could not send transaction - do a call to get revert data");
+            transaction().call().await?;
+            // if we are here the call afterwards succeeded - we don't really know why the receipt failed so just return the wrapped receipt
+            Err(TransactionError::Rpc(eyre::eyre!(
+                "cannot finish transaction for unknown reason: {receipt:?}"
+            )))
         }
-    }
-}
-
-/// Helper function to get the revert data in case the transaction failed.
-async fn check_receipt<P, D, N, F, R>(transaction: F, receipt: &R) -> Result<(), TransactionError>
-where
-    P: Provider<N>,
-    D: CallDecoder + Unpin,
-    N: Network,
-    F: Fn() -> CallBuilder<P, D, N>,
-    R: ReceiptResponse + std::fmt::Debug,
-{
-    if receipt.status() {
-        handle_success_receipt(receipt);
-        Ok(())
-    } else {
-        tracing::debug!("could not send transaction - do a call to get revert data");
-        transaction().call().await?;
-        // if we are here the call afterwards succeeded - we don't really know why the receipt failed so just return the wrapped receipt
-        Err(TransactionError::Rpc(eyre::eyre!(
-            "cannot finish transaction for unknown reason: {receipt:?}"
-        )))
     }
 }
 

--- a/oprf-key-gen/src/services/transaction_handler.rs
+++ b/oprf-key-gen/src/services/transaction_handler.rs
@@ -108,7 +108,7 @@ impl TransactionHandler {
         }
         match transaction_result {
             Ok(receipt) => {
-                return check_receipt(transaction, receipt).await;
+                return check_receipt(transaction, &receipt).await;
             }
             Err(err) => {
                 if matches!(
@@ -136,18 +136,7 @@ impl TransactionHandler {
                                 tracing::debug!(
                                     "got receipt for transaction after null response error, additional tries: {tries}"
                                 );
-                                if receipt.status() {
-                                    handle_success_receipt(&receipt);
-                                    return Ok(());
-                                }
-                                tracing::debug!(
-                                    "could not send transaction - do a call to get revert data"
-                                );
-                                transaction().call().await?;
-                                // if we are here the call afterwards succeeded - we don't really know why the receipt failed so just return the wrapped receipt
-                                return Err(TransactionError::Rpc(eyre::eyre!(
-                                    "cannot finish transaction for unknown reason: {receipt:?}"
-                                )));
+                                return check_receipt(transaction, &receipt).await;
                             }
                             Ok(None) => {
                                 tracing::debug!(
@@ -164,25 +153,23 @@ impl TransactionHandler {
                         }
                     }
                 }
-                return Err(TransactionError::Rpc(eyre::eyre!(err)));
+                return Err(TransactionError::Rpc(eyre::Report::from(err)));
             }
         }
     }
 }
 
 /// Helper function to get the revert data in case the transaction failed.
-async fn check_receipt<P, D, N, F>(
-    transaction: F,
-    receipt: N::ReceiptResponse,
-) -> Result<(), TransactionError>
+async fn check_receipt<P, D, N, F, R>(transaction: F, receipt: &R) -> Result<(), TransactionError>
 where
     P: Provider<N>,
     D: CallDecoder + Unpin,
     N: Network,
     F: Fn() -> CallBuilder<P, D, N>,
+    R: ReceiptResponse + std::fmt::Debug,
 {
     if receipt.status() {
-        handle_success_receipt(&receipt);
+        handle_success_receipt(receipt);
         Ok(())
     } else {
         tracing::debug!("could not send transaction - do a call to get revert data");

--- a/oprf-key-gen/src/services/transaction_handler.rs
+++ b/oprf-key-gen/src/services/transaction_handler.rs
@@ -4,7 +4,8 @@ use alloy::{
     contract::{CallBuilder, CallDecoder},
     network::{Network, ReceiptResponse},
     primitives::Address,
-    providers::Provider,
+    providers::{PendingTransactionError, Provider},
+    transports::RpcError,
 };
 use eyre::Context as _;
 use nodes_common::web3;
@@ -79,11 +80,15 @@ impl TransactionHandler {
         N: Network,
         F: Fn() -> CallBuilder<P, D, N>,
     {
-        let transaction_result = transaction()
+        let pending_tx = transaction()
             .gas(self.max_gas_per_transaction)
             .send()
             .await
-            .context("while broadcasting to network")?
+            .context("while broadcasting to network")?;
+
+        let pending_tx_hash = pending_tx.tx_hash().to_owned();
+
+        let transaction_result = pending_tx
             .with_required_confirmations(self.confirmations_for_transaction)
             .with_timeout(Some(self.max_wait_time))
             .get_receipt()
@@ -106,6 +111,59 @@ impl TransactionHandler {
                 return check_receipt(transaction, receipt).await;
             }
             Err(err) => {
+                if matches!(
+                    err,
+                    PendingTransactionError::TransportError(RpcError::NullResp)
+                ) {
+                    // we got a null response. This can mean the transaction was accepted but the provider failed to return a proper responser.
+                    let mut tries = 0;
+                    loop {
+                        tries += 1;
+                        if tries > 5 {
+                            return Err(TransactionError::Rpc(eyre::eyre!(
+                                "transaction might have been accepted but could not get receipt after multiple tries: {pending_tx_hash}, last error: {err:?}"
+                            )));
+                        }
+
+                        let maybe_receipt = self
+                            .rpc_provider
+                            .http()
+                            .get_transaction_receipt(pending_tx_hash)
+                            .await;
+
+                        match maybe_receipt {
+                            Ok(Some(receipt)) => {
+                                tracing::debug!(
+                                    "got receipt for transaction after null response error, additional tries: {tries}"
+                                );
+                                if receipt.status() {
+                                    handle_success_receipt(&receipt);
+                                    return Ok(());
+                                }
+                                tracing::debug!(
+                                    "could not send transaction - do a call to get revert data"
+                                );
+                                transaction().call().await?;
+                                // if we are here the call afterwards succeeded - we don't really know why the receipt failed so just return the wrapped receipt
+                                return Err(TransactionError::Rpc(eyre::eyre!(
+                                    "cannot finish transaction for unknown reason: {receipt:?}"
+                                )));
+                            }
+                            Ok(None) => {
+                                tracing::debug!(
+                                    "transaction receipt not available yet after null response error, additional tries: {tries}"
+                                );
+                                tokio::time::sleep(Duration::from_secs(2)).await;
+                            }
+                            Err(err) => {
+                                tracing::debug!(
+                                    "error while fetching receipt for transaction after null response error, additional tries: {tries}, error: {err:?}"
+                                );
+                                tokio::time::sleep(Duration::from_secs(2)).await;
+                            }
+                        }
+                    }
+                }
                 return Err(TransactionError::Rpc(eyre::eyre!(err)));
             }
         }


### PR DESCRIPTION
Proposal for another wrapper around the retry logic, specifically for NullResponses.
Tries to get the transaction receipt manually if we get a NullResponse, retrying a few times.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction confirmation/receipt retrieval behavior by adding retry-on-`NullResp` logic and new configurable timing/attempt limits, which can affect reliability and latency of on-chain operations.
> 
> **Overview**
> Adds two new config knobs, `max_tries_fetching_receipt` and `sleep_between_get_receipt`, and wires them into service startup.
> 
> Refactors `TransactionHandler::new` to take `TransactionHandlerArgs` and updates callers/tests accordingly. `TransactionHandler::attempt_transaction` now detects `NullResp` from `get_receipt()` and falls back to repeatedly calling `eth_getTransactionReceipt` with a constant backoff before continuing receipt handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18da6fb8aeac8ad43a951148c9bf7a6a678ff62d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->