### PR TITLE
build: remove unneeded feature from dependency

### DIFF
--- a/oprf-types/Cargo.toml
+++ b/oprf-types/Cargo.toml
@@ -21,8 +21,7 @@ async-trait = { workspace = true }
 circom-types = { workspace = true, features = [
   "bn254",
   "groth16",
-  "proof",
-  "zkey"
+  "proof"
 ], optional = true }
 eyre = { workspace = true }
 groth16-sol = { workspace = true, optional = true }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk dependency configuration change that only removes the `zkey` feature flag from `circom-types`; potential impact is limited to builds that implicitly relied on that feature being enabled.
> 
> **Overview**
> Removes the `zkey` feature from the `circom-types` dependency in `oprf-types/Cargo.toml`, leaving only `bn254`, `groth16`, and `proof` enabled for the optional `chain` feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31867cd0b8d8b112f123374d6cf235c737230d71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->