### PR TITLE
build(key-gen,service)!: bump to alloy version 2.0.0 and nodes-common…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dc44b606f29348ce7c127e7f872a6d2df3cfeff85b7d6bba62faca75112fdd"
+checksum = "a547705d5c1b42575a0542bae2ba45bc62a6154be86611afaef1c0ab5c38598e"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -62,7 +62,6 @@ dependencies = [
  "alloy-signer-local",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ipc",
  "alloy-transport-ws",
  "alloy-trie",
 ]
@@ -80,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4ff99651d46cef43767b5e8262ea228cd05287409ccb0c947cc25e70a952f9"
+checksum = "ae8c24c95e90c1608c2d91cff1b451d796474168d3310ccc8b7cd12502ca8169"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -107,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0701b0eda8051a2398591113e7862f807ccdd3315d0b441f06c2a0865a379b"
+checksum = "7d211ad0ef468a70a7a829e49683ff59ad25f02b4ab3764344c4c2663329a52c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -121,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c83c7a3c4e1151e8cac383d0a67ddf358f37e5ea51c95a1283d897c9de0a5a"
+checksum = "c59d55233ac14aa7fa6bcdcad45ba305e90c556065e0947cd9f243c4469e7c2d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -140,6 +139,7 @@ dependencies = [
  "futures-util",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -205,7 +205,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "borsh",
- "k256",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -224,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def1626eea28d48c6cc0a6f16f34d4af0001906e4f889df6c660b39c86fd044d"
+checksum = "ae69eaa5096b47ffe97e6a5d6bde7e7fa2dec106af22a9315621d11039c3de3c"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -243,14 +242,13 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2 0.10.9",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d9d1aba3f914f0e8db9e4616ae37f3d811426d95bdccf44e47d0605ab202f6"
+checksum = "39789db0b3f3bbef0e6549c87bc6842b73886ebabee1405b6941685b1cc34083"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -288,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57586581f2008933241d16c3e3f633168b3a5d2738c5c42ea5246ec5e0ef17a"
+checksum = "662b525af73e86b2167dae923261c8edf440ba7e1426b30a8b993177bc214c02"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -303,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b36c2a0ed74e48851f78415ca5b465211bd678891ba11e88fee09eac534bab1"
+checksum = "c657c2d9751d3c7d94990554b231e5372c3c2e4bad842806280b6151a0d6a05d"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -329,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636c8051da58802e757b76c3b65af610b95799f72423dc955737dec73de234fd"
+checksum = "59e7c4bb0ebbd6d7406d2808968f43c0d5186c69c5e58cedcbee7380f4cd1fcf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -342,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce6930ce52e43b0768dc99ceeff5cb9e673e8c9f87d926914cd028b2e3f7233"
+checksum = "2e78e79286335697f025dd722e5d0d101f8d8aeecdded71114e2c1f2a02104b6"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -391,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3dd56e2eafe8b1803e325867ac2c8a4c73c9fb5f341ffd8347f9344458c5922"
+checksum = "c4fea0fc2628cdbc851aaa333124f9d8ab9f567ab8d4c20202819db13aa1a534"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -406,15 +404,11 @@ dependencies = [
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-anvil",
- "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
- "alloy-rpc-types-trace",
- "alloy-rpc-types-txpool",
  "alloy-signer",
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ipc",
  "alloy-transport-ws",
  "async-stream",
  "async-trait",
@@ -426,7 +420,7 @@ dependencies = [
  "lru",
  "parking_lot",
  "pin-project",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -438,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eebf54983d4fccea08053c218ee5c288adf2e660095a243d0532a8070b43955"
+checksum = "edc7b42e514613c717887dc77bb58d35e845557ebd63a18c3f92a77094e4891f"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -482,20 +476,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91577235d341a1bdbee30a463655d08504408a4d51e9f72edbfc5a622829f402"
+checksum = "d5ee7b51752c68fb95f21705e402700750e692b1d21ccc294ac48fadc8655d53"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ipc",
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "tokio",
@@ -508,26 +501,21 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cff039bf01a17d76c0aace3a3a773d5f895eb4c68baaae729ec9da9e86c99c"
+checksum = "8fa76988f54105ad4398828e8aaf1a39b3f07f91fb79091529056689514ee8c2"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-anvil",
- "alloy-rpc-types-debug",
- "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "alloy-rpc-types-trace",
- "alloy-rpc-types-txpool",
  "alloy-serde",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22250cf438b6a3926de67683c08163bfa1fd1efa47ee9512cbcd631b6b0243c"
+checksum = "3d276bea4e92e4991269d31b9abd3e722eed2565b82036478a4416adb8dd4992"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -537,49 +525,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73234a141ecce14e2989748c04fcac23deee67a445e2c4c167cfb42d4dacd1b6"
+checksum = "1f1a9a3bda9be7f6515316eb792710532411878bbfc88934973f4b371376b00d"
 dependencies = [
  "alloy-consensus-any",
+ "alloy-network-primitives",
+ "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
-]
-
-[[package]]
-name = "alloy-rpc-types-debug"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779f70ab16a77e305571881b07a9bc6b0068ae6f962497baf5762825c5b839fb"
-dependencies = [
- "alloy-primitives",
- "derive_more",
  "serde",
- "serde_with",
-]
-
-[[package]]
-name = "alloy-rpc-types-engine"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10620d600cc46538f613c561ac9a923843c6c74c61f054828dcdb8dd18c72ec4"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "derive_more",
- "rand 0.8.5",
- "serde",
- "strum",
+ "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010e101dbebe0c678248907a2545b574a87d078d82c2f6f5d0e8e7c9a6149a10"
+checksum = "dda4ece0050154ab278241aeffade58916b04f38254832e8cb6e4671c6e72ed2"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -597,36 +560,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-rpc-types-trace"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be096f74d85e1f927580b398bf7bc5b4aa62326f149680ec0867e3c040c9aced"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "alloy-rpc-types-txpool"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ab75189fbc29c5dd6f0bc1529bccef7b00773b458763f4d9d81a77ae4a1a2d"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "serde",
-]
-
-[[package]]
 name = "alloy-serde"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6d631f8b975229361d8af7b2c749af31c73b3cf1352f90e144ddb06227105e"
+checksum = "beaa5c581a67e2743d95b4849eb9cfeb90866429cdaa6d8f6b75eb988b2d0cd9"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -635,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f40010b5e8f79b70bf163b38cd15f529b18ca88c4427c0e43441ee54e4ed82"
+checksum = "c5da9ae50f9b48d7b4e2e5cde87175257be7e5e56909a7794720597c1d9806f6"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -650,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c4ec1cc27473819399a3f0da83bc1cef0ceaac8c1c93997696e46dc74377a58"
+checksum = "49b794002d57fd2f71b4c87298a41ca24dfc0f2cf6630d95106a477e451747ba"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -739,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03bb3f02b9a7ab23dacd1822fa7f69aa5c8eefcdcf57fad085e0b8d76fb4334"
+checksum = "19dec9bfb59647254afdecbb5ddcddd7ba02edcd48ffa40510bddfbed0be1634"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -762,14 +699,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce599598ef8ebe067f3627509358d9faaa1ef94f77f834a7783cd44209ef55c"
+checksum = "2035f3c4d6bee20624da2dcf765d469b292398e48d766ffade61b0fcf8b4d45d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
  "itertools 0.14.0",
- "reqwest",
+ "reqwest 0.13.2",
  "serde_json",
  "tower",
  "tracing",
@@ -777,39 +714,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-transport-ipc"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49963a2561ebd439549915ea61efb70a7b13b97500ec16ca507721c9d9957d07"
-dependencies = [
- "alloy-json-rpc",
- "alloy-pubsub",
- "alloy-transport",
- "bytes",
- "futures",
- "interprocess",
- "pin-project",
- "serde",
- "serde_json",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "alloy-transport-ws"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed38ea573c6658e0c2745af9d1f1773b1ed83aa59fbd9c286358ad469c3233a"
+checksum = "a5aa8ff49386df3e008b73c7fb0a5479410e8493fdb86a8b916877a16e8aead9"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
  "http",
+ "rustls",
  "serde_json",
  "tokio",
- "tokio-tungstenite 0.26.2",
+ "tokio-tungstenite",
  "tracing",
+ "url",
  "ws_stream_wasm",
 ]
 
@@ -831,11 +750,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.6.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
+checksum = "3520337f3d3d063a7fe20f47aaa62d695e3dc0372b34f601560dee24e76988b9"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -1476,7 +1395,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1551,7 +1470,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "tower",
  "url",
  "uuid",
@@ -1884,6 +1803,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2032,6 +1957,16 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -2313,8 +2248,18 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -2324,6 +2269,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
  "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
@@ -2338,7 +2296,18 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.111",
 ]
@@ -2498,12 +2467,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "doctest-file"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
 
 [[package]]
 name = "dotenvy"
@@ -3618,21 +3581,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "interprocess"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d941b405bd2322993887859a8ee6ac9134945a24ec5ec763a8a962fc64dfec2d"
-dependencies = [
- "doctest-file",
- "futures-core",
- "libc",
- "recvmsg",
- "tokio",
- "widestring",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "inventory"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3695,6 +3643,50 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.111",
+]
 
 [[package]]
 name = "jobserver"
@@ -4238,7 +4230,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "reqwest",
+ "reqwest 0.12.28",
  "rmp",
  "ryu",
  "thiserror 1.0.69",
@@ -4255,7 +4247,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.28",
 ]
 
 [[package]]
@@ -4738,6 +4730,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -4908,12 +4901,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "recvmsg"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5020,6 +5007,43 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -5225,6 +5249,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -5517,7 +5568,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -6097,9 +6148,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-nodes-common"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b463ab18039730c44b38167f09acbaf91c0ceaea30c6218d259b9f3cb44f30f"
+checksum = "9a0ab40a81dbbcb8431822ce5a5d6339a0d9db1d78366989c8d188ed62da2d84"
 dependencies = [
  "alloy",
  "axum",
@@ -6166,7 +6217,7 @@ dependencies = [
  "taceo-poseidon2",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "tracing",
  "uuid",
 ]
@@ -6208,7 +6259,7 @@ dependencies = [
  "humantime",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls",
  "secrecy",
  "serde",
@@ -6246,7 +6297,7 @@ dependencies = [
  "metrics",
  "parking_lot",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls",
  "secrecy",
  "serde",
@@ -6308,7 +6359,7 @@ dependencies = [
  "tokio-util",
  "tower-http",
  "tracing",
- "tungstenite 0.28.0",
+ "tungstenite",
  "uuid",
  "zeroize",
 ]
@@ -6330,7 +6381,7 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "reqwest",
+ "reqwest 0.12.28",
  "serde_json",
  "sqlx",
  "taceo-ark-babyjubjub",
@@ -6400,7 +6451,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry_sdk",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -6658,22 +6709,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
-dependencies = [
- "futures-util",
- "log",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tungstenite 0.26.2",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -6684,7 +6719,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite 0.28.0",
+ "tungstenite",
  "webpki-roots 0.26.11",
 ]
 
@@ -6951,25 +6986,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tungstenite"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.9.2",
- "rustls",
- "rustls-pki-types",
- "sha1",
- "thiserror 2.0.18",
- "utf-8",
-]
 
 [[package]]
 name = "tungstenite"
@@ -7374,6 +7390,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7400,12 +7425,6 @@ dependencies = [
  "libredox",
  "wasite",
 ]
-
-[[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -7499,6 +7518,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -7535,6 +7563,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
@@ -7566,6 +7609,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -7578,6 +7627,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -7587,6 +7642,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7608,6 +7669,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -7617,6 +7684,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7632,6 +7705,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -7641,6 +7720,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [workspace.dependencies]
-alloy = { version = "1.6", default-features = false }
+alloy = { version = "2", default-features = false }
 ark-babyjubjub = { package = "taceo-ark-babyjubjub", version = "^0.5.3" }
 ark-bn254 = { version = "0.5" }
 ark-ec = "0.5"
@@ -50,7 +50,7 @@ humantime-serde = "1.1.1"
 itertools = "0.14"
 k256 = "0.13"
 metrics = "0.24"
-nodes-common = { package = "taceo-nodes-common", version = "0.4.3", default-features = false }
+nodes-common = { package = "taceo-nodes-common", version = "0.5", default-features = false }
 nodes-observability = { package = "taceo-nodes-observability", version = "0.1" }
 num-bigint = "0.4"
 parking_lot = "0.12"

--- a/oprf-client/src/ws/native.rs
+++ b/oprf-client/src/ws/native.rs
@@ -52,16 +52,6 @@ impl WebSocketSession {
         }
     }
 
-    /// Tries to close the websocket on a best effort basis without sending a close-frame to the server and initiating tear down.
-    async fn silent_close(&mut self) {
-        if let Err(err) = self.inner.close(None).await {
-            tracing::trace!(
-                "Received an error when trying to best effort close {}: {err:?}",
-                self.service
-            );
-        }
-    }
-
     /// Calls [`Self::best_effort_close`] and returns an [`NodeError::UnexpectedMessage`] with the provided reason.
     async fn protocol_error<T>(&mut self, reason: T) -> NodeError
     where
@@ -131,8 +121,6 @@ impl WebSocketSession {
             },
 
             tungstenite::Message::Close(frame) => {
-                self.silent_close().await;
-
                 if let Some(frame) = frame
                     && frame.code != CloseCode::Normal
                 {

--- a/oprf-key-gen/Cargo.toml
+++ b/oprf-key-gen/Cargo.toml
@@ -38,10 +38,10 @@ itertools = { workspace = true }
 k256 = { workspace = true, features = ["ecdsa", "serde"] }
 metrics = { workspace = true }
 nodes-common = { workspace = true, features = [
-  "alloy",
   "api",
   "postgres",
-  "serde"
+  "serde",
+  "web3"
 ] }
 nodes-observability = { workspace = true }
 oprf-core = { package = "taceo-oprf-core", path = "../oprf-core", version = "0.5" }

--- a/oprf-key-gen/Cargo.toml
+++ b/oprf-key-gen/Cargo.toml
@@ -16,6 +16,7 @@ alloy = { workspace = true, features = [
   "contract",
   "provider-http",
   "provider-ws",
+  "reqwest-rustls-tls",
   "rpc-types-eth",
   "signer-local",
   "sol-types"

--- a/oprf-key-gen/src/config.rs
+++ b/oprf-key-gen/src/config.rs
@@ -9,8 +9,8 @@
 //! - Optional fields with sensible defaults (see below).
 //! - Serde deserialization (with [`humantime_serde`] for durations).
 //!
-//! RPC connectivity (HTTP and WebSocket URLs, chain ID) is configured separately
-//! via `nodes_common::web3::RpcProviderConfig`.
+//! HTTP RPC connectivity is configured via `nodes_common::web3::HttpRpcProviderConfig`.
+//! The WebSocket URL for event subscriptions is a separate top-level field (`ws_rpc_url`).
 //!
 //! # Defaults
 //!
@@ -65,7 +65,7 @@ pub struct OprfKeyGenServiceConfig {
     #[serde(rename = "rpc")]
     pub rpc_provider_config: web3::HttpRpcProviderConfig,
 
-    /// The blockchain RPC config
+    /// The websocket RPC url used for `eth_subscribe`.
     pub ws_rpc_url: Url,
 
     /// Max time we wait for a submitted transaction receipt to reach the required
@@ -156,7 +156,7 @@ pub struct OprfKeyGenServiceConfigMandatoryValues {
     /// Blockchain RPC configuration used for contract interaction.
     pub rpc_provider_config: HttpRpcProviderConfig,
 
-    /// The ws URL for `etg_getLogs`.
+    /// The websocket RPC url used for `eth_subscribe`.
     pub ws_rpc_url: Url,
 }
 

--- a/oprf-key-gen/src/config.rs
+++ b/oprf-key-gen/src/config.rs
@@ -27,10 +27,12 @@ use std::num::NonZeroU16;
 use std::{path::PathBuf, time::Duration};
 
 use alloy::primitives::Address;
+use nodes_common::web3::HttpRpcProviderConfig;
 use nodes_common::{
     Environment,
-    web3::{self, RpcProviderConfig},
+    web3::{self},
 };
+use reqwest::Url;
 use secrecy::SecretString;
 use serde::Deserialize;
 
@@ -61,7 +63,10 @@ pub struct OprfKeyGenServiceConfig {
 
     /// The blockchain RPC config
     #[serde(rename = "rpc")]
-    pub rpc_provider_config: web3::RpcProviderConfig,
+    pub rpc_provider_config: web3::HttpRpcProviderConfig,
+
+    /// The blockchain RPC config
+    pub ws_rpc_url: Url,
 
     /// Max time we wait for a submitted transaction receipt to reach the required
     /// number of confirmations before treating it as failed.
@@ -149,7 +154,10 @@ pub struct OprfKeyGenServiceConfigMandatoryValues {
     pub expected_num_peers: NonZeroU16,
 
     /// Blockchain RPC configuration used for contract interaction.
-    pub rpc_provider_config: RpcProviderConfig,
+    pub rpc_provider_config: HttpRpcProviderConfig,
+
+    /// The ws URL for `etg_getLogs`.
+    pub ws_rpc_url: Url,
 }
 
 impl OprfKeyGenServiceConfig {
@@ -195,11 +203,13 @@ impl OprfKeyGenServiceConfig {
             expected_threshold,
             expected_num_peers,
             rpc_provider_config,
+            ws_rpc_url,
         } = args;
         Self {
             environment,
             oprf_key_registry_contract,
             wallet_private_key,
+            ws_rpc_url,
             zkey_path,
             witness_graph_path,
             expected_num_peers,

--- a/oprf-key-gen/src/lib.rs
+++ b/oprf-key-gen/src/lib.rs
@@ -179,20 +179,20 @@ pub async fn start(
     tracing::info!("my wallet address: {address}");
     let wallet = EthereumWallet::from(private_key);
 
-    let http_provider =
+    let http_rpc_provider =
         nodes_common::web3::HttpRpcProviderBuilder::with_config(&config.rpc_provider_config)
             .environment(config.environment)
             .wallet(wallet)
             .build()
             .context("while init blockchain connection")?;
 
-    // Build WebSocket provider
-    let ws_provider = ProviderBuilder::new()
+    let ws_rpc_provider = ProviderBuilder::new()
         .connect_ws(WsConnect::new(config.ws_rpc_url.clone()))
-        .await?
+        .await
+        .context("while connecting ws provider")?
         .erased();
 
-    let balance = http_provider
+    let balance = http_rpc_provider
         .get_balance(address)
         .await
         .context("while get_balance")?;
@@ -204,7 +204,7 @@ pub async fn start(
     ::metrics::gauge!(METRICS_ID_KEY_GEN_WALLET_BALANCE, METRICS_ATTRID_WALLET_ADDRESS => address.to_string())
         .set(f64::from(balance) / ETH_TO_WEI as f64);
 
-    contract_sanity_checks(&http_provider, address, &config)
+    contract_sanity_checks(&http_rpc_provider, address, &config)
         .await
         .context("while doing sanity checks")?;
 
@@ -225,7 +225,7 @@ pub async fn start(
         sleep_between_get_receipt: config.sleep_between_get_receipt,
         max_tries_fetching_receipt: config.max_tries_fetching_receipt,
         max_gas_per_transaction: config.max_gas_per_transaction,
-        rpc_provider: http_provider.clone(),
+        rpc_provider: http_rpc_provider.clone(),
         wallet_address: address,
     });
 
@@ -235,8 +235,8 @@ pub async fn start(
         let cancellation_token = cancellation_token.clone();
         services::key_event_watcher::key_event_watcher_task(
             services::key_event_watcher::KeyEventWatcherTaskConfig {
-                http_provider,
-                ws_provider,
+                http_rpc_provider,
+                ws_rpc_provider,
                 contract_address,
                 dlog_secret_gen_service,
                 start_block: config.start_block,

--- a/oprf-key-gen/src/lib.rs
+++ b/oprf-key-gen/src/lib.rs
@@ -39,12 +39,15 @@ use crate::{
     },
 };
 use alloy::{
-    consensus::constants::ETH_TO_WEI, network::EthereumWallet, primitives::Address,
-    providers::Provider as _, signers::local::PrivateKeySigner,
+    consensus::constants::ETH_TO_WEI,
+    network::EthereumWallet,
+    primitives::Address,
+    providers::{Provider as _, ProviderBuilder, WsConnect},
+    signers::local::PrivateKeySigner,
 };
 use eyre::Context as _;
 use groth16_material::circom::CircomGroth16MaterialBuilder;
-use nodes_common::web3::RpcProvider;
+use nodes_common::web3::{self};
 use oprf_types::{chain::OprfKeyRegistry, crypto::PartyId};
 
 pub(crate) mod api;
@@ -78,7 +81,7 @@ impl KeyGenTasks {
 }
 
 async fn contract_sanity_checks(
-    rpc_provider: &RpcProvider,
+    rpc_provider: &web3::HttpRpcProvider,
     key_gen_wallet_address: Address,
     config: &OprfKeyGenServiceConfig,
 ) -> eyre::Result<()> {
@@ -87,7 +90,7 @@ async fn contract_sanity_checks(
         config.expected_threshold,
         config.expected_num_peers
     );
-    let contract = OprfKeyRegistry::new(config.oprf_key_registry_contract, rpc_provider.http());
+    let contract = OprfKeyRegistry::new(config.oprf_key_registry_contract, rpc_provider.inner());
     // Fetch the party ID and log it.
     // This call verifies whether we are registered at the contract as participant and serves as early failing point if not
     let get_party_id_call = contract.getPartyIdForParticipant(key_gen_wallet_address);
@@ -176,16 +179,20 @@ pub async fn start(
     tracing::info!("my wallet address: {address}");
     let wallet = EthereumWallet::from(private_key);
 
-    let rpc_provider =
-        nodes_common::web3::RpcProviderBuilder::with_config(&config.rpc_provider_config)
+    let http_provider =
+        nodes_common::web3::HttpRpcProviderBuilder::with_config(&config.rpc_provider_config)
             .environment(config.environment)
             .wallet(wallet)
             .build()
-            .await
             .context("while init blockchain connection")?;
 
-    let balance = rpc_provider
-        .http()
+    // Build WebSocket provider
+    let ws_provider = ProviderBuilder::new()
+        .connect_ws(WsConnect::new(config.ws_rpc_url.clone()))
+        .await?
+        .erased();
+
+    let balance = http_provider
         .get_balance(address)
         .await
         .context("while get_balance")?;
@@ -197,7 +204,7 @@ pub async fn start(
     ::metrics::gauge!(METRICS_ID_KEY_GEN_WALLET_BALANCE, METRICS_ATTRID_WALLET_ADDRESS => address.to_string())
         .set(f64::from(balance) / ETH_TO_WEI as f64);
 
-    contract_sanity_checks(&rpc_provider, address, &config)
+    contract_sanity_checks(&http_provider, address, &config)
         .await
         .context("while doing sanity checks")?;
 
@@ -218,7 +225,7 @@ pub async fn start(
         sleep_between_get_receipt: config.sleep_between_get_receipt,
         max_tries_fetching_receipt: config.max_tries_fetching_receipt,
         max_gas_per_transaction: config.max_gas_per_transaction,
-        rpc_provider: rpc_provider.clone(),
+        rpc_provider: http_provider.clone(),
         wallet_address: address,
     });
 
@@ -227,13 +234,16 @@ pub async fn start(
         let contract_address = config.oprf_key_registry_contract;
         let cancellation_token = cancellation_token.clone();
         services::key_event_watcher::key_event_watcher_task(
-            rpc_provider,
-            contract_address,
-            dlog_secret_gen_service,
-            config.start_block,
-            started_services.new_service(),
-            transaction_handler,
-            cancellation_token,
+            services::key_event_watcher::KeyEventWatcherTaskConfig {
+                http_provider,
+                ws_provider,
+                contract_address,
+                dlog_secret_gen_service,
+                start_block: config.start_block,
+                start_signal: started_services.new_service(),
+                transaction_handler,
+                cancellation_token,
+            },
         )
     });
 

--- a/oprf-key-gen/src/services/key_event_watcher.rs
+++ b/oprf-key-gen/src/services/key_event_watcher.rs
@@ -75,46 +75,43 @@ impl From<alloy::contract::Error> for TransactionError {
     }
 }
 
+pub(crate) struct KeyEventWatcherTaskConfig {
+    pub(crate) http_provider: web3::HttpRpcProvider,
+    pub(crate) ws_provider: DynProvider,
+    pub(crate) contract_address: Address,
+    pub(crate) dlog_secret_gen_service: DLogSecretGenService,
+    pub(crate) start_block: Option<u64>,
+    pub(crate) start_signal: Arc<AtomicBool>,
+    pub(crate) transaction_handler: TransactionHandler,
+    pub(crate) cancellation_token: CancellationToken,
+}
+
 /// Background task that subscribes to key generation events and handles them.
 ///
 /// Connects to the blockchain via WebSocket and verifies that the
 /// `OprfKeyRegistry` contract is ready.
-pub(crate) async fn key_event_watcher_task(
-    rpc_provider: web3::RpcProvider,
-    contract_address: Address,
-    dlog_secret_gen_service: DLogSecretGenService,
-    start_block: Option<u64>,
-    start_signal: Arc<AtomicBool>,
-    transaction_handler: TransactionHandler,
-    cancellation_token: CancellationToken,
-) -> eyre::Result<()> {
+pub(crate) async fn key_event_watcher_task(args: KeyEventWatcherTaskConfig) -> eyre::Result<()> {
     // shutdown service if event watcher encounters an error and drops this guard
-    let _drop_guard = cancellation_token.clone().drop_guard();
+    let _drop_guard = args.cancellation_token.clone().drop_guard();
     tracing::info!("start handling events");
-    handle_events(
-        rpc_provider,
+    handle_events(args)
+        .await
+        .inspect(|()| tracing::info!("successfully closed key_event_watcher without error"))
+}
+
+/// Filters for various key generation event signatures and handles them
+async fn handle_events(args: KeyEventWatcherTaskConfig) -> eyre::Result<()> {
+    let KeyEventWatcherTaskConfig {
+        http_provider,
+        ws_provider,
         contract_address,
         dlog_secret_gen_service,
         start_block,
         start_signal,
         transaction_handler,
         cancellation_token,
-    )
-    .await
-    .inspect(|()| tracing::info!("successfully closed key_event_watcher without error"))
-}
-
-/// Filters for various key generation event signatures and handles them
-async fn handle_events(
-    rpc_provider: web3::RpcProvider,
-    contract_address: Address,
-    dlog_secret_gen_service: DLogSecretGenService,
-    start_block: Option<u64>,
-    start_signal: Arc<AtomicBool>,
-    transaction_handler: TransactionHandler,
-    cancellation_token: CancellationToken,
-) -> eyre::Result<()> {
-    let contract = OprfKeyRegistry::new(contract_address, rpc_provider.http());
+    } = args;
+    let contract = OprfKeyRegistry::new(contract_address, http_provider.inner());
     let event_signatures = vec![
         OprfKeyRegistry::SecretGenRound1::SIGNATURE_HASH,
         OprfKeyRegistry::SecretGenRound2::SIGNATURE_HASH,
@@ -131,7 +128,7 @@ async fn handle_events(
         .from_block(BlockNumberOrTag::Latest)
         .event_signature(event_signatures.clone());
     // subscribe now so we don't miss any events between now and when we start processing past events
-    let sub = rpc_provider.subscriptions().subscribe_logs(&filter).await?;
+    let sub = ws_provider.subscribe_logs(&filter).await?;
     let mut latest_block = 0;
 
     // if start_block is set, load past events from there to head
@@ -142,8 +139,7 @@ async fn handle_events(
             .from_block(BlockNumberOrTag::Number(start_block))
             .to_block(BlockNumberOrTag::Latest)
             .event_signature(event_signatures);
-        let logs = rpc_provider
-            .http()
+        let logs = http_provider
             .get_logs(&filter)
             .await
             .context("while loading past logs")?;

--- a/oprf-key-gen/src/services/key_event_watcher.rs
+++ b/oprf-key-gen/src/services/key_event_watcher.rs
@@ -76,8 +76,8 @@ impl From<alloy::contract::Error> for TransactionError {
 }
 
 pub(crate) struct KeyEventWatcherTaskConfig {
-    pub(crate) http_provider: web3::HttpRpcProvider,
-    pub(crate) ws_provider: DynProvider,
+    pub(crate) http_rpc_provider: web3::HttpRpcProvider,
+    pub(crate) ws_rpc_provider: DynProvider,
     pub(crate) contract_address: Address,
     pub(crate) dlog_secret_gen_service: DLogSecretGenService,
     pub(crate) start_block: Option<u64>,
@@ -102,8 +102,8 @@ pub(crate) async fn key_event_watcher_task(args: KeyEventWatcherTaskConfig) -> e
 /// Filters for various key generation event signatures and handles them
 async fn handle_events(args: KeyEventWatcherTaskConfig) -> eyre::Result<()> {
     let KeyEventWatcherTaskConfig {
-        http_provider,
-        ws_provider,
+        http_rpc_provider,
+        ws_rpc_provider,
         contract_address,
         dlog_secret_gen_service,
         start_block,
@@ -111,7 +111,7 @@ async fn handle_events(args: KeyEventWatcherTaskConfig) -> eyre::Result<()> {
         transaction_handler,
         cancellation_token,
     } = args;
-    let contract = OprfKeyRegistry::new(contract_address, http_provider.inner());
+    let contract = OprfKeyRegistry::new(contract_address, http_rpc_provider.inner());
     let event_signatures = vec![
         OprfKeyRegistry::SecretGenRound1::SIGNATURE_HASH,
         OprfKeyRegistry::SecretGenRound2::SIGNATURE_HASH,
@@ -128,7 +128,7 @@ async fn handle_events(args: KeyEventWatcherTaskConfig) -> eyre::Result<()> {
         .from_block(BlockNumberOrTag::Latest)
         .event_signature(event_signatures.clone());
     // subscribe now so we don't miss any events between now and when we start processing past events
-    let sub = ws_provider.subscribe_logs(&filter).await?;
+    let sub = ws_rpc_provider.subscribe_logs(&filter).await?;
     let mut latest_block = 0;
 
     // if start_block is set, load past events from there to head
@@ -139,7 +139,7 @@ async fn handle_events(args: KeyEventWatcherTaskConfig) -> eyre::Result<()> {
             .from_block(BlockNumberOrTag::Number(start_block))
             .to_block(BlockNumberOrTag::Latest)
             .event_signature(event_signatures);
-        let logs = http_provider
+        let logs = http_rpc_provider
             .get_logs(&filter)
             .await
             .context("while loading past logs")?;

--- a/oprf-key-gen/src/services/key_event_watcher/tests.rs
+++ b/oprf-key-gen/src/services/key_event_watcher/tests.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use alloy::{network::EthereumWallet, primitives::U160, signers::local::PrivateKeySigner};
 use groth16_material::circom::{CircomGroth16Material, CircomGroth16MaterialBuilder};
-use nodes_common::{Environment, web3::RpcProviderBuilder};
+use nodes_common::{Environment, web3::HttpRpcProviderBuilder};
 use oprf_core::ddlog_equality::shamir::DLogShareShamir;
 use oprf_test_utils::{DeploySetup, OPRF_PEER_PRIVATE_KEY_0, PEER_ADDRESSES, TestSetup};
 use oprf_types::{
@@ -44,19 +44,16 @@ fn random_public_key() -> OprfPublicKey {
     OprfPublicKey::new(rand::random())
 }
 
-async fn test_config(setup: &TestSetup) -> (CircomGroth16Material, TransactionHandler) {
-    let rpc_provider = RpcProviderBuilder::with_default_values(
-        vec![setup.anvil.endpoint_url()],
-        setup.anvil.ws_endpoint_url(),
-    )
-    .environment(Environment::Dev)
-    .chain_id(31_337)
-    .wallet(EthereumWallet::new(
-        PrivateKeySigner::from_str(OPRF_PEER_PRIVATE_KEY_0).expect("works"),
-    ))
-    .build()
-    .await
-    .expect("can build RPC providers");
+fn test_config(setup: &TestSetup) -> (CircomGroth16Material, TransactionHandler) {
+    let rpc_provider =
+        HttpRpcProviderBuilder::with_default_values(vec![setup.anvil.endpoint_url()])
+            .environment(Environment::Dev)
+            .chain_id(31_337)
+            .wallet(EthereumWallet::new(
+                PrivateKeySigner::from_str(OPRF_PEER_PRIVATE_KEY_0).expect("works"),
+            ))
+            .build()
+            .expect("can build RPC providers");
 
     let transaction_handler = TransactionHandler::new(TransactionHandlerArgs {
         max_wait_time_watch_transaction: Duration::from_secs(10),
@@ -74,7 +71,7 @@ async fn test_config(setup: &TestSetup) -> (CircomGroth16Material, TransactionHa
 #[tokio::test]
 async fn test_send_invalid_proof() -> eyre::Result<()> {
     let setup = TestSetup::new(DeploySetup::TwoThree).await?;
-    let (key_gen_material, transaction_handler) = test_config(&setup).await;
+    let (key_gen_material, transaction_handler) = test_config(&setup);
     let secret_manager = test_secret_manager();
     let secret_manager_service: SecretManagerService = secret_manager.service();
     let secret_gen = DLogSecretGenService::init(key_gen_material, secret_manager_service);
@@ -168,7 +165,7 @@ async fn test_delete() -> eyre::Result<()> {
 #[tokio::test]
 async fn test_round2_in_wrong_round_during_load_public_keys() -> eyre::Result<()> {
     let setup = TestSetup::new(DeploySetup::TwoThree).await?;
-    let (key_gen_material, transaction_handler) = test_config(&setup).await;
+    let (key_gen_material, transaction_handler) = test_config(&setup);
     let secret_manager = test_secret_manager();
     let secret_manager_service: SecretManagerService = secret_manager.service();
     let secret_gen = DLogSecretGenService::init(key_gen_material, secret_manager_service);

--- a/oprf-key-gen/src/services/transaction_handler.rs
+++ b/oprf-key-gen/src/services/transaction_handler.rs
@@ -31,7 +31,7 @@ pub(crate) struct TransactionHandler {
     sleep_between_get_receipt: Duration,
     max_tries_fetching_receipt: usize,
     max_gas_per_transaction: u64,
-    rpc_provider: web3::RpcProvider,
+    rpc_provider: web3::HttpRpcProvider,
     wallet_address: Address,
 }
 
@@ -41,7 +41,7 @@ pub(crate) struct TransactionHandlerArgs {
     pub(crate) sleep_between_get_receipt: Duration,
     pub(crate) max_tries_fetching_receipt: usize,
     pub(crate) max_gas_per_transaction: u64,
-    pub(crate) rpc_provider: web3::RpcProvider,
+    pub(crate) rpc_provider: web3::HttpRpcProvider,
     pub(crate) wallet_address: Address,
 }
 
@@ -123,12 +123,7 @@ impl TransactionHandler {
 
         tracing::trace!("transaction with hash: {tx_hash} confirmed");
 
-        if let Ok(balance) = self
-            .rpc_provider
-            .http()
-            .get_balance(self.wallet_address)
-            .await
-        {
+        if let Ok(balance) = self.rpc_provider.get_balance(self.wallet_address).await {
             let balance_eth = alloy::primitives::utils::format_ether(balance);
             tracing::trace!("current wallet balance: {balance_eth} ETH",);
             ::metrics::gauge!(METRICS_ID_KEY_GEN_WALLET_BALANCE, METRICS_ATTRID_WALLET_ADDRESS => self.wallet_address.to_string())
@@ -141,7 +136,6 @@ impl TransactionHandler {
             Err(PendingTransactionError::TransportError(TransportError::NullResp)) => {
                 let receipt = (|| async {
                     self.rpc_provider
-                        .http()
                         .get_transaction_receipt(tx_hash)
                         .await?
                         .ok_or(TransportError::NullResp)

--- a/oprf-key-gen/src/tests/mod.rs
+++ b/oprf-key-gen/src/tests/mod.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use alloy::{primitives::U160, sol_types::SolEvent};
 use axum_test::TestServer;
-use nodes_common::web3::RpcProviderConfig;
+use nodes_common::web3::HttpRpcProviderConfig;
 use nodes_common::{Environment, StartedServices};
 use oprf_test_utils::{DeploySetup, PEER_PRIVATE_KEYS, TestSetup};
 
@@ -68,10 +68,10 @@ impl TestKeyGen {
                 witness_graph_path: setup.witness_path(),
                 expected_threshold: expected_threshold.try_into().expect("Is non-zero"),
                 expected_num_peers: expected_num_peers.try_into().expect("Is non-zero"),
-                rpc_provider_config: RpcProviderConfig::with_default_values(
-                    vec![anvil.endpoint_url()],
-                    anvil.ws_endpoint_url(),
-                ),
+                rpc_provider_config: HttpRpcProviderConfig::with_default_values(vec![
+                    anvil.endpoint_url(),
+                ]),
+                ws_rpc_url: anvil.ws_endpoint_url(),
             });
 
         // anvil doesn't work with confirmations

--- a/oprf-service/Cargo.toml
+++ b/oprf-service/Cargo.toml
@@ -16,6 +16,7 @@ alloy = { workspace = true, features = [
   "contract",
   "provider-http",
   "provider-ws",
+  "reqwest-rustls-tls",
   "rpc-types-eth",
   "sol-types"
 ] }

--- a/oprf-service/Cargo.toml
+++ b/oprf-service/Cargo.toml
@@ -33,10 +33,10 @@ humantime.workspace = true
 humantime-serde = { workspace = true }
 metrics = { workspace = true }
 nodes-common = { workspace = true, features = [
-  "alloy",
   "api",
   "postgres",
-  "serde"
+  "serde",
+  "web3"
 ] }
 oprf-core = { package = "taceo-oprf-core", path = "../oprf-core", version = "0.5" }
 oprf-types = { package = "taceo-oprf-types", path = "../oprf-types", version = "0.12" }

--- a/oprf-service/examples/taceo-oprf-service-example.rs
+++ b/oprf-service/examples/taceo-oprf-service-example.rs
@@ -38,7 +38,7 @@ pub struct ExampleOprfNodeConfig {
 
     /// The blockchain RPC config
     #[serde(rename = "rpc")]
-    pub rpc_provider_config: web3::RpcProviderConfig,
+    pub rpc_provider_config: web3::HttpRpcProviderConfig,
 
     /// The OPRF service config
     #[serde(rename = "service")]
@@ -92,10 +92,9 @@ async fn main() -> eyre::Result<ExitCode> {
 
     tracing::info!("connect to chain RPC...");
     let rpc_provider =
-        nodes_common::web3::RpcProviderBuilder::with_config(&config.rpc_provider_config)
+        nodes_common::web3::HttpRpcProviderBuilder::with_config(&config.rpc_provider_config)
             .environment(config.node_config.environment)
             .build()
-            .await
             .context("while init blockchain connection")?;
     let result = start_service(
         config,
@@ -119,7 +118,7 @@ async fn main() -> eyre::Result<ExitCode> {
 
 pub async fn start_service(
     config: ExampleOprfNodeConfig,
-    rpc_provider: web3::RpcProvider,
+    rpc_provider: web3::HttpRpcProvider,
     secret_manager: SecretManagerService,
     shutdown_signal: impl std::future::Future<Output = ()> + Send + 'static,
 ) -> eyre::Result<()> {

--- a/oprf-service/src/config.rs
+++ b/oprf-service/src/config.rs
@@ -5,7 +5,7 @@
 //!
 //! The struct supports:
 //! - Required fields: `environment`, `oprf_key_registry_contract`,
-//!   `chain_ws_rpc_url`, and `version_req`.
+//!   `ws_rpc_url`, and `version_req`.
 //! - Optional fields with sensible defaults (see below).
 //! - Serde deserialization (with [`humantime_serde`] for durations).
 //!

--- a/oprf-service/src/config.rs
+++ b/oprf-service/src/config.rs
@@ -21,7 +21,7 @@
 
 use std::time::Duration;
 
-use alloy::primitives::Address;
+use alloy::{primitives::Address, transports::http::reqwest::Url};
 use nodes_common::Environment;
 use semver::VersionReq;
 use serde::{
@@ -37,6 +37,9 @@ pub struct OprfNodeServiceConfig {
     pub environment: Environment,
     /// The Address of the `OprfKeyRegistry` contract.
     pub oprf_key_registry_contract: Address,
+
+    /// The ws URL for `eth_subscribe`.
+    pub ws_rpc_url: Url,
 
     /// Accepted `SemVer` versions of clients.
     #[serde(deserialize_with = "deserialize_version_req")]
@@ -120,12 +123,14 @@ impl OprfNodeServiceConfig {
     pub fn with_default_values(
         environment: Environment,
         oprf_key_registry_contract: Address,
+        ws_rpc_url: Url,
         version_req: VersionReq,
     ) -> Self {
         Self {
             environment,
             oprf_key_registry_contract,
             version_req,
+            ws_rpc_url,
             ws_max_message_size: Self::default_ws_max_message_size(),
             session_lifetime: Self::default_session_lifetime(),
             get_oprf_key_material_timeout: Self::default_get_oprf_key_material_timeout(),

--- a/oprf-service/src/lib.rs
+++ b/oprf-service/src/lib.rs
@@ -55,6 +55,7 @@ use crate::services::key_event_watcher::KeyEventWatcherTaskArgs;
 use crate::services::open_sessions::OpenSessions;
 use crate::services::oprf_key_material_store::OprfKeyMaterialStore;
 use crate::{config::OprfNodeServiceConfig, services::secret_manager::SecretManagerService};
+use alloy::providers::{Provider as _, ProviderBuilder, WsConnect};
 use axum::Router;
 use eyre::Context as _;
 use http::StatusCode;
@@ -116,7 +117,7 @@ impl OprfServiceBuilder {
     pub async fn init(
         config: OprfNodeServiceConfig,
         secret_manager: SecretManagerService,
-        rpc_provider: web3::RpcProvider,
+        http_rpc_provider: web3::HttpRpcProvider,
         started_services: StartedServices,
         cancellation_token: CancellationToken,
     ) -> eyre::Result<Self> {
@@ -128,8 +129,16 @@ impl OprfServiceBuilder {
             .await
             .context("while loading address")?;
 
+        tracing::info!("connecting with ws provider..");
+        // Build WebSocket provider
+        let ws_rpc_provider = ProviderBuilder::new()
+            .connect_ws(WsConnect::new(config.ws_rpc_url.clone()))
+            .await?
+            .erased();
+
         tracing::info!("loading party id with address {address}..");
-        let contract = OprfKeyRegistry::new(config.oprf_key_registry_contract, rpc_provider.http());
+        let contract =
+            OprfKeyRegistry::new(config.oprf_key_registry_contract, http_rpc_provider.inner());
         let party_id = PartyId(
             contract
                 .getPartyIdForParticipant(address)
@@ -158,11 +167,12 @@ impl OprfServiceBuilder {
 
         tracing::info!("spawning key event watcher..");
         let key_event_watcher = tokio::spawn({
-            let rpc_provider = rpc_provider.clone();
+            let http_rpc_provider = http_rpc_provider.clone();
             let contract_address = config.oprf_key_registry_contract;
             let cancellation_token = cancellation_token.clone();
             services::key_event_watcher::key_event_watcher_task(KeyEventWatcherTaskArgs {
-                rpc_provider,
+                http_rpc_provider,
+                ws_rpc_provider,
                 contract_address,
                 secret_manager,
                 oprf_key_material_store: oprf_key_material_store.clone(),

--- a/oprf-service/src/lib.rs
+++ b/oprf-service/src/lib.rs
@@ -130,10 +130,10 @@ impl OprfServiceBuilder {
             .context("while loading address")?;
 
         tracing::info!("connecting with ws provider..");
-        // Build WebSocket provider
         let ws_rpc_provider = ProviderBuilder::new()
             .connect_ws(WsConnect::new(config.ws_rpc_url.clone()))
-            .await?
+            .await
+            .context("while connecting ws provider")?
             .erased();
 
         tracing::info!("loading party id with address {address}..");

--- a/oprf-service/src/services/key_event_watcher.rs
+++ b/oprf-service/src/services/key_event_watcher.rs
@@ -15,7 +15,7 @@ use std::{
 use alloy::{
     eips::BlockNumberOrTag,
     primitives::{Address, LogData},
-    providers::Provider as _,
+    providers::{DynProvider, Provider as _},
     rpc::types::{Filter, Log},
     sol_types::SolEvent as _,
 };
@@ -56,7 +56,8 @@ enum FetchOprfKeyMaterialError {
 
 /// The arguments to start the key-even-watcher.
 pub(crate) struct KeyEventWatcherTaskArgs {
-    pub(crate) rpc_provider: web3::RpcProvider,
+    pub(crate) http_rpc_provider: web3::HttpRpcProvider,
+    pub(crate) ws_rpc_provider: DynProvider,
     pub(crate) contract_address: Address,
     pub(crate) secret_manager: SecretManagerService,
     pub(crate) oprf_key_material_store: OprfKeyMaterialStore,
@@ -89,7 +90,8 @@ pub(crate) async fn key_event_watcher_task(
 /// Filters for various key generation event signatures and handles them
 async fn handle_events(key_event_watcher_task_args: KeyEventWatcherTaskArgs) -> eyre::Result<()> {
     let KeyEventWatcherTaskArgs {
-        rpc_provider,
+        http_rpc_provider,
+        ws_rpc_provider,
         contract_address,
         secret_manager,
         oprf_key_material_store,
@@ -107,7 +109,7 @@ async fn handle_events(key_event_watcher_task_args: KeyEventWatcherTaskArgs) -> 
         .from_block(BlockNumberOrTag::Latest)
         .event_signature(event_signatures.clone());
     // subscribe now so we don't miss any events between now and when we start processing past events
-    let sub = rpc_provider.subscriptions().subscribe_logs(&filter).await?;
+    let sub = ws_rpc_provider.subscribe_logs(&filter).await?;
     let mut latest_block = 0;
 
     // if start_block is set, load past events from there to head
@@ -118,8 +120,7 @@ async fn handle_events(key_event_watcher_task_args: KeyEventWatcherTaskArgs) -> 
             .from_block(BlockNumberOrTag::Number(start_block))
             .to_block(BlockNumberOrTag::Latest)
             .event_signature(event_signatures);
-        let logs = rpc_provider
-            .http()
+        let logs = http_rpc_provider
             .get_logs(&filter)
             .await
             .context("while loading past logs")?;

--- a/oprf-service/src/tests/setup.rs
+++ b/oprf-service/src/tests/setup.rs
@@ -6,7 +6,7 @@ use ark_ff::UniformRand as _;
 use async_trait::async_trait;
 use axum_test::{TestServer, TestWebSocket};
 use http::StatusCode;
-use nodes_common::web3::RpcProviderBuilder;
+use nodes_common::web3::HttpRpcProviderBuilder;
 use nodes_common::{Environment, StartedServices};
 use oprf_core::ddlog_equality::shamir::{DLogCommitmentsShamir, DLogProofShareShamir};
 use oprf_core::oprf::BlindingFactor;
@@ -173,21 +173,18 @@ impl TestNode {
         let mut config = OprfNodeServiceConfig::with_default_values(
             Environment::Dev,
             *oprf_key_registry,
+            anvil.ws_endpoint_url(),
             "1.0.0".parse().expect("Valid VersionReq"),
         );
         config.session_lifetime = Duration::from_secs(10);
 
         let child_token = cancellation_token.child_token();
 
-        let rpc_provider = RpcProviderBuilder::with_default_values(
-            vec![anvil.endpoint_url()],
-            anvil.ws_endpoint_url(),
-        )
-        .environment(Environment::Dev)
-        .chain_id(31_337)
-        .build()
-        .await
-        .expect("can build RPC providers");
+        let rpc_provider = HttpRpcProviderBuilder::with_default_values(vec![anvil.endpoint_url()])
+            .environment(Environment::Dev)
+            .chain_id(31_337)
+            .build()
+            .expect("can build RPC providers");
 
         let started_services = StartedServices::new();
         let (service, key_event_watcher_task) = OprfServiceBuilder::init(

--- a/run-setup.sh
+++ b/run-setup.sh
@@ -90,7 +90,7 @@ start_keygen() {
         local db_conn="postgres://postgres:postgres@localhost:5432/postgres"
 
         RUST_LOG="taceo=trace,warn" \
-        TACEO_OPRF_KEY_GEN__BIND_ADDR=127.0.0.1:$port \
+        TACEO_OPRF_KEY_GEN__BIND_ADDR=0.0.0.0:$port \
         TACEO_OPRF_KEY_GEN__SERVICE__WALLET_PRIVATE_KEY=${node_private_keys[$i]} \
         TACEO_OPRF_KEY_GEN__SERVICE__ENVIRONMENT=dev \
         TACEO_OPRF_KEY_GEN__SERVICE__ZKEY_PATH=./circom/main/key-gen/OPRFKeyGen.13.arks.zkey \
@@ -99,8 +99,8 @@ start_keygen() {
         TACEO_OPRF_KEY_GEN__SERVICE__CONFIRMATIONS_FOR_TRANSACTION=1 \
         TACEO_OPRF_KEY_GEN__SERVICE__EXPECTED_THRESHOLD=2 \
         TACEO_OPRF_KEY_GEN__SERVICE__EXPECTED_NUM_PEERS=3 \
+        TACEO_OPRF_KEY_GEN__SERVICE__WS_RPC_URL=ws://127.0.0.1:8545 \
         TACEO_OPRF_KEY_GEN__SERVICE__RPC__HTTP_URLS=http://127.0.0.1:8545 \
-        TACEO_OPRF_KEY_GEN__SERVICE__RPC__WS_URL=ws://127.0.0.1:8545 \
         TACEO_OPRF_KEY_GEN__SERVICE__RPC__CHAIN_ID=31337 \
         TACEO_OPRF_KEY_GEN__POSTGRES__CONNECTION_STRING=$db_conn \
         TACEO_OPRF_KEY_GEN__POSTGRES__SCHEMA=oprf$i \
@@ -133,11 +133,11 @@ start_nodes() {
         TACEO_OPRF_NODE__POSTGRES__SCHEMA=oprf$i \
         TACEO_OPRF_NODE__SERVICE__ENVIRONMENT=dev \
         TACEO_OPRF_NODE__SERVICE__OPRF_KEY_REGISTRY_CONTRACT=$oprf_key_registry \
+        TACEO_OPRF_NODE__SERVICE__WS_RPC_URL=ws://127.0.0.1:8545 \
         TACEO_OPRF_NODE__RPC__HTTP_URLS=http://127.0.0.1:8545 \
-        TACEO_OPRF_NODE__RPC__WS_URL=ws://127.0.0.1:8545 \
         TACEO_OPRF_NODE__RPC__CHAIN_ID=31337 \
         TACEO_OPRF_NODE__SERVICE__VERSION_REQ=">=0.0.0" \
-        TACEO_OPRF_NODE__BIND_ADDR=127.0.0.1:$port \
+        TACEO_OPRF_NODE__BIND_ADDR=0.0.0.0:$port \
         ./target/release/examples/taceo-oprf-service-example > logs/node$i.log 2>&1 &
         nodes_pids+=($!)
         echo "started node$i with PID ${nodes_pids[$i]}"


### PR DESCRIPTION
… 0.5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to major dependency upgrades (`alloy` 2.x, `taceo-nodes-common` 0.5.x) and refactoring of blockchain RPC/provider wiring (separating HTTP calls from WS subscriptions), which can affect event watching and transaction flows at runtime.
> 
> **Overview**
> Upgrades core Ethereum/web3 dependencies, bumping `alloy` to `2.x` and `taceo-nodes-common` to `0.5.x`, with corresponding lockfile churn (notably new `reqwest 0.13` and TLS/platform verifier deps) and updated feature flags.
> 
> Refactors both **key-gen** and **service** to use the new `nodes_common::web3::HttpRpcProvider*` types for HTTP RPC calls while creating a separate `alloy` WS provider (`ProviderBuilder`/`WsConnect`) for `eth_subscribe` log streaming; configs now include an explicit `ws_rpc_url` field and scripts/tests are updated accordingly.
> 
> Makes a small websocket client behavior change by removing the internal "silent close" path on receiving a close frame, relying on the normal close handling instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94e48cb6e8c634ab290e7f917960cbfed60f5a2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->