### PR TITLE
Feature gate oprf-types to reduce deps for client.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6406,6 +6406,7 @@ dependencies = [
  "async-trait",
  "eyre",
  "http",
+ "ruint",
  "serde",
  "taceo-ark-babyjubjub",
  "taceo-ark-serde-compat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ reqwest = { version = "0.12", default-features = false, features = [
   "json",
   "rustls-tls",
 ] }
+ruint = { version = "1", features = ["serde"] }
 rustls = "0.23"
 secrecy = "0.10"
 semver = "1"

--- a/oprf-client/Cargo.toml
+++ b/oprf-client/Cargo.toml
@@ -18,7 +18,7 @@ ciborium = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 oprf-core = { package = "taceo-oprf-core", path = "../oprf-core", version = "0.5" }
-oprf-types = { package = "taceo-oprf-types", path = "../oprf-types", version = "0.12" }
+oprf-types = { package = "taceo-oprf-types", path = "../oprf-types", version = "0.12", default-features = false }
 poseidon2 = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/oprf-types/Cargo.toml
+++ b/oprf-types/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["cryptography", "mpc", "oprf"]
 publish = true
 
 [dependencies]
-alloy = { workspace = true, features = ["contract"] }
+alloy = { workspace = true, features = ["contract"], optional = true }
 ark-babyjubjub = { workspace = true }
 ark-ff = { workspace = true }
 ark-serde-compat = { workspace = true }
@@ -23,11 +23,15 @@ circom-types = { workspace = true, features = [
   "groth16",
   "proof",
   "zkey"
-] }
+], optional = true }
 eyre = { workspace = true }
-groth16-sol = { workspace = true }
+groth16-sol = { workspace = true, optional = true }
 http = { workspace = true }
 oprf-core = { package = "taceo-oprf-core", path = "../oprf-core", version = "0.5" }
 ruint = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 uuid = { workspace = true, features = ["serde", "v4"] }
+
+[features]
+default = ["chain"]
+chain = ["dep:alloy", "dep:groth16-sol", "dep:circom-types"]

--- a/oprf-types/Cargo.toml
+++ b/oprf-types/Cargo.toml
@@ -28,5 +28,6 @@ eyre = { workspace = true }
 groth16-sol = { workspace = true }
 http = { workspace = true }
 oprf-core = { package = "taceo-oprf-core", path = "../oprf-core", version = "0.5" }
+ruint = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 uuid = { workspace = true, features = ["serde", "v4"] }

--- a/oprf-types/src/crypto.rs
+++ b/oprf-types/src/crypto.rs
@@ -9,13 +9,14 @@
 //! * [`EphemeralEncryptionPublicKey`]
 //! * [`OprfPublicKey`]
 //! * [`SecretGenCommitment`]
-//! * [`SecretGenCiphertexts`] / [`SecretGenCiphertext`]
+//! * `SecretGenCiphertexts` / `SecretGenCiphertext` (requires the `chain` feature)
 
 use std::fmt;
 
 use ark_serde_compat::babyjubjub;
 use ark_serialize::CanonicalDeserialize;
 use ark_serialize::CanonicalSerialize;
+#[cfg(feature = "chain")]
 use circom_types::{ark_bn254::Bn254, groth16::Proof};
 use oprf_core::ddlog_equality::shamir::DLogShareShamir;
 use serde::{Deserialize, Serialize};
@@ -78,7 +79,8 @@ pub struct SecretGenCommitment {
 ///
 /// Contains ciphertexts for all OPRF nodes (including the node itself) with the evaluations
 /// of the polynomial generated in the first round. The ciphertexts of the nodes
-/// is sorted according to their respective party ID.  
+/// is sorted according to their respective party ID.
+#[cfg(feature = "chain")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SecretGenCiphertexts {
     /// The proof that the ciphertexts were computed correctly
@@ -90,6 +92,7 @@ pub struct SecretGenCiphertexts {
 /// A ciphertext for an OPRF node used in round 2 of the OPRF-nullifier generation protocol.
 ///
 /// Contains the [`EphemeralEncryptionPublicKey`] of the sender, the ciphertext itself, and a nonce.
+#[cfg(feature = "chain")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SecretGenCiphertext {
     #[serde(with = "ark_serde_compat::field")]
@@ -185,6 +188,7 @@ impl fmt::Display for EphemeralEncryptionPublicKey {
     }
 }
 
+#[cfg(feature = "chain")]
 impl SecretGenCiphertexts {
     /// Creates a new instance by wrapping the provided value.
     #[must_use]
@@ -193,6 +197,7 @@ impl SecretGenCiphertexts {
     }
 }
 
+#[cfg(feature = "chain")]
 impl SecretGenCiphertext {
     /// Creates a new ciphertext contribution for an OPRF node by wrapping a nonce, a ciphertext and a commitment to the plain text.
     #[must_use]

--- a/oprf-types/src/lib.rs
+++ b/oprf-types/src/lib.rs
@@ -28,8 +28,8 @@
 //!   identifiers, and Merkle roots, with consistent serialization and
 //!   display implementations.
 //! * Cryptographic types used in the OPRF protocol (see [`crypto`] module).
-//! * On-chain contribution types exchanged during key generation (see
-//!   [`chain`] module).
+//! * On-chain contribution types exchanged during key generation (see the
+//!   `chain` module, available with the `chain` feature).
 //! * API versioned types for client/server communication (see [`api`] module).
 //!
 //! Use these types to pass, store, and (de)serialize identifiers and
@@ -45,6 +45,7 @@ pub use ark_babyjubjub;
 pub use async_trait;
 
 pub mod api;
+#[cfg(feature = "chain")]
 pub mod chain;
 pub mod crypto;
 

--- a/oprf-types/src/lib.rs
+++ b/oprf-types/src/lib.rs
@@ -37,8 +37,8 @@
 
 use std::fmt;
 
-use alloy::primitives::{U160, U256};
 use ark_ff::PrimeField;
+use ruint::aliases::{U160, U256};
 use serde::{Deserialize, Serialize};
 
 pub use ark_babyjubjub;


### PR DESCRIPTION
- **refactor(oprf-types): use ruint::aliases instead of alloy::primitives for U160/U256**
- **refactor(oprf-types): introduce 'chain' feature, mark alloy/circom-types/groth16-sol optional**
- **refactor(oprf-client): disable default features on oprf-types**
- **chore: cargo fmt**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes `oprf-types` public feature defaults and conditionally compiles several exported types/modules, which can break downstream builds or serialization expectations if the `chain` feature isn’t enabled where needed.
> 
> **Overview**
> Reduces the dependency footprint of `taceo-oprf-types` for client use by introducing a `chain` feature: on-chain/keygen contribution types (including `SecretGenCiphertexts`/`SecretGenCiphertext` and the `chain` module) are now compiled only when `chain` is enabled, and the heavy deps (`alloy`, `circom-types`, `groth16-sol`) are made optional behind that feature.
> 
> Also replaces `alloy::primitives` `U160`/`U256` usage with `ruint::aliases` and wires `oprf-client` to depend on `oprf-types` with `default-features = false`, plus adds `ruint` to the workspace dependencies/lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4655d04aeee2e715eb0dc6d26e03dd439a724efc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->