### PR TITLE
chore(key-gen): fix trace msg in transaction handler

### DIFF
--- a/oprf-key-gen/src/services/transaction_handler.rs
+++ b/oprf-key-gen/src/services/transaction_handler.rs
@@ -100,7 +100,7 @@ impl TransactionHandler {
     ///     })
     ///     .await?;
     /// ```
-    #[instrument(level = "info", skip_all)]
+    #[instrument(level = "info", skip_all, fields(tx_hash = tracing::field::Empty))]
     pub(crate) async fn attempt_transaction<P, D, N, F>(
         &self,
         transaction: F,
@@ -119,9 +119,9 @@ impl TransactionHandler {
             .with_required_confirmations(self.confirmations_for_transaction)
             .with_timeout(Some(self.max_wait_time_watch_transaction));
         let tx_hash = pending_transaction.tx_hash().to_owned();
+        let current_span = tracing::Span::current();
+        current_span.record("tx_hash", tx_hash.to_string());
         let receipt_result = pending_transaction.get_receipt().await;
-
-        tracing::trace!("transaction with hash: {tx_hash} confirmed");
 
         if let Ok(balance) = self.rpc_provider.get_balance(self.wallet_address).await {
             let balance_eth = alloy::primitives::utils::format_ether(balance);
@@ -165,10 +165,6 @@ where
     F: Fn() -> CallBuilder<P, D, N>,
     R: ReceiptResponse + std::fmt::Debug,
 {
-    tracing::trace!(
-        "transaction with hash: {} confirmed",
-        receipt.transaction_hash()
-    );
     if receipt.status() {
         handle_success_receipt(receipt);
         Ok(())
@@ -183,6 +179,10 @@ where
 }
 
 fn handle_success_receipt<R: ReceiptResponse>(receipt: &R) {
+    tracing::trace!(
+        "transaction with hash: {} confirmed",
+        receipt.transaction_hash()
+    );
     let gas_used = receipt
         .gas_used()
         .to_string()

--- a/oprf-key-gen/src/services/transaction_handler.rs
+++ b/oprf-key-gen/src/services/transaction_handler.rs
@@ -165,6 +165,10 @@ where
     F: Fn() -> CallBuilder<P, D, N>,
     R: ReceiptResponse + std::fmt::Debug,
 {
+    tracing::trace!(
+        "transaction with hash: {} confirmed",
+        receipt.transaction_hash()
+    );
     if receipt.status() {
         handle_success_receipt(receipt);
         Ok(())


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: logging-only changes that add structured `tx_hash` context and move the confirmation trace to use the receipt’s transaction hash, without altering transaction submission or receipt handling behavior.
> 
> **Overview**
> Improves transaction observability in `TransactionHandler` by **adding a `tx_hash` field to the `attempt_transaction` tracing span** and recording the broadcast transaction hash into that span.
> 
> Moves the “transaction confirmed” trace into `handle_success_receipt`, logging the hash from the actual receipt (instead of emitting a standalone trace before receipt validation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af515e5d59dfb336ea313d92b269a41a04b45d7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->