### PR TITLE
ci: remove build on main for key-gen

### DIFF
--- a/.github/workflows/build-and-push-oprf-key-gen.yml
+++ b/.github/workflows/build-and-push-oprf-key-gen.yml
@@ -4,8 +4,6 @@ name: Build and Push (oprf-key-gen)
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
     tags:
       - 'oprf-key-gen-v*'
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change that just narrows when the image build workflow runs. Main risk is reduced coverage: `oprf-key-gen` images will no longer be built automatically on `main` commits unless tagged or manually triggered.
> 
> **Overview**
> Updates the `build-and-push-oprf-key-gen` GitHub Actions workflow to **no longer run on `main` branch pushes**, and instead trigger only via `workflow_dispatch` or version tag pushes (`oprf-key-gen-v*`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c817512eb79daeee0a1ee2f2338ab2cabd34a4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->