### PR TITLE
chore: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3
   - package-ecosystem: cargo
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
Adds `.github/dependabot.yml` with weekly updates for each Dependabot ecosystem mapped from the detected languages on the default branch.

Detected languages: Just,PLpgSQL,Rust,Shell

- Weekly updates for `github-actions`
- Weekly updates for `cargo`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to Dependabot behavior; no runtime code or security logic is affected.
> 
> **Overview**
> Adds Dependabot `cooldown` settings to the existing `.github/dependabot.yml` so both `github-actions` and `cargo` update checks keep the weekly schedule but wait **3 days** after an update before opening another PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abf4e6edb5936aa351ca97f2bea19d98d12de83b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->