### PR TITLE
themis/backfill logs keygen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6149,12 +6149,11 @@ dependencies = [
 [[package]]
 name = "taceo-nodes-common"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0ab40a81dbbcb8431822ce5a5d6339a0d9db1d78366989c8d188ed62da2d84"
 dependencies = [
  "alloy",
  "axum",
  "backon",
+ "futures",
  "git-version",
  "humantime-serde",
  "secrecy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6386,6 +6386,7 @@ dependencies = [
  "taceo-ark-babyjubjub",
  "taceo-groth16-material",
  "taceo-groth16-sol",
+ "taceo-nodes-common",
  "taceo-nodes-observability",
  "taceo-oprf-core",
  "taceo-oprf-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -1776,15 +1775,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cadence"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3075f133bee430b7644c54fb629b9b4420346ffa275a45c81a6babe8b09b4f51"
-dependencies = [
- "crossbeam-channel",
-]
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,15 +2138,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2426,27 +2407,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2564,12 +2524,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
 name = "enum-ordinalize"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2613,7 +2567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3333,7 +3287,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -3897,110 +3850,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics-exporter-dogstatsd"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961f3712d8a7cfe14caaf74c3af503fe701cee6439ff49a7a3ebd04bf49c0502"
-dependencies = [
- "bytes",
- "itoa",
- "metrics",
- "metrics-util 0.20.1",
- "ryu",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "metrics-exporter-prometheus"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
-dependencies = [
- "base64 0.22.1",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "indexmap 2.12.1",
- "ipnet",
- "metrics",
- "metrics-util 0.19.1",
- "quanta",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "metrics-exporter-prometheus"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b166dea96003ee2531cf14833efedced545751d800f03535801d833313f8c15"
-dependencies = [
- "base64 0.22.1",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "indexmap 2.12.1",
- "ipnet",
- "metrics",
- "metrics-util 0.20.1",
- "quanta",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "metrics-exporter-statsd"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57971e32cdee88619fb6c673fd89cfd37c12f2dd7c187fb400b7aae0ede0ed9e"
-dependencies = [
- "cadence",
- "metrics",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "metrics-util"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
- "hashbrown 0.15.5",
- "metrics",
- "quanta",
- "rand 0.9.4",
- "rand_xoshiro",
- "sketches-ddsketch",
-]
-
-[[package]]
-name = "metrics-util"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
-dependencies = [
- "aho-corasick",
- "crossbeam-epoch",
- "crossbeam-utils",
- "hashbrown 0.16.1",
- "indexmap 2.12.1",
- "metrics",
- "ordered-float",
- "quanta",
- "radix_trie",
- "rand 0.9.4",
- "rand_xoshiro",
- "sketches-ddsketch",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4015,24 +3864,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4199,98 +4030,6 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "opentelemetry"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570074cc999d1a58184080966e5bd3bf3a9a4af650c3b05047c2621e7405cd17"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "opentelemetry-datadog"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2332447b423a5db29681a8690fc65d9029d7741b03af1eb89964e4757295471a"
-dependencies = [
- "ahash",
- "futures-core",
- "http",
- "indexmap 2.12.1",
- "itoa",
- "once_cell",
- "opentelemetry",
- "opentelemetry-http",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk",
- "reqwest 0.12.28",
- "rmp",
- "ryu",
- "thiserror 1.0.69",
- "url",
-]
-
-[[package]]
-name = "opentelemetry-http"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6351496aeaa49d7c267fb480678d85d1cd30c5edb20b497c48c56f62a8c14b99"
-dependencies = [
- "async-trait",
- "bytes",
- "http",
- "opentelemetry",
- "reqwest 0.12.28",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db945c1eaea8ac6a9677185357480d215bb6999faa9f691d0c4d4d641eab7a09"
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c627d9f4c9cdc1f21a29ee4bfbd6028fcb8bcf2a857b43f3abdf72c9c862f3"
-dependencies = [
- "async-trait",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "glob",
- "once_cell",
- "opentelemetry",
- "percent-encoding",
- "rand 0.8.6",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "ordered-float"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "page_size"
@@ -4684,21 +4423,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quanta"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "once_cell",
- "raw-cpuid",
- "wasi",
- "web-sys",
- "winapi",
-]
-
-[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4782,16 +4506,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
-
-[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4863,24 +4577,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
-dependencies = [
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "11.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4907,17 +4603,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.16",
- "libredox",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4977,9 +4662,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -5087,17 +4770,6 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
-]
-
-[[package]]
-name = "rmp"
-version = "0.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
-dependencies = [
- "byteorder",
- "num-traits",
- "paste",
 ]
 
 [[package]]
@@ -5209,7 +4881,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5268,7 +4940,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5670,12 +5342,6 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "sketches-ddsketch"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 
 [[package]]
 name = "slab"
@@ -6148,7 +5814,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-nodes-common"
-version = "0.5.1"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158a4265e0eb2f65ef786ddccf870bb63829bc1e00b6d4e4a97666bdc68209ee"
 dependencies = [
  "alloy",
  "axum",
@@ -6169,18 +5837,12 @@ dependencies = [
 
 [[package]]
 name = "taceo-nodes-observability"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77bc648f21f0d20603e6e3fbe99aa11046db6117e4da986a912b4ec226441476"
+checksum = "f7a5d1aebf2040316548b47bd3d7e2855a975702637fd9019f3148b1ee5b40de"
 dependencies = [
  "eyre",
- "humantime",
  "metrics",
- "metrics-exporter-dogstatsd",
- "metrics-exporter-prometheus 0.17.2",
- "metrics-exporter-statsd",
- "secrecy",
- "telemetry-batteries",
  "tracing",
  "tracing-subscriber 0.3.22",
 ]
@@ -6436,35 +6098,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "telemetry-batteries"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567e8ea5b9968949fc71963b787bc50dd26a220277686984c75919e99c46ecf1"
-dependencies = [
- "chrono",
- "dirs",
- "http",
- "metrics",
- "metrics-exporter-prometheus 0.16.2",
- "metrics-exporter-statsd",
- "opentelemetry",
- "opentelemetry-datadog",
- "opentelemetry-http",
- "opentelemetry_sdk",
- "rand 0.8.6",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "tracing-appender",
- "tracing-opentelemetry",
- "tracing-serde 0.1.3",
- "tracing-subscriber 0.3.22",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6474,7 +6107,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6871,18 +6504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-appender"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
-dependencies = [
- "crossbeam-channel",
- "thiserror 2.0.18",
- "time",
- "tracing-subscriber 0.3.22",
-]
-
-[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6904,55 +6525,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc58af5d3f6c5811462cabb3289aec0093f7338e367e5a33d28c0433b3c7360b"
-dependencies = [
- "js-sys",
- "once_cell",
- "opentelemetry",
- "opentelemetry_sdk",
- "smallvec",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber 0.3.22",
- "web-time",
-]
-
-[[package]]
-name = "tracing-serde"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6968,18 +6540,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
- "nu-ansi-term",
  "once_cell",
  "regex-automata",
- "serde",
- "serde_json",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
- "tracing-serde 0.2.0",
 ]
 
 [[package]]
@@ -7449,7 +7015,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ humantime-serde = "1.1.1"
 itertools = "0.14"
 k256 = "0.13"
 metrics = "0.24"
-nodes-common = { package = "taceo-nodes-common", version = "0.5", default-features = false }
+nodes-common = { package = "taceo-nodes-common", path = "../nodes-helpers/nodes-common", version = "0.5", default-features = false }
 nodes-observability = { package = "taceo-nodes-observability", version = "0.1" }
 num-bigint = "0.4"
 parking_lot = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ humantime-serde = "1.1.1"
 itertools = "0.14"
 k256 = "0.13"
 metrics = "0.24"
-nodes-common = { package = "taceo-nodes-common", path = "../nodes-helpers/nodes-common", version = "0.5", default-features = false }
-nodes-observability = { package = "taceo-nodes-observability", version = "0.1" }
+nodes-common = { package = "taceo-nodes-common", version = "0.5.2", default-features = false }
+nodes-observability = { package = "taceo-nodes-observability", version = "0.1.2", default-features = false }
 num-bigint = "0.4"
 parking_lot = "0.12"
 poseidon2 = { package = "taceo-poseidon2", version = "0.2", default-features = false }

--- a/oprf-key-gen/Cargo.toml
+++ b/oprf-key-gen/Cargo.toml
@@ -74,6 +74,7 @@ tracing.workspace = true
 zeroize = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
+alloy = { workspace = true, features = ["node-bindings"] }
 axum-test = { workspace = true, features = ["ws"] }
 oprf-test-utils = { package = "taceo-oprf-test-utils", path = "../oprf-test-utils", version = "0.11" }
 parking_lot = { workspace = true }

--- a/oprf-key-gen/migrations/20260428072903_chain_event_cursor.down.sql
+++ b/oprf-key-gen/migrations/20260428072903_chain_event_cursor.down.sql
@@ -1,0 +1,2 @@
+-- Add down migration script here
+DROP TABLE IF EXISTS chain_cursor;

--- a/oprf-key-gen/migrations/20260428072903_chain_event_cursor.up.sql
+++ b/oprf-key-gen/migrations/20260428072903_chain_event_cursor.up.sql
@@ -1,0 +1,9 @@
+-- Add up migration script here
+CREATE TABLE chain_cursor (
+    id BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (id = TRUE),
+    block BIGINT NOT NULL,
+    idx BIGINT NOT NULL
+);
+
+INSERT INTO chain_cursor (block, idx)
+VALUES (0, 0);

--- a/oprf-key-gen/src/config.rs
+++ b/oprf-key-gen/src/config.rs
@@ -14,6 +14,8 @@
 //!
 //! # Defaults
 //!
+//! For the backfill defaults, we refer to `nodes_common::web3::event_stream`.
+//!
 //! | Field                                    | Default     |
 //! |------------------------------------------|-------------|
 //! | `max_wait_time_transaction_confirmation` | 300 s       |
@@ -28,6 +30,7 @@ use std::{path::PathBuf, time::Duration};
 
 use alloy::primitives::Address;
 use nodes_common::web3::HttpRpcProviderConfig;
+use nodes_common::web3::event_stream::EventStreamConfig;
 use nodes_common::{
     Environment,
     web3::{self},
@@ -76,9 +79,12 @@ pub struct OprfKeyGenServiceConfig {
     #[serde(with = "humantime_serde")]
     pub max_wait_time_transaction_confirmation: Duration,
 
-    /// The block number to start listening for events from the `OprfKeyRegistry` contract.
-    /// If not set, will start from the latest block.
-    pub start_block: Option<u64>,
+    /// Additional config for backfill.
+    ///
+    /// See `nodes-common` for the optional values that might be configured.
+    #[serde(default)]
+    #[serde(rename = "backfill")]
+    pub event_stream_config: EventStreamConfig,
 
     /// Maximum amount of gas a single transaction is allowed to consume.
     /// This acts as a safety limit to prevent transactions from exceeding expected execution costs. The default value is set to approximately 2× the average gas used by a round-2 transaction, which is currently the most gas-intensive round.
@@ -217,12 +223,12 @@ impl OprfKeyGenServiceConfig {
             rpc_provider_config,
             max_wait_time_transaction_confirmation:
                 Self::default_max_wait_time_transaction_confirmation(),
-            start_block: None,
             max_gas_per_transaction: Self::default_max_gas_per_transaction(),
             confirmations_for_transaction: Self::default_confirmations_for_transaction(),
             i_am_alive_interval: Self::default_i_am_alive_interval(),
             max_tries_fetching_receipt: Self::default_max_tries_fetching_receipt(),
             sleep_between_get_receipt: Self::default_sleep_between_get_receipt(),
+            event_stream_config: EventStreamConfig::default(),
         }
     }
 }

--- a/oprf-key-gen/src/lib.rs
+++ b/oprf-key-gen/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs)]
+// #![deny(missing_docs)]
 #![deny(clippy::all, clippy::pedantic)]
 #![deny(
     clippy::allow_attributes_without_reason,
@@ -25,7 +25,7 @@
 //!
 //! For details on the OPRF protocol, see the [design document](https://github.com/TaceoLabs/oprf-service/blob/main/docs/oprf.pdf).
 
-use std::str::FromStr as _;
+use std::{str::FromStr as _, time::Duration};
 
 use crate::{
     config::OprfKeyGenServiceConfig,
@@ -33,6 +33,7 @@ use crate::{
         METRICS_ATTRID_WALLET_ADDRESS, METRICS_ID_I_AM_ALIVE, METRICS_ID_KEY_GEN_WALLET_BALANCE,
     },
     services::{
+        event_cursor_store::ChainCursorService,
         secret_gen::DLogSecretGenService,
         secret_manager::SecretManagerService,
         transaction_handler::{TransactionHandler, TransactionHandlerArgs},
@@ -42,17 +43,20 @@ use alloy::{
     consensus::constants::ETH_TO_WEI,
     network::EthereumWallet,
     primitives::Address,
-    providers::{Provider as _, ProviderBuilder, WsConnect},
+    providers::{DynProvider, Provider as _, ProviderBuilder, WsConnect},
     signers::local::PrivateKeySigner,
 };
 use eyre::Context as _;
 use groth16_material::circom::CircomGroth16MaterialBuilder;
 use nodes_common::web3::{self};
 use oprf_types::{chain::OprfKeyRegistry, crypto::PartyId};
+use secrecy::ExposeSecret;
+use tokio_util::sync::CancellationToken;
 
 pub(crate) mod api;
 pub mod config;
 pub mod metrics;
+pub mod postgres;
 pub(crate) mod services;
 
 #[cfg(test)]
@@ -60,13 +64,16 @@ mod tests;
 
 pub use nodes_common::Environment;
 pub use nodes_common::StartedServices;
-use secrecy::ExposeSecret;
+pub use services::event_cursor_store;
 pub use services::secret_manager;
-use tokio_util::sync::CancellationToken;
 
 /// The tasks spawned by the key-gen library. Should call [`KeyGenTasks::join`] when shutting down for graceful shutdown.
 pub struct KeyGenTasks {
     key_event_watcher: tokio::task::JoinHandle<eyre::Result<()>>,
+
+    // keep the providers as long alive as the task are alive
+    _http_rpc_provider: web3::HttpRpcProvider,
+    _ws_rpc_provider: DynProvider,
 }
 
 impl KeyGenTasks {
@@ -143,10 +150,17 @@ async fn contract_sanity_checks(
 /// - Initializes the `DLogSecretGenService`, which uses the secret manager to persist in-progress key-gen state between rounds.
 /// - Creates a `TransactionHandler` used for submitting and confirming on-chain transactions.
 ///
+/// # Parameters
+/// - `secret_manager` – Postgres-backed store for key shares and in-progress state.
+/// - `chain_cursor_service` – Postgres-backed cursor store; the `key_event_watcher` loads
+///   the persisted `(block, log_index)` on startup so backfill resumes from where the
+///   previous run left off rather than from the chain head.
+///
 /// # Spawned Tasks
 /// The service spawns the following background tasks:
 /// - `key_event_watcher` – subscribes to the `OprfKeyRegistry` contract events and
-///   drives the key generation / resharing protocol.
+///   drives the key generation / resharing protocol. Backfills missed events from the
+///   last persisted chain cursor.
 /// - `i_am_alive` – periodically emits a metric once all services have started,
 ///   used as a basic liveness indicator.
 ///
@@ -164,10 +178,12 @@ async fn contract_sanity_checks(
 pub async fn start(
     config: OprfKeyGenServiceConfig,
     secret_manager: SecretManagerService,
+    chain_cursor_service: ChainCursorService,
     started_services: StartedServices,
     cancellation_token: CancellationToken,
 ) -> eyre::Result<(axum::Router, KeyGenTasks)> {
     tracing::info!("init oprf key-gen service..");
+
     tracing::info!("initializing wallet...");
     let private_key = PrivateKeySigner::from_str(config.wallet_private_key.expose_secret())
         .context("while loading wallet private key")?;
@@ -217,6 +233,7 @@ pub async fn start(
     .await
     .context("while joining build groth16 task")?
     .context("while building groth16 material")?;
+
     let dlog_secret_gen_service =
         DLogSecretGenService::init(key_gen_material, secret_manager.clone());
     let transaction_handler = TransactionHandler::new(TransactionHandlerArgs {
@@ -235,13 +252,14 @@ pub async fn start(
         let cancellation_token = cancellation_token.clone();
         services::key_event_watcher::key_event_watcher_task(
             services::key_event_watcher::KeyEventWatcherTaskConfig {
-                http_rpc_provider,
-                ws_rpc_provider,
+                http_rpc_provider: http_rpc_provider.clone(),
+                ws_rpc_provider: ws_rpc_provider.clone(),
                 contract_address,
                 dlog_secret_gen_service,
-                start_block: config.start_block,
+                chain_cursor_service,
                 start_signal: started_services.new_service(),
                 transaction_handler,
+                event_stream_config: config.event_stream_config,
                 cancellation_token,
             },
         )
@@ -249,26 +267,40 @@ pub async fn start(
 
     let key_gen_router = api::routes(address, started_services.clone());
 
-    tokio::task::spawn({
-        let cancellation_token = cancellation_token.clone();
-        let mut interval = tokio::time::interval(config.i_am_alive_interval);
-        async move {
-            tracing::info!("starting i am alive task");
-            loop {
-                tokio::select! {
-                   _ = interval.tick() => {
-                        if started_services.all_started() {
-                            ::metrics::counter!(METRICS_ID_I_AM_ALIVE).increment(1);
-                        }
-                   },
-                   () = cancellation_token.cancelled() => {
-                       break;
-                   }
-                }
-            }
-            tracing::info!("shutting down i am alive task");
-        }
-    });
+    tokio::task::spawn(start_i_am_alive_task(
+        started_services,
+        config.i_am_alive_interval,
+        cancellation_token,
+    ));
 
-    Ok((key_gen_router, KeyGenTasks { key_event_watcher }))
+    Ok((
+        key_gen_router,
+        KeyGenTasks {
+            key_event_watcher,
+            _http_rpc_provider: http_rpc_provider,
+            _ws_rpc_provider: ws_rpc_provider,
+        },
+    ))
+}
+
+async fn start_i_am_alive_task(
+    started_services: StartedServices,
+    i_am_alive_interval: Duration,
+    cancellation_token: CancellationToken,
+) {
+    let mut interval = tokio::time::interval(i_am_alive_interval);
+    tracing::info!("starting i am alive task");
+    loop {
+        tokio::select! {
+           _ = interval.tick() => {
+                if started_services.all_started() {
+                    ::metrics::counter!(METRICS_ID_I_AM_ALIVE).increment(1);
+                }
+           },
+           () = cancellation_token.cancelled() => {
+               break;
+           }
+        }
+    }
+    tracing::info!("shutting down i am alive task");
 }

--- a/oprf-key-gen/src/lib.rs
+++ b/oprf-key-gen/src/lib.rs
@@ -1,4 +1,4 @@
-// #![deny(missing_docs)]
+#![deny(missing_docs)]
 #![deny(clippy::all, clippy::pedantic)]
 #![deny(
     clippy::allow_attributes_without_reason,
@@ -71,7 +71,7 @@ pub use services::secret_manager;
 pub struct KeyGenTasks {
     key_event_watcher: tokio::task::JoinHandle<eyre::Result<()>>,
 
-    // keep the providers as long alive as the task are alive
+    // keep the providers alive as long as the tasks are
     _http_rpc_provider: web3::HttpRpcProvider,
     _ws_rpc_provider: DynProvider,
 }

--- a/oprf-key-gen/src/main.rs
+++ b/oprf-key-gen/src/main.rs
@@ -10,9 +10,7 @@ use config::Config;
 use eyre::Context;
 use nodes_common::{StartedServices, postgres::PostgresConfig};
 use serde::Deserialize;
-use taceo_oprf_key_gen::{
-    config::OprfKeyGenServiceConfig, secret_manager::postgres::PostgresSecretManager,
-};
+use taceo_oprf_key_gen::{config::OprfKeyGenServiceConfig, postgres::PostgresDb};
 
 /// The top-level configuration for the OPRF key-gen binary.
 ///
@@ -32,7 +30,7 @@ struct OprfKeyGenConfig {
     #[serde(rename = "service")]
     pub key_gen_config: OprfKeyGenServiceConfig,
 
-    /// The postgres config for the secret-manager
+    /// Postgres config used by the shared [`PostgresDb`] backend (secret manager and chain cursor store).
     #[serde(rename = "postgres")]
     pub postgres_config: PostgresConfig,
 }
@@ -79,13 +77,17 @@ async fn run(config: OprfKeyGenConfig) -> eyre::Result<()> {
     taceo_oprf_key_gen::metrics::describe_metrics();
     tracing::info!("{}", nodes_common::version_info!());
 
-    tracing::info!("starting Postgres secret-manager...");
-    // Load the Postgres secret manager.
-    let secret_manager = Arc::new(
-        PostgresSecretManager::init(&config.postgres_config)
-            .await
-            .context("while starting postgres secret-manager")?,
-    );
+    tracing::info!("connecting to postgres DB...");
+
+    let postgres = PostgresDb::init(&config.postgres_config)
+        .await
+        .context("while starting postgres secret-manager")?;
+
+    // Init postgres secret manager (Postgres backed)
+    let secret_manager = Arc::new(postgres.clone());
+
+    // Init chain event store (Postgres backed)
+    let chain_cursor_store = Arc::new(postgres.clone());
 
     let (cancellation_token, _) =
         nodes_common::spawn_shutdown_task(nodes_common::default_shutdown_signal());
@@ -97,6 +99,7 @@ async fn run(config: OprfKeyGenConfig) -> eyre::Result<()> {
     let (key_gen_router, key_gen_task) = taceo_oprf_key_gen::start(
         config.key_gen_config,
         secret_manager,
+        chain_cursor_store,
         StartedServices::new(),
         cancellation_token.clone(),
     )

--- a/oprf-key-gen/src/postgres.rs
+++ b/oprf-key-gen/src/postgres.rs
@@ -115,7 +115,7 @@ impl ChainCursorStorage for PostgresDb {
     #[instrument(level = "debug", skip_all)]
     #[allow(
         clippy::cast_sign_loss,
-        reason = "We want to loose the sign because sqlx can only store i64, but we have u64"
+        reason = "We serialize the u64 as i64 due sqlx limitations. We deserialize it then to u64 which is ok"
     )]
     async fn load_chain_cursor(&self) -> eyre::Result<ChainCursor> {
         tracing::trace!("loading chain event cursor...");

--- a/oprf-key-gen/src/postgres.rs
+++ b/oprf-key-gen/src/postgres.rs
@@ -64,8 +64,6 @@ enum PostgresDbError {
 impl PostgresDb {
     /// Initializes a [`PostgresDb`] by building the connection pool, ensuring the configured schema exists, and running all pending migrations.
     ///
-    /// Creates the Postgres connection pool, ensures the configured schema exists, and runs all pending database migrations.
-    ///
     /// # Errors
     /// Returns an error if creating the database pool fails, or if running the migrations fails.
     #[instrument(level = "debug", skip_all)]

--- a/oprf-key-gen/src/postgres.rs
+++ b/oprf-key-gen/src/postgres.rs
@@ -1,34 +1,56 @@
-//! This module provides an implementation of [`SecretManager`] using a Postgres database to store shares.
+//! Postgres backend for the OPRF key-gen service.
 //!
-//! The node wallet address, in-progress key-gen state, pending shares, and finalized shares are
-//! persisted in Postgres so the service can resume protocol rounds across process restarts.
+//! This module provides [`PostgresDb`], a single Postgres-backed store that implements both
+//! [`SecretManager`] and [`ChainCursorStorage`] on one shared [`sqlx::PgPool`].
+//!
+//! - [`SecretManager`]: persists the node wallet address, in-progress key-gen state,
+//!   pending shares, and finalized shares so the service can resume protocol rounds across
+//!   process restarts.
+//! - [`ChainCursorStorage`]: persists the `(block, log_index)` cursor used by the
+//!   `key_event_watcher` service to resume event-log backfill after a restart.
+//!
+//! The schema is managed by the embedded migrations in `./migrations`, applied automatically
+//! during [`PostgresDb::init`].
 
 use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-
 use async_trait::async_trait;
+use nodes_common::web3::event_stream::ChainCursor;
+use oprf_core::ddlog_equality::shamir::DLogShareShamir;
+use oprf_types::crypto::OprfPublicKey;
+use sqlx::Acquire;
+use sqlx::PgExecutor;
+use sqlx::Row as _;
+use tracing::instrument;
+
+use crate::secret_manager;
+use crate::secret_manager::KeyGenIntermediateValues;
+use crate::secret_manager::SecretManager;
+use crate::secret_manager::SecretManagerError;
+use crate::services::event_cursor_store::ChainCursorStorage;
 use backon::BackoffBuilder;
 use backon::ConstantBackoff;
 use backon::ConstantBuilder;
 use backon::Retryable;
 use eyre::Context;
 use nodes_common::postgres::{CreateSchema, PostgresConfig};
-use oprf_core::ddlog_equality::shamir::DLogShareShamir;
-use oprf_types::{OprfKeyId, ShareEpoch, crypto::OprfPublicKey};
-use sqlx::Acquire;
-use sqlx::PgExecutor;
+use oprf_types::{OprfKeyId, ShareEpoch};
 use sqlx::PgPool;
-use tracing::instrument;
 
-use crate::secret_manager::SecretManager;
-use crate::secret_manager::SecretManagerError;
-use crate::services::secret_gen::KeyGenIntermediateValues;
+type Result<T> = std::result::Result<T, PostgresDbError>;
+
+/// Postgres-backed store implementing both [`SecretManager`] and [`ChainCursorStorage`] on a shared `PgPool`.
+#[derive(Clone, Debug)]
+pub struct PostgresDb {
+    pool: PgPool,
+    max_retries: NonZeroUsize,
+    retry_delay: Duration,
+}
 
 #[derive(Debug, thiserror::Error)]
-#[non_exhaustive]
-enum PostgresSecretManagerError {
+enum PostgresDbError {
     #[error("Intermediates NOT stored for {0}/{1} - stuck")]
     MissingIntermediates(OprfKeyId, ShareEpoch),
     #[error("Refusing to overwrite newer share")]
@@ -39,40 +61,8 @@ enum PostgresSecretManagerError {
     Internal(#[from] eyre::Report),
 }
 
-impl From<PostgresSecretManagerError> for super::SecretManagerError {
-    fn from(value: PostgresSecretManagerError) -> Self {
-        match value {
-            PostgresSecretManagerError::MissingIntermediates(oprf_key_id, share_epoch) => {
-                Self::MissingIntermediates(oprf_key_id, share_epoch)
-            }
-            PostgresSecretManagerError::RefusingToRollbackEpoch => Self::RefusingToRollbackEpoch,
-            PostgresSecretManagerError::DbError(error) => {
-                if let Some(error) = error.as_database_error()
-                    && error.is_check_violation()
-                {
-                    // we tried to store on deleted share
-                    Self::StoreOnDeletedShare
-                } else {
-                    Self::Internal(eyre::Report::from(error))
-                }
-            }
-            PostgresSecretManagerError::Internal(report) => Self::Internal(report),
-        }
-    }
-}
-
-type Result<T> = std::result::Result<T, PostgresSecretManagerError>;
-
-/// The postgres secret manager wrapping a `PgPool`.
-#[derive(Debug)]
-pub struct PostgresSecretManager {
-    pool: PgPool,
-    max_retries: NonZeroUsize,
-    retry_delay: Duration,
-}
-
-impl PostgresSecretManager {
-    /// Initializes the `PostgresSecretManager`.
+impl PostgresDb {
+    /// Initializes a [`PostgresDb`] by building the connection pool, ensuring the configured schema exists, and running all pending migrations.
     ///
     /// Creates the Postgres connection pool, ensures the configured schema exists, and runs all pending database migrations.
     ///
@@ -97,12 +87,114 @@ impl PostgresSecretManager {
             retry_delay: db_config.retry_delay,
         })
     }
+
+    #[inline]
+    fn backoff_strategy(&self) -> ConstantBackoff {
+        ConstantBuilder::new()
+            .with_delay(self.retry_delay)
+            .with_max_times(self.max_retries.get())
+            .build()
+    }
+
+    async fn with_retry<F, Fut, T>(&self, op_name: &str, f: F) -> Result<T>
+    where
+        F: Fn() -> Fut,
+        Fut: Future<Output = Result<T>>,
+    {
+        f.retry(self.backoff_strategy())
+            .sleep(tokio::time::sleep)
+            .when(is_retryable_error)
+            .notify(|e, duration| {
+                tracing::warn!("Retrying {op_name} in db: {e} after {duration:?}");
+            })
+            .await
+    }
 }
 
 #[async_trait]
-impl SecretManager for PostgresSecretManager {
+impl ChainCursorStorage for PostgresDb {
+    /// Loads the `ChainEventCursor` for backfill.
+    #[instrument(level = "debug", skip_all)]
+    #[allow(
+        clippy::cast_sign_loss,
+        reason = "We want to loose the sign because sqlx can only store i64, but we have u64"
+    )]
+    async fn load_chain_cursor(&self) -> eyre::Result<ChainCursor> {
+        tracing::trace!("loading chain event cursor...");
+        let get_chain_cursor = || async {
+            let row = sqlx::query(
+                "
+                    SELECT block, idx
+                    FROM chain_cursor
+                ",
+            )
+            .fetch_one(&self.pool)
+            .await?;
+            let block = row.get::<i64, _>(0) as u64;
+            let index = row.get::<i64, _>(1) as u64;
+            Ok(ChainCursor::new(block, index))
+        };
+        Ok(self
+            .with_retry("load-chain-cursor", get_chain_cursor)
+            .await?)
+    }
+
+    #[allow(
+        clippy::cast_possible_wrap,
+        reason = "We want to wrap the value because sqlx can only store i64, but we have u64"
+    )]
+    async fn store_chain_cursor(&self, chain_cursor: ChainCursor) -> eyre::Result<()> {
+        let store_chain_cursor = || async {
+            Ok(sqlx::query(
+                "
+                    UPDATE chain_cursor
+                    SET block = $1, idx = $2
+                    WHERE id = TRUE
+                      AND ($1 > block OR ($1 = block AND $2 > idx));
+                ",
+            )
+            .bind(chain_cursor.block() as i64)
+            .bind(chain_cursor.index() as i64)
+            .execute(&self.pool)
+            .await?
+            .rows_affected())
+        };
+        let rows_affected = self
+            .with_retry("store-chain-cursor", store_chain_cursor)
+            .await?;
+        if rows_affected == 0 {
+            tracing::warn!("did not update chain-event cursor - refusing to rollback");
+        }
+        Ok(())
+    }
+}
+
+impl From<PostgresDbError> for SecretManagerError {
+    fn from(value: PostgresDbError) -> Self {
+        match value {
+            PostgresDbError::MissingIntermediates(oprf_key_id, share_epoch) => {
+                Self::MissingIntermediates(oprf_key_id, share_epoch)
+            }
+            PostgresDbError::RefusingToRollbackEpoch => Self::RefusingToRollbackEpoch,
+            PostgresDbError::DbError(error) => {
+                if let Some(error) = error.as_database_error()
+                    && error.is_check_violation()
+                {
+                    // we tried to store on deleted share
+                    Self::StoreOnDeletedShare
+                } else {
+                    Self::Internal(eyre::Report::from(error))
+                }
+            }
+            PostgresDbError::Internal(report) => Self::Internal(report),
+        }
+    }
+}
+
+#[async_trait]
+impl SecretManager for PostgresDb {
     #[instrument(level = "info", skip(self))]
-    async fn store_wallet_address(&self, address: String) -> super::Result<()> {
+    async fn store_wallet_address(&self, address: String) -> secret_manager::Result<()> {
         tracing::trace!("storing wallet address...");
         let store_address = || async {
             sqlx::query(
@@ -129,14 +221,14 @@ impl SecretManager for PostgresSecretManager {
         &self,
         oprf_key_id: OprfKeyId,
         epoch: ShareEpoch,
-    ) -> super::Result<Option<DLogShareShamir>> {
+    ) -> secret_manager::Result<Option<DLogShareShamir>> {
         tracing::trace!("loading share...");
         let get_share = || Self::get_share_by_epoch_inner(oprf_key_id, epoch, &self.pool);
         Ok(self.with_retry("get-share-by-epoch", get_share).await?)
     }
 
     #[instrument(level = "debug", skip(self))]
-    async fn delete_oprf_key_material(&self, oprf_key_id: OprfKeyId) -> super::Result<()> {
+    async fn delete_oprf_key_material(&self, oprf_key_id: OprfKeyId) -> secret_manager::Result<()> {
         tracing::trace!("trying to delete key-material..");
 
         let delete_transaction = || async {
@@ -169,7 +261,7 @@ impl SecretManager for PostgresSecretManager {
         oprf_key_id: OprfKeyId,
         pending_epoch: ShareEpoch,
         intermediate: KeyGenIntermediateValues,
-    ) -> super::Result<KeyGenIntermediateValues> {
+    ) -> secret_manager::Result<KeyGenIntermediateValues> {
         tracing::trace!("trying to store intermediates...");
         let store_intermediates = || async {
             sqlx::query_scalar(
@@ -200,7 +292,7 @@ impl SecretManager for PostgresSecretManager {
         &self,
         oprf_key_id: OprfKeyId,
         pending_epoch: ShareEpoch,
-    ) -> super::Result<Option<KeyGenIntermediateValues>> {
+    ) -> secret_manager::Result<Option<KeyGenIntermediateValues>> {
         tracing::trace!("trying to fetch intermediates...");
 
         let fetch_keygen = || async {
@@ -234,7 +326,7 @@ impl SecretManager for PostgresSecretManager {
     }
 
     #[instrument(level = "debug", skip(self))]
-    async fn abort_keygen(&self, oprf_key_id: OprfKeyId) -> super::Result<()> {
+    async fn abort_keygen(&self, oprf_key_id: OprfKeyId) -> secret_manager::Result<()> {
         tracing::trace!("trying to abort key-gen...");
 
         let abort_keygen = || Self::delete_intermediates_inner(oprf_key_id, &self.pool);
@@ -250,7 +342,7 @@ impl SecretManager for PostgresSecretManager {
         oprf_key_id: OprfKeyId,
         pending_epoch: ShareEpoch,
         share: DLogShareShamir,
-    ) -> super::Result<()> {
+    ) -> secret_manager::Result<()> {
         tracing::trace!("store pending dlog-share..");
         let store_pending = || async {
             Ok(sqlx::query(
@@ -291,7 +383,7 @@ impl SecretManager for PostgresSecretManager {
         oprf_key_id: OprfKeyId,
         epoch: ShareEpoch,
         public_key: OprfPublicKey,
-    ) -> super::Result<()> {
+    ) -> secret_manager::Result<()> {
         tracing::trace!("storing share...");
 
         let confirm_dlog_share = || async {
@@ -317,9 +409,7 @@ impl SecretManager for PostgresSecretManager {
             }
             let pending_share = Self::fetch_pending_share_inner(oprf_key_id, epoch, &mut *conn)
                 .await?
-                .ok_or_else(|| {
-                    PostgresSecretManagerError::MissingIntermediates(oprf_key_id, epoch)
-                })?;
+                .ok_or_else(|| PostgresDbError::MissingIntermediates(oprf_key_id, epoch))?;
 
             let rows_affected = Self::store_confirmed_dlog_share_inner(
                 oprf_key_id,
@@ -330,7 +420,7 @@ impl SecretManager for PostgresSecretManager {
             )
             .await?;
             if rows_affected != 1 {
-                return Err(PostgresSecretManagerError::RefusingToRollbackEpoch);
+                return Err(PostgresDbError::RefusingToRollbackEpoch);
             }
             Self::delete_intermediates_inner(oprf_key_id, &mut *conn).await?;
             tx.commit().await?;
@@ -342,15 +432,7 @@ impl SecretManager for PostgresSecretManager {
     }
 }
 
-impl PostgresSecretManager {
-    #[inline]
-    fn backoff_strategy(&self) -> ConstantBackoff {
-        ConstantBuilder::new()
-            .with_delay(self.retry_delay)
-            .with_max_times(self.max_retries.get())
-            .build()
-    }
-
+impl PostgresDb {
     async fn get_share_by_epoch_inner(
         oprf_key_id: OprfKeyId,
         epoch: ShareEpoch,
@@ -458,26 +540,26 @@ impl PostgresSecretManager {
         .await?
         .rows_affected())
     }
-
-    async fn with_retry<F, Fut, T>(&self, op_name: &str, f: F) -> Result<T>
-    where
-        F: Fn() -> Fut,
-        Fut: Future<Output = Result<T>>,
-    {
-        f.retry(self.backoff_strategy())
-            .sleep(tokio::time::sleep)
-            .when(is_retryable_error)
-            .notify(|e, duration| {
-                tracing::warn!("Retrying {op_name} in db: {e} after {duration:?}");
-            })
-            .await
-    }
 }
 
 #[inline]
-fn is_retryable_error(e: &PostgresSecretManagerError) -> bool {
+fn to_db_ark_serialize_uncompressed<T: CanonicalSerialize>(t: &T) -> zeroize::Zeroizing<Vec<u8>> {
+    let mut bytes = Vec::with_capacity(t.uncompressed_size());
+    t.serialize_uncompressed(&mut bytes).expect("Can serialize");
+    zeroize::Zeroizing::from(bytes)
+}
+
+#[inline]
+fn from_db_ark_serialize_uncompressed<T: CanonicalDeserialize>(b: Vec<u8>) -> Result<T> {
+    T::deserialize_uncompressed(zeroize::Zeroizing::from(b).as_slice()).map_err(|e| {
+        PostgresDbError::from(eyre::eyre!("Cannot deserialize bytes: DB not sane: {e}"))
+    })
+}
+
+#[inline]
+fn is_retryable_error(e: &PostgresDbError) -> bool {
     match e {
-        PostgresSecretManagerError::DbError(err) => match err {
+        PostgresDbError::DbError(err) => match err {
             // structural / driver-level errors
             sqlx::Error::PoolTimedOut
             | sqlx::Error::Io(_)
@@ -497,20 +579,6 @@ fn is_retryable_error(e: &PostgresSecretManagerError) -> bool {
 
         _ => false,
     }
-}
-
-#[inline]
-fn to_db_ark_serialize_uncompressed<T: CanonicalSerialize>(t: &T) -> zeroize::Zeroizing<Vec<u8>> {
-    let mut bytes = Vec::with_capacity(t.uncompressed_size());
-    t.serialize_uncompressed(&mut bytes).expect("Can serialize");
-    zeroize::Zeroizing::from(bytes)
-}
-
-#[inline]
-fn from_db_ark_serialize_uncompressed<T: CanonicalDeserialize>(b: Vec<u8>) -> Result<T> {
-    T::deserialize_uncompressed(zeroize::Zeroizing::from(b).as_slice()).map_err(|e| {
-        PostgresSecretManagerError::from(eyre::eyre!("Cannot deserialize bytes: DB not sane: {e}"))
-    })
 }
 
 #[cfg(test)]

--- a/oprf-key-gen/src/postgres/tests.rs
+++ b/oprf-key-gen/src/postgres/tests.rs
@@ -13,30 +13,28 @@ use groth16_material::circom::{CircomGroth16Material, CircomGroth16MaterialBuild
 use nodes_common::postgres::{PostgresConfig, SanitizedSchema};
 use nodes_common::web3::event_stream::ChainCursor;
 use oprf_core::ddlog_equality::shamir::DLogShareShamir;
-use oprf_test_utils::{TEST_ETH_ADDRESS, TEST_ETH_PRIVATE_KEY, TEST_SCHEMA};
+use oprf_test_utils::{TEST_ETH_ADDRESS, TEST_ETH_PRIVATE_KEY};
 use oprf_types::{OprfKeyId, ShareEpoch, crypto::OprfPublicKey};
 use secrecy::SecretString;
 use sqlx::Row;
 use sqlx::{PgConnection, postgres::PgRow};
 
-pub(crate) async fn postgres_secret_manager(connection_string: &str) -> eyre::Result<PostgresDb> {
-    postgres_secret_manager_with_schema(
-        connection_string,
-        TEST_SCHEMA.parse().expect("Is a valid schema"),
-    )
-    .await
+async fn postgres_secret_manager() -> eyre::Result<(PostgresDb, &'static str, SanitizedSchema)> {
+    let conn = oprf_test_utils::shared_postgres_testcontainer().await?;
+    let schema = oprf_test_utils::next_test_schema();
+    let db = postgres_secret_manager_with_schema(conn, schema.clone()).await?;
+    Ok((db, conn, schema))
+}
+
+async fn postgres_db() -> eyre::Result<PostgresDb> {
+    let (db, _, _) = postgres_secret_manager().await?;
+    Ok(db)
 }
 
 pub(crate) async fn postgres_secret_manager_with_schema(
     connection_string: &str,
     schema: SanitizedSchema,
 ) -> eyre::Result<PostgresDb> {
-    let mut pg_connection =
-        oprf_test_utils::open_pg_connection(connection_string, TEST_SCHEMA).await?;
-    sqlx::migrate!("./migrations")
-        .run(&mut pg_connection)
-        .await?;
-
     PostgresDb::init(&PostgresConfig::with_default_values(
         SecretString::from(connection_string.to_owned()),
         schema,
@@ -46,8 +44,7 @@ pub(crate) async fn postgres_secret_manager_with_schema(
 
 #[tokio::test]
 async fn load_wallet_private_key_returns_correct_key() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
+    let (secret_manager, connection_string, schema) = postgres_secret_manager().await?;
 
     let key = PrivateKeySigner::from_str(TEST_ETH_PRIVATE_KEY)?;
     let address = key.address();
@@ -57,7 +54,7 @@ async fn load_wallet_private_key_returns_correct_key() -> eyre::Result<()> {
 
     // check that the address is stored in the DB
     let mut pg_connection =
-        oprf_test_utils::open_pg_connection(&connection_string, TEST_SCHEMA).await?;
+        oprf_test_utils::open_pg_connection(connection_string, &schema.to_string()).await?;
     let stored_address: String =
         sqlx::query_scalar("SELECT address FROM evm_address WHERE id = TRUE")
             .fetch_one(&mut pg_connection)
@@ -184,8 +181,7 @@ fn assert_row_matches(
 
 #[tokio::test]
 async fn fetch_keygen_intermediates_missing_returns_none() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
+    let secret_manager = postgres_db().await?;
     let oprf_key_id = OprfKeyId::new(U160::from(42));
     let epoch = ShareEpoch::new(12);
 
@@ -198,8 +194,7 @@ async fn fetch_keygen_intermediates_missing_returns_none() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn key_gen_round1_is_idempotent() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = std::sync::Arc::new(postgres_secret_manager(&connection_string).await?);
+    let secret_manager = std::sync::Arc::new(postgres_db().await?);
     let dlog_secret_gen = DLogSecretGenService::init(key_gen_material()?, secret_manager.clone());
     let oprf_key_id = OprfKeyId::new(U160::from(42));
     let epoch = ShareEpoch::default();
@@ -236,8 +231,7 @@ async fn key_gen_round1_is_idempotent() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn store_pending_share_without_intermediates_fails() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
+    let secret_manager = postgres_db().await?;
     let oprf_key_id = OprfKeyId::new(U160::from(42));
     let epoch = ShareEpoch::new(42);
     let share = DLogShareShamir::from(rand::random::<ark_babyjubjub::Fr>());
@@ -256,9 +250,9 @@ async fn store_pending_share_without_intermediates_fails() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn confirm_without_pending_share_fails() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
-    let mut conn = oprf_test_utils::open_pg_connection(&connection_string, TEST_SCHEMA).await?;
+    let (secret_manager, connection_string, schema) = postgres_secret_manager().await?;
+    let mut conn =
+        oprf_test_utils::open_pg_connection(connection_string, &schema.to_string()).await?;
 
     let oprf_key_id = OprfKeyId::new(U160::from(42));
     let public_key = OprfPublicKey::new(rand::random());
@@ -280,9 +274,9 @@ async fn confirm_without_pending_share_fails() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn abort_keygen_is_idempotent_and_preserves_confirmed_share() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
-    let mut conn = oprf_test_utils::open_pg_connection(&connection_string, TEST_SCHEMA).await?;
+    let (secret_manager, connection_string, schema) = postgres_secret_manager().await?;
+    let mut conn =
+        oprf_test_utils::open_pg_connection(connection_string, &schema.to_string()).await?;
 
     let oprf_key_id = OprfKeyId::new(U160::from(42));
     let epoch = ShareEpoch::new(42);
@@ -311,10 +305,9 @@ async fn abort_keygen_is_idempotent_and_preserves_confirmed_share() -> eyre::Res
 
 #[tokio::test]
 async fn store_dlog_share_and_fetch_previous() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
+    let (secret_manager, connection_string, schema) = postgres_secret_manager().await?;
     let mut pg_connection =
-        oprf_test_utils::open_pg_connection(&connection_string, TEST_SCHEMA).await?;
+        oprf_test_utils::open_pg_connection(connection_string, &schema.to_string()).await?;
 
     let oprf_key_id = OprfKeyId::new(U160::from(42));
     let public_key = OprfPublicKey::new(rand::random());
@@ -439,10 +432,9 @@ async fn store_dlog_share_and_fetch_previous() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn store_dlog_share_as_consumer() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
+    let (secret_manager, connection_string, schema) = postgres_secret_manager().await?;
     let mut pg_connection =
-        oprf_test_utils::open_pg_connection(&connection_string, TEST_SCHEMA).await?;
+        oprf_test_utils::open_pg_connection(connection_string, &schema.to_string()).await?;
 
     let oprf_key_id = OprfKeyId::new(U160::from(42));
     let public_key = OprfPublicKey::new(rand::random());
@@ -499,10 +491,9 @@ async fn store_dlog_share_as_consumer() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn try_retrieve_random_empty_epochs() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
+    let (secret_manager, connection_string, schema) = postgres_secret_manager().await?;
     let mut pg_connection =
-        oprf_test_utils::open_pg_connection(&connection_string, TEST_SCHEMA).await?;
+        oprf_test_utils::open_pg_connection(connection_string, &schema.to_string()).await?;
 
     let oprf_key_id = OprfKeyId::new(U160::from(42));
     let public_key = OprfPublicKey::new(rand::random());
@@ -556,9 +547,9 @@ async fn try_retrieve_random_empty_epochs() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn confirm_after_abort_keygen_fails() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
-    let mut conn = oprf_test_utils::open_pg_connection(&connection_string, TEST_SCHEMA).await?;
+    let (secret_manager, connection_string, schema) = postgres_secret_manager().await?;
+    let mut conn =
+        oprf_test_utils::open_pg_connection(connection_string, &schema.to_string()).await?;
 
     let oprf_key_id = OprfKeyId::new(U160::from(42));
     let public_key = OprfPublicKey::new(rand::random());
@@ -582,10 +573,9 @@ async fn confirm_after_abort_keygen_fails() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn confirm_same_epoch_without_restaging_is_idempotent() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
+    let (secret_manager, connection_string, schema) = postgres_secret_manager().await?;
     let mut pg_connection =
-        oprf_test_utils::open_pg_connection(&connection_string, TEST_SCHEMA).await?;
+        oprf_test_utils::open_pg_connection(connection_string, &schema.to_string()).await?;
 
     let oprf_key_id = OprfKeyId::new(U160::from(42));
     let public_key = OprfPublicKey::new(rand::random());
@@ -637,10 +627,9 @@ async fn confirm_same_epoch_without_restaging_is_idempotent() -> eyre::Result<()
 
 #[tokio::test]
 async fn confirm_same_epoch_after_restaging_is_idempotent() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
+    let (secret_manager, connection_string, schema) = postgres_secret_manager().await?;
     let mut pg_connection =
-        oprf_test_utils::open_pg_connection(&connection_string, TEST_SCHEMA).await?;
+        oprf_test_utils::open_pg_connection(connection_string, &schema.to_string()).await?;
 
     let oprf_key_id = OprfKeyId::new(U160::from(42));
     let public_key = OprfPublicKey::new(rand::random());
@@ -686,9 +675,9 @@ async fn confirm_same_epoch_after_restaging_is_idempotent() -> eyre::Result<()> 
 
 #[tokio::test]
 async fn delete_oprf_key_material_is_idempotent_and_soft_deletes_share() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
-    let mut conn = oprf_test_utils::open_pg_connection(&connection_string, TEST_SCHEMA).await?;
+    let (secret_manager, connection_string, schema) = postgres_secret_manager().await?;
+    let mut conn =
+        oprf_test_utils::open_pg_connection(connection_string, &schema.to_string()).await?;
 
     let oprf_key_id = OprfKeyId::new(U160::from(42));
     let public_key = OprfPublicKey::new(rand::random());
@@ -721,9 +710,9 @@ async fn delete_oprf_key_material_is_idempotent_and_soft_deletes_share() -> eyre
 
 #[tokio::test]
 async fn confirm_deleted_share_returns_store_on_deleted_share() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
-    let mut conn = oprf_test_utils::open_pg_connection(&connection_string, TEST_SCHEMA).await?;
+    let (secret_manager, connection_string, schema) = postgres_secret_manager().await?;
+    let mut conn =
+        oprf_test_utils::open_pg_connection(connection_string, &schema.to_string()).await?;
 
     let oprf_key_id = OprfKeyId::new(U160::from(42));
     let public_key = OprfPublicKey::new(rand::random());
@@ -754,10 +743,9 @@ async fn confirm_deleted_share_returns_store_on_deleted_share() -> eyre::Result<
 
 #[tokio::test]
 async fn test_delete() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
+    let (secret_manager, connection_string, schema) = postgres_secret_manager().await?;
     let mut pg_connection =
-        oprf_test_utils::open_pg_connection(&connection_string, TEST_SCHEMA).await?;
+        oprf_test_utils::open_pg_connection(connection_string, &schema.to_string()).await?;
 
     let oprf_key_id = OprfKeyId::new(U160::from(42));
     let public_key = OprfPublicKey::new(rand::random());
@@ -804,8 +792,7 @@ async fn test_delete() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn test_load_chain_cursor_on_empty_db() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
+    let secret_manager = postgres_db().await?;
 
     let should_genesis_cursor = secret_manager.load_chain_cursor().await?;
     assert!(
@@ -817,8 +804,7 @@ async fn test_load_chain_cursor_on_empty_db() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn test_insert_chain_cursor_then_load() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
+    let secret_manager = postgres_db().await?;
 
     let should_chain_cursor = ChainCursor::new(42, 0x42);
     secret_manager
@@ -834,8 +820,7 @@ async fn test_insert_chain_cursor_then_load() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn test_insert_chain_cursor_refusing_rollback() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
+    let secret_manager = postgres_db().await?;
 
     let should_chain_cursor = ChainCursor::new(42, 0x42);
     let chain_cursor_earlier_block = ChainCursor::new(41, 0x42);

--- a/oprf-key-gen/src/postgres/tests.rs
+++ b/oprf-key-gen/src/postgres/tests.rs
@@ -2,7 +2,8 @@
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use crate::secret_manager::postgres::{PostgresSecretManager, to_db_ark_serialize_uncompressed};
+use crate::event_cursor_store::ChainCursorStorage;
+use crate::postgres::{PostgresDb, to_db_ark_serialize_uncompressed};
 use crate::secret_manager::{SecretManager as _, SecretManagerError};
 use crate::services::secret_gen::DLogSecretGenService;
 use alloy::{primitives::U160, signers::local::PrivateKeySigner, sol_types::SolValue as _};
@@ -10,6 +11,7 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize as _};
 use eyre::Context;
 use groth16_material::circom::{CircomGroth16Material, CircomGroth16MaterialBuilder, Validate};
 use nodes_common::postgres::{PostgresConfig, SanitizedSchema};
+use nodes_common::web3::event_stream::ChainCursor;
 use oprf_core::ddlog_equality::shamir::DLogShareShamir;
 use oprf_test_utils::{TEST_ETH_ADDRESS, TEST_ETH_PRIVATE_KEY, TEST_SCHEMA};
 use oprf_types::{OprfKeyId, ShareEpoch, crypto::OprfPublicKey};
@@ -17,9 +19,7 @@ use secrecy::SecretString;
 use sqlx::Row;
 use sqlx::{PgConnection, postgres::PgRow};
 
-pub(crate) async fn postgres_secret_manager(
-    connection_string: &str,
-) -> eyre::Result<PostgresSecretManager> {
+pub(crate) async fn postgres_secret_manager(connection_string: &str) -> eyre::Result<PostgresDb> {
     postgres_secret_manager_with_schema(
         connection_string,
         TEST_SCHEMA.parse().expect("Is a valid schema"),
@@ -30,14 +30,14 @@ pub(crate) async fn postgres_secret_manager(
 pub(crate) async fn postgres_secret_manager_with_schema(
     connection_string: &str,
     schema: SanitizedSchema,
-) -> eyre::Result<PostgresSecretManager> {
+) -> eyre::Result<PostgresDb> {
     let mut pg_connection =
         oprf_test_utils::open_pg_connection(connection_string, TEST_SCHEMA).await?;
     sqlx::migrate!("./migrations")
         .run(&mut pg_connection)
         .await?;
 
-    PostgresSecretManager::init(&PostgresConfig::with_default_values(
+    PostgresDb::init(&PostgresConfig::with_default_values(
         SecretString::from(connection_string.to_owned()),
         schema,
     ))
@@ -211,7 +211,7 @@ async fn key_gen_round1_is_idempotent() -> eyre::Result<()> {
         .fetch_keygen_intermediates(oprf_key_id, epoch)
         .await?
         .expect("intermediates should be present");
-    let serialized_intermediates = to_db_ark_serialize_uncompressed(&intermediates);
+    let serialized_intermediates = super::to_db_ark_serialize_uncompressed(&intermediates);
 
     let retried_contribution = dlog_secret_gen
         .key_gen_round1(oprf_key_id, epoch, 2)
@@ -798,6 +798,71 @@ async fn test_delete() -> eyre::Result<()> {
             .get_share_by_epoch(oprf_key_id, epoch42)
             .await?
             .is_none()
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_load_chain_cursor_on_empty_db() -> eyre::Result<()> {
+    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
+    let secret_manager = postgres_secret_manager(&connection_string).await?;
+
+    let should_genesis_cursor = secret_manager.load_chain_cursor().await?;
+    assert!(
+        should_genesis_cursor.is_genesis(),
+        "Should be genesis cursor on empty DB"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_insert_chain_cursor_then_load() -> eyre::Result<()> {
+    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
+    let secret_manager = postgres_secret_manager(&connection_string).await?;
+
+    let should_chain_cursor = ChainCursor::new(42, 0x42);
+    secret_manager
+        .store_chain_cursor(should_chain_cursor)
+        .await?;
+    let is_chain_cursor = secret_manager.load_chain_cursor().await?;
+    assert_eq!(
+        is_chain_cursor, should_chain_cursor,
+        "Should load inserted chain cursor"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_insert_chain_cursor_refusing_rollback() -> eyre::Result<()> {
+    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
+    let secret_manager = postgres_secret_manager(&connection_string).await?;
+
+    let should_chain_cursor = ChainCursor::new(42, 0x42);
+    let chain_cursor_earlier_block = ChainCursor::new(41, 0x42);
+    let chain_cursor_earlier_index = ChainCursor::new(42, 0x41);
+
+    secret_manager
+        .store_chain_cursor(should_chain_cursor)
+        .await?;
+
+    secret_manager
+        .store_chain_cursor(chain_cursor_earlier_block)
+        .await?;
+
+    assert_eq!(
+        should_chain_cursor,
+        secret_manager.load_chain_cursor().await?,
+        "Should have refused insertions of older cursor"
+    );
+
+    secret_manager
+        .store_chain_cursor(chain_cursor_earlier_index)
+        .await?;
+
+    assert_eq!(
+        should_chain_cursor,
+        secret_manager.load_chain_cursor().await?,
+        "Should have refused insertions of older cursor"
     );
     Ok(())
 }

--- a/oprf-key-gen/src/services.rs
+++ b/oprf-key-gen/src/services.rs
@@ -11,7 +11,9 @@
 //! - [`key_event_watcher`] – watches the blockchain for key-generation events.
 //! - [`secret_gen`] – handles multi-round secret generation protocols.
 //! - [`secret_manager`] – stores and retrieves secrets.
-//! - [`transaction_handler`] – handles transaction submitting including error handling and retry when the RPC breaks down
+//! - [`transaction_handler`] – handles transaction submitting including error handling and retry when the RPC breaks down.
+//! - [`event_cursor_store`] – persists the chain event cursor so that `key_event_watcher` can resume backfill from the last processed `(block, log_index)` after a restart.
+pub mod event_cursor_store;
 pub(crate) mod key_event_watcher;
 pub(crate) mod secret_gen;
 pub mod secret_manager;

--- a/oprf-key-gen/src/services/event_cursor_store.rs
+++ b/oprf-key-gen/src/services/event_cursor_store.rs
@@ -1,0 +1,37 @@
+//! Chain event cursor persistence for the OPRF key-gen service.
+//!
+//! This module defines the [`ChainCursorStorage`] trait, which is used to
+//! durably persist and retrieve the `(block, log_index)` position up to which
+//! the `key_event_watcher` service has processed on-chain events.
+//! On startup the watcher loads this cursor and resumes backfill from that point,
+//! ensuring no key-generation events are missed across restarts.
+//!
+//! Implementations must enforce monotonicity: storing a cursor that would roll back
+//! an already-persisted position should be a no-op (the [`crate::postgres::PostgresDb`]
+//! implementation logs a warning and silently discards such updates).
+//!
+//! Current [`ChainCursorStorage`] implementations:
+//! - Postgres
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use nodes_common::web3::event_stream::ChainCursor;
+
+/// A thread-safe, dynamically-dispatched [`ChainCursorStorage`].
+pub type ChainCursorService = Arc<dyn ChainCursorStorage + Send + Sync>;
+
+/// Persistent storage for the chain event cursor.
+#[async_trait]
+pub trait ChainCursorStorage {
+    /// Returns the last durably stored `(block, log_index)` cursor.
+    ///
+    /// Returns `(0, 0)` if no cursor has been stored yet, causing the watcher to
+    /// backfill from genesis.
+    async fn load_chain_cursor(&self) -> eyre::Result<ChainCursor>;
+
+    /// Persists the given cursor.
+    ///
+    /// Implementations must ignore updates that would move the cursor backwards.
+    async fn store_chain_cursor(&self, chain_cursor: ChainCursor) -> eyre::Result<()>;
+}

--- a/oprf-key-gen/src/services/key_event_watcher.rs
+++ b/oprf-key-gen/src/services/key_event_watcher.rs
@@ -3,8 +3,8 @@
 //! This module provides [`key_event_watcher_task`], a task that can be spawned to monitor an
 //! on-chain `OprfKeyRegistry` contract for key generation events.
 //!
-//! The watcher loads the persisted [`ChainCursor`](nodes_common::web3::event_stream::ChainCursor)
-//! from the [`ChainCursorService`](crate::event_cursor_store::ChainCursorService) on startup and
+//! The watcher loads the persisted [`ChainCursor`]
+//! from the [`ChainCursorService`] on startup and
 //! passes it to the event stream so backfill resumes from the last processed `(block, log_index)`.
 //! After each handled log the cursor is stored unconditionally before propagating any handler error.
 //! The watcher subscribes to various key generation events and reports contributions back to the contract.
@@ -221,7 +221,6 @@ async fn key_gen_event(
                 .context("while decoding key-gen round2 event")?
                 .inner
                 .data;
-            let handle_span = tracing::Span::current();
             handle_span.record("oprf_key_id", oprfKeyId.to_string());
             handle_span.record("epoch", epoch.to_string());
             let epoch = ShareEpoch::from(epoch);
@@ -246,7 +245,6 @@ async fn key_gen_event(
                 .inner
                 .data;
             let oprf_key_id = OprfKeyId::from(oprfKeyId);
-            let handle_span = tracing::Span::current();
             handle_span.record("oprf_key_id", oprf_key_id.to_string());
             handle_span.record("epoch", "0");
             handle_span.record("event", "key-gen round 3");
@@ -260,7 +258,6 @@ async fn key_gen_event(
                 .data;
             let oprf_key_id = OprfKeyId::from(oprfKeyId);
             let epoch = ShareEpoch::from(epoch);
-            let handle_span = tracing::Span::current();
             handle_span.record("oprf_key_id", oprf_key_id.to_string());
             handle_span.record("epoch", epoch.to_string());
             handle_span.record("event", "finalize");
@@ -278,7 +275,6 @@ async fn key_gen_event(
                 .data;
             let oprf_key_id = OprfKeyId::from(oprfKeyId);
             let epoch = ShareEpoch::from(epoch);
-            let handle_span = tracing::Span::current();
             handle_span.record("oprf_key_id", oprf_key_id.to_string());
             handle_span.record("epoch", epoch.to_string());
             handle_span.record("event", "reshare round 1");
@@ -304,7 +300,6 @@ async fn key_gen_event(
                 .data;
             let oprf_key_id = OprfKeyId::from(oprfKeyId);
             let epoch = ShareEpoch::from(epoch);
-            let handle_span = tracing::Span::current();
             handle_span.record("oprf_key_id", oprf_key_id.to_string());
             handle_span.record("epoch", epoch.to_string());
             handle_span.record("event", "reshare round 3");
@@ -325,7 +320,6 @@ async fn key_gen_event(
                 .inner
                 .data;
             let oprf_key_id = OprfKeyId::from(oprfKeyId);
-            let handle_span = tracing::Span::current();
             handle_span.record("oprf_key_id", oprf_key_id.to_string());
             handle_span.record("event", "abort");
             handle_abort(oprf_key_id, secret_gen).await
@@ -337,7 +331,6 @@ async fn key_gen_event(
                 .inner
                 .data;
             let oprf_key_id = OprfKeyId::from(oprfKeyId);
-            let handle_span = tracing::Span::current();
             handle_span.record("oprf_key_id", oprf_key_id.to_string());
             handle_span.record("event", "delete");
             handle_delete(oprf_key_id, secret_gen).await
@@ -349,7 +342,6 @@ async fn key_gen_event(
                 .inner
                 .data;
             let oprf_key_id = OprfKeyId::from(oprfKeyId);
-            let handle_span = tracing::Span::current();
             handle_span.record("oprf_key_id", oprf_key_id.to_string());
             handle_span.record("event", "not enough producers");
             handle_not_enough_producers(oprf_key_id, secret_gen).await

--- a/oprf-key-gen/src/services/key_event_watcher.rs
+++ b/oprf-key-gen/src/services/key_event_watcher.rs
@@ -1,7 +1,12 @@
 //! Alloy-based Key Generation Event Watcher
 //!
-//! This module provides [`key_event_watcher_task`], an task than can be spawned to monitor an on-chain `OprfKeyRegistry` contract for key generation events.
+//! This module provides [`key_event_watcher_task`], a task that can be spawned to monitor an
+//! on-chain `OprfKeyRegistry` contract for key generation events.
 //!
+//! The watcher loads the persisted [`ChainCursor`](nodes_common::web3::event_stream::ChainCursor)
+//! from the [`ChainCursorService`](crate::event_cursor_store::ChainCursorService) on startup and
+//! passes it to the event stream so backfill resumes from the last processed `(block, log_index)`.
+//! After each handled log the cursor is stored unconditionally before propagating any handler error.
 //! The watcher subscribes to various key generation events and reports contributions back to the contract.
 
 use std::sync::{
@@ -10,6 +15,7 @@ use std::sync::{
 };
 
 use crate::{
+    event_cursor_store::ChainCursorService,
     metrics::{
         METRICS_ATTRID_PROTOCOL, METRICS_ATTRID_ROLE, METRICS_ATTRVAL_PROTOCOL_KEY_GEN,
         METRICS_ATTRVAL_PROTOCOL_RESHARE, METRICS_ATTRVAL_ROLE_CONSUMER,
@@ -26,15 +32,17 @@ use crate::{
     },
 };
 use alloy::{
-    eips::BlockNumberOrTag,
     primitives::{Address, LogData, U256},
-    providers::{DynProvider, Provider},
-    rpc::types::{Filter, Log},
+    providers::DynProvider,
+    rpc::types::Log,
     sol_types::SolEvent as _,
 };
 use eyre::Context;
-use futures::StreamExt as _;
-use nodes_common::web3;
+use futures::StreamExt;
+use nodes_common::web3::{
+    self,
+    event_stream::{ChainCursor, EventStreamBuilder, EventStreamConfig},
+};
 use oprf_types::{
     OprfKeyId, ShareEpoch,
     chain::{
@@ -80,9 +88,10 @@ pub(crate) struct KeyEventWatcherTaskConfig {
     pub(crate) ws_rpc_provider: DynProvider,
     pub(crate) contract_address: Address,
     pub(crate) dlog_secret_gen_service: DLogSecretGenService,
-    pub(crate) start_block: Option<u64>,
+    pub(crate) chain_cursor_service: ChainCursorService,
     pub(crate) start_signal: Arc<AtomicBool>,
     pub(crate) transaction_handler: TransactionHandler,
+    pub(crate) event_stream_config: EventStreamConfig,
     pub(crate) cancellation_token: CancellationToken,
 }
 
@@ -94,23 +103,24 @@ pub(crate) async fn key_event_watcher_task(args: KeyEventWatcherTaskConfig) -> e
     // shutdown service if event watcher encounters an error and drops this guard
     let _drop_guard = args.cancellation_token.clone().drop_guard();
     tracing::info!("start handling events");
-    handle_events(args)
-        .await
-        .inspect(|()| tracing::info!("successfully closed key_event_watcher without error"))
-}
-
-/// Filters for various key generation event signatures and handles them
-async fn handle_events(args: KeyEventWatcherTaskConfig) -> eyre::Result<()> {
     let KeyEventWatcherTaskConfig {
         http_rpc_provider,
         ws_rpc_provider,
         contract_address,
         dlog_secret_gen_service,
-        start_block,
+        chain_cursor_service,
         start_signal,
         transaction_handler,
+        event_stream_config,
         cancellation_token,
     } = args;
+
+    tracing::info!("loading chain-cursor");
+    let chain_cursor = chain_cursor_service
+        .load_chain_cursor()
+        .await
+        .context("while loading chain cursor")?;
+    tracing::info!("chain cursor at: {chain_cursor}");
     let contract = OprfKeyRegistry::new(contract_address, http_rpc_provider.inner());
     let event_signatures = vec![
         OprfKeyRegistry::SecretGenRound1::SIGNATURE_HASH,
@@ -123,75 +133,44 @@ async fn handle_events(args: KeyEventWatcherTaskConfig) -> eyre::Result<()> {
         OprfKeyRegistry::KeyGenAbort::SIGNATURE_HASH,
         OprfKeyRegistry::NotEnoughProducers::SIGNATURE_HASH,
     ];
-    let filter = Filter::new()
-        .address(contract_address)
-        .from_block(BlockNumberOrTag::Latest)
-        .event_signature(event_signatures.clone());
-    // subscribe now so we don't miss any events between now and when we start processing past events
-    let sub = ws_rpc_provider.subscribe_logs(&filter).await?;
-    let mut latest_block = 0;
 
-    // if start_block is set, load past events from there to head
-    if let Some(start_block) = start_block {
-        tracing::info!("loading past events from block {start_block}..");
-        let filter = Filter::new()
-            .address(contract_address)
-            .from_block(BlockNumberOrTag::Number(start_block))
-            .to_block(BlockNumberOrTag::Latest)
-            .event_signature(event_signatures);
-        let logs = http_rpc_provider
-            .get_logs(&filter)
-            .await
-            .context("while loading past logs")?;
-        for log in logs {
-            let block_number = log.block_number.unwrap_or_default();
-            latest_block = block_number;
-            tracing::info!("handling past event from block {block_number}..");
-            key_gen_event(
-                log,
-                &contract,
-                &dlog_secret_gen_service,
-                &transaction_handler,
-            )
-            .await
-            .context("while handling past log")?;
-        }
-    }
+    let mut event_stream = EventStreamBuilder::with_config(
+        chain_cursor,
+        contract_address,
+        http_rpc_provider,
+        ws_rpc_provider.clone(),
+        event_signatures,
+        event_stream_config,
+    )
+    .build()
+    .await
+    .context("while building event-stream")?;
 
-    let mut stream = sub.into_stream();
     start_signal.store(true, Ordering::Relaxed);
-    tracing::info!("key event watcher is ready");
     loop {
         let log = tokio::select! {
-            log = stream.next() => {
-                log.ok_or_else(||eyre::eyre!("logs subscribe stream was closed"))?
+            log = event_stream.next() => {
+                log.ok_or_else(||eyre::eyre!("logs subscribe stream was closed"))?.context("while fetching event from event_stream")?
             }
             () = cancellation_token.cancelled() => {
                 break;
             }
         };
-        // skip logs from blocks we've already handled with get_logs
-        if let Some(block_number) = log.block_number
-            && block_number <= latest_block
-        {
-            tracing::info!(
-                "skipping event from block {block_number} - already handled up to {latest_block}"
-            );
-            continue;
-        }
         key_gen_event(
             log,
             &contract,
             &dlog_secret_gen_service,
+            &chain_cursor_service,
             &transaction_handler,
         )
-        .await
-        .context("while handling log")?;
+        .await?;
     }
+
+    tracing::info!("successfully closed key_event_watcher without error");
     Ok(())
 }
 
-#[instrument(level = "info", skip_all, fields(oprf_key_id=tracing::field::Empty, epoch=tracing::field::Empty, event=tracing::field::Empty))]
+#[instrument(level = "info", skip_all, fields(oprf_key_id=tracing::field::Empty, epoch=tracing::field::Empty, event=tracing::field::Empty, block=tracing::field::Empty,index=tracing::field::Empty))]
 #[allow(
     clippy::too_many_lines,
     reason = "Is easier to have one large match instead of many single methods"
@@ -200,8 +179,20 @@ async fn key_gen_event(
     log: Log<LogData>,
     contract: &OprfKeyRegistryInstance<DynProvider>,
     secret_gen: &DLogSecretGenService,
+    chain_cursor_service: &ChainCursorService,
     transaction_handler: &TransactionHandler,
 ) -> Result<()> {
+    let block = log
+        .block_number
+        .ok_or_else(|| eyre::eyre!("block number empty in log"))?;
+    let index = log
+        .log_index
+        .ok_or_else(|| eyre::eyre!("index empty in log"))?;
+    let new_chain_cursor = ChainCursor::new(block, index);
+
+    let handle_span = tracing::Span::current();
+    handle_span.record("block", block);
+    handle_span.record("index", index);
     let result = match log.topic0() {
         Some(&OprfKeyRegistry::SecretGenRound1::SIGNATURE_HASH) => {
             let OprfKeyRegistry::SecretGenRound1 {
@@ -212,7 +203,6 @@ async fn key_gen_event(
                 .context("while decoding key-gen round1 event")?
                 .inner
                 .data;
-            let handle_span = tracing::Span::current();
             handle_span.record("oprf_key_id", oprfKeyId.to_string());
             handle_span.record("epoch", "0");
             handle_span.record("event", "key-gen round 1");
@@ -369,6 +359,12 @@ async fn key_gen_event(
             return Ok(());
         }
     };
+    // we store the chain_event_cursor irrelevant if we encountered an error or not.
+    // TODO This needs some fine tuning in a follow up PR though.
+    chain_cursor_service
+        .store_chain_cursor(new_chain_cursor)
+        .await
+        .context("while storing new event cursor")?;
     match result {
         Ok(()) => Ok(()),
         Err(TransactionError::Revert(RevertError::OprfKeyRegistry(

--- a/oprf-key-gen/src/services/secret_gen/tests.rs
+++ b/oprf-key-gen/src/services/secret_gen/tests.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 use oprf_types::crypto::{EphemeralEncryptionPublicKey, SecretGenCiphertexts};
 use rand::Rng;
 
-use crate::secret_manager::{SecretManager, postgres};
+use crate::{postgres, secret_manager::SecretManager};
 
 use super::*;
 

--- a/oprf-key-gen/src/services/secret_gen/tests.rs
+++ b/oprf-key-gen/src/services/secret_gen/tests.rs
@@ -76,25 +76,25 @@ async fn test_secret_gen() -> eyre::Result<()> {
         .bbf_num_2_bits_helper()
         .build_from_bytes(&key_gen_zkey, &graph)?;
 
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
+    let connection_string = oprf_test_utils::shared_postgres_testcontainer().await?;
     let secret_manager0 = Arc::new(
         postgres::tests::postgres_secret_manager_with_schema(
-            &connection_string,
-            "node0".parse().expect("should be valid schema"),
+            connection_string,
+            oprf_test_utils::next_test_schema(),
         )
         .await?,
     );
     let secret_manager1 = Arc::new(
         postgres::tests::postgres_secret_manager_with_schema(
-            &connection_string,
-            "node1".parse().expect("should be valid schema"),
+            connection_string,
+            oprf_test_utils::next_test_schema(),
         )
         .await?,
     );
     let secret_manager2 = Arc::new(
         postgres::tests::postgres_secret_manager_with_schema(
-            &connection_string,
-            "node2".parse().expect("should be valid schema"),
+            connection_string,
+            oprf_test_utils::next_test_schema(),
         )
         .await?,
     );

--- a/oprf-key-gen/src/services/secret_manager.rs
+++ b/oprf-key-gen/src/services/secret_manager.rs
@@ -14,8 +14,6 @@ use oprf_types::{OprfKeyId, ShareEpoch, crypto::OprfPublicKey};
 
 pub use crate::services::secret_gen::KeyGenIntermediateValues;
 
-pub mod postgres;
-
 /// Dynamic trait object for secret manager service.
 ///
 /// Must be `Send + Sync` to work with async contexts (e.g., Axum).

--- a/oprf-key-gen/src/tests/keygen_test_secret_manager.rs
+++ b/oprf-key-gen/src/tests/keygen_test_secret_manager.rs
@@ -48,9 +48,10 @@ impl ChainCursorStorage for TestChainCursorService {
 
     async fn store_chain_cursor(&self, chain_cursor: ChainCursor) -> eyre::Result<()> {
         let mut stored_cursor = self.0.lock();
-        if stored_cursor.is_before(chain_cursor) {
+        if chain_cursor.is_before(*stored_cursor) {
             eyre::bail!("trying to rewind cursor")
         }
+        *stored_cursor = chain_cursor;
         Ok(())
     }
 }

--- a/oprf-key-gen/src/tests/keygen_test_secret_manager.rs
+++ b/oprf-key-gen/src/tests/keygen_test_secret_manager.rs
@@ -31,8 +31,12 @@ pub(crate) struct TestChainCursorService(Arc<Mutex<ChainCursor>>);
 pub(crate) struct TestKeyGenSecretManager(Arc<Mutex<TestKeyGenSecretManagerState>>);
 
 impl TestChainCursorService {
-    pub(crate) fn service() -> crate::ChainCursorService {
-        Arc::new(Self::default())
+    pub(crate) fn with_cursor(cursor: ChainCursor) -> Self {
+        Self(Arc::new(Mutex::new(cursor)))
+    }
+
+    pub(crate) fn service(&self) -> crate::ChainCursorService {
+        Arc::new(self.clone())
     }
 }
 
@@ -43,7 +47,10 @@ impl ChainCursorStorage for TestChainCursorService {
     }
 
     async fn store_chain_cursor(&self, chain_cursor: ChainCursor) -> eyre::Result<()> {
-        *self.0.lock() = chain_cursor;
+        let mut stored_cursor = self.0.lock();
+        if stored_cursor.is_before(chain_cursor) {
+            *stored_cursor = chain_cursor;
+        }
         Ok(())
     }
 }

--- a/oprf-key-gen/src/tests/keygen_test_secret_manager.rs
+++ b/oprf-key-gen/src/tests/keygen_test_secret_manager.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use async_trait::async_trait;
+use nodes_common::web3::event_stream::ChainCursor;
 use oprf_core::ddlog_equality::shamir::DLogShareShamir;
 use oprf_test_utils::{TEST_TIMEOUT, test_secret_manager::TestSecretManager};
 use oprf_types::{
@@ -11,7 +12,10 @@ use oprf_types::{
 use parking_lot::Mutex;
 use rand::{CryptoRng, Rng};
 
-use crate::secret_manager::{KeyGenIntermediateValues, SecretManager, SecretManagerError};
+use crate::{
+    event_cursor_store::ChainCursorStorage,
+    secret_manager::{KeyGenIntermediateValues, SecretManager, SecretManagerError},
+};
 
 struct TestKeyGenSecretManagerState {
     base: TestSecretManager,
@@ -20,8 +24,29 @@ struct TestKeyGenSecretManagerState {
     deleted_keys: HashMap<OprfKeyId, ShareEpoch>,
 }
 
+#[derive(Clone, Default)]
+pub(crate) struct TestChainCursorService(Arc<Mutex<ChainCursor>>);
+
 #[derive(Clone)]
 pub(crate) struct TestKeyGenSecretManager(Arc<Mutex<TestKeyGenSecretManagerState>>);
+
+impl TestChainCursorService {
+    pub(crate) fn service() -> crate::ChainCursorService {
+        Arc::new(Self::default())
+    }
+}
+
+#[async_trait]
+impl ChainCursorStorage for TestChainCursorService {
+    async fn load_chain_cursor(&self) -> eyre::Result<ChainCursor> {
+        Ok(*self.0.lock())
+    }
+
+    async fn store_chain_cursor(&self, chain_cursor: ChainCursor) -> eyre::Result<()> {
+        *self.0.lock() = chain_cursor;
+        Ok(())
+    }
+}
 
 impl TestKeyGenSecretManager {
     pub(crate) fn new(wallet_private_key: &str) -> Self {

--- a/oprf-key-gen/src/tests/keygen_test_secret_manager.rs
+++ b/oprf-key-gen/src/tests/keygen_test_secret_manager.rs
@@ -49,7 +49,7 @@ impl ChainCursorStorage for TestChainCursorService {
     async fn store_chain_cursor(&self, chain_cursor: ChainCursor) -> eyre::Result<()> {
         let mut stored_cursor = self.0.lock();
         if stored_cursor.is_before(chain_cursor) {
-            *stored_cursor = chain_cursor;
+            eyre::bail!("trying to rewind cursor")
         }
         Ok(())
     }

--- a/oprf-key-gen/src/tests/mod.rs
+++ b/oprf-key-gen/src/tests/mod.rs
@@ -1,14 +1,19 @@
 #![allow(clippy::large_futures, reason = "doesnt matter for tests")]
 use std::fmt;
+use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use alloy::{primitives::U160, sol_types::SolEvent};
 use axum_test::TestServer;
+use eyre::Context as _;
 use nodes_common::web3::HttpRpcProviderConfig;
+use nodes_common::web3::event_stream::{ChainCursor, SkipBackfill};
 use nodes_common::{Environment, StartedServices};
-use oprf_test_utils::{DeploySetup, PEER_PRIVATE_KEYS, TestSetup};
+use oprf_test_utils::{
+    DeploySetup, MineStrategy, OPRF_PEER_ADDRESS_0, PEER_PRIVATE_KEYS, TestSetup,
+};
 
-use oprf_test_utils::{OPRF_PEER_ADDRESS_0, TEST_TIMEOUT};
+use oprf_test_utils::TEST_TIMEOUT;
 use oprf_types::{OprfKeyId, ShareEpoch, chain::OprfKeyRegistry};
 use tokio_util::sync::CancellationToken;
 
@@ -16,7 +21,6 @@ use crate::tests::keygen_test_secret_manager::TestChainCursorService;
 use crate::{
     KeyGenTasks,
     config::{OprfKeyGenServiceConfig, OprfKeyGenServiceConfigMandatoryValues},
-    secret_manager::SecretManagerService,
     start,
     tests::keygen_test_secret_manager::TestKeyGenSecretManager,
 };
@@ -29,7 +33,60 @@ pub(crate) struct TestKeyGen {
     pub(crate) server: TestServer,
     pub(crate) key_gen_task: KeyGenTasks,
     pub(crate) started_services: StartedServices,
+    pub(crate) cursor_service: TestChainCursorService,
     pub(crate) cancellation_token: CancellationToken,
+}
+
+pub(crate) struct TestKeyGenBuilder<'a> {
+    party_id: usize,
+    test_setup: &'a TestSetup,
+    secret_manager: Option<TestKeyGenSecretManager>,
+    skip_backfill: SkipBackfill,
+    cursor_service: TestChainCursorService,
+}
+
+impl<'a> TestKeyGenBuilder<'a> {
+    pub(crate) fn new(party_id: usize, test_setup: &'a TestSetup) -> Self {
+        Self {
+            party_id,
+            test_setup,
+            secret_manager: None,
+            skip_backfill: SkipBackfill::Yes,
+            cursor_service: TestChainCursorService::default(),
+        }
+    }
+
+    pub(crate) fn secret_manager(mut self, secret_manager: TestKeyGenSecretManager) -> Self {
+        self.secret_manager = Some(secret_manager);
+        self
+    }
+
+    pub(crate) fn skip_backfill(mut self, skip_backfill: SkipBackfill) -> Self {
+        self.skip_backfill = skip_backfill;
+        self
+    }
+
+    pub(crate) fn cursor_service(mut self, cursor_service: TestChainCursorService) -> Self {
+        self.cursor_service = cursor_service;
+        self
+    }
+
+    pub(crate) fn starting_cursor(mut self, cursor: ChainCursor) -> Self {
+        self.cursor_service = TestChainCursorService::with_cursor(cursor);
+        self
+    }
+
+    pub(crate) async fn build(self) -> eyre::Result<TestKeyGen> {
+        TestKeyGen::start_inner(
+            self.party_id,
+            self.test_setup,
+            self.skip_backfill,
+            self.secret_manager
+                .unwrap_or_else(|| TestKeyGenSecretManager::new(PEER_PRIVATE_KEYS[self.party_id])),
+            self.cursor_service,
+        )
+        .await
+    }
 }
 
 impl fmt::Debug for TestKeyGen {
@@ -41,7 +98,13 @@ impl fmt::Debug for TestKeyGen {
 }
 
 impl TestKeyGen {
-    pub(crate) async fn start(party_id: usize, test_setup: &TestSetup) -> eyre::Result<Self> {
+    async fn start_inner(
+        party_id: usize,
+        test_setup: &TestSetup,
+        skip_backfill: SkipBackfill,
+        secret_manager: TestKeyGenSecretManager,
+        cursor_service: TestChainCursorService,
+    ) -> eyre::Result<Self> {
         let TestSetup {
             anvil,
             oprf_key_registry,
@@ -53,8 +116,6 @@ impl TestKeyGen {
         assert!(party_id < 5, "can only spawn 5 key-gens");
         let private_key = PEER_PRIVATE_KEYS[party_id];
         let child_token = cancellation_token.child_token();
-        let secret_manager = TestKeyGenSecretManager::new(private_key);
-        let keygen_secret_manager: SecretManagerService = secret_manager.service();
         let (expected_threshold, expected_num_peers) = match test_setup.setup {
             DeploySetup::TwoThree => (2, 3),
             DeploySetup::ThreeFive => (3, 5),
@@ -75,15 +136,17 @@ impl TestKeyGen {
                 ws_rpc_url: anvil.ws_endpoint_url(),
             });
 
-        // anvil doesn't work with confirmations
         config.confirmations_for_transaction = 0;
         config.rpc_provider_config.chain_id = Some(31_337);
+        config.event_stream_config.skip_backfill = skip_backfill;
+        config.event_stream_config.confirmations_after_sync_block =
+            NonZeroUsize::try_from(2).expect("2 is non-zero");
 
         let started_services = StartedServices::new();
         let (router, key_gen_task) = start(
             config,
-            keygen_secret_manager,
-            TestChainCursorService::service(),
+            secret_manager.service(),
+            cursor_service.service(),
             started_services.clone(),
             child_token.clone(),
         )
@@ -97,9 +160,35 @@ impl TestKeyGen {
             secret_manager,
             server,
             key_gen_task,
+            cursor_service,
             started_services,
             cancellation_token: child_token,
         })
+    }
+
+    pub(crate) async fn start(party_id: usize, test_setup: &TestSetup) -> eyre::Result<Self> {
+        TestKeyGenBuilder::new(party_id, test_setup).build().await
+    }
+
+    pub(crate) async fn start_three_with_backfill(
+        test_setup: &TestSetup,
+    ) -> eyre::Result<[Self; 3]> {
+        let starting_cursor = ChainCursor::new(0, 1);
+        let (keygen0, keygen1, keygen2) = tokio::join!(
+            TestKeyGenBuilder::new(0, test_setup)
+                .skip_backfill(SkipBackfill::No)
+                .starting_cursor(starting_cursor)
+                .build(),
+            TestKeyGenBuilder::new(1, test_setup)
+                .skip_backfill(SkipBackfill::No)
+                .starting_cursor(starting_cursor)
+                .build(),
+            TestKeyGenBuilder::new(2, test_setup)
+                .skip_backfill(SkipBackfill::No)
+                .starting_cursor(starting_cursor)
+                .build(),
+        );
+        Ok([keygen0?, keygen1?, keygen2?])
     }
 
     pub(crate) async fn start_three(test_setup: &TestSetup) -> eyre::Result<[Self; 3]> {
@@ -120,6 +209,35 @@ impl TestKeyGen {
             Self::start(4, test_setup)
         );
         Ok([keygen0?, keygen1?, keygen2?, keygen3?, keygen4?])
+    }
+
+    pub(crate) async fn shutdown(
+        self,
+    ) -> eyre::Result<(usize, TestKeyGenSecretManager, TestChainCursorService)> {
+        let fut = async move {
+            self.cancellation_token.cancel();
+            self.key_gen_task.join().await?;
+            Ok((self.party_id, self.secret_manager, self.cursor_service))
+        };
+        tokio::time::timeout(TEST_TIMEOUT, fut)
+            .await
+            .context("Cannot shutdown in time")?
+    }
+
+    pub(crate) async fn restart(self, test_setup: &TestSetup) -> eyre::Result<TestKeyGen> {
+        let restart_fut = async {
+            self.cancellation_token.cancel();
+            self.key_gen_task.join().await?;
+            TestKeyGenBuilder::new(self.party_id, test_setup)
+                .skip_backfill(SkipBackfill::No)
+                .secret_manager(self.secret_manager)
+                .cursor_service(self.cursor_service)
+                .build()
+                .await
+        };
+        tokio::time::timeout(TEST_TIMEOUT, restart_fut)
+            .await
+            .context("Cannot restart in time")?
     }
 }
 
@@ -184,6 +302,53 @@ async fn test_keygen_works_two_three() -> eyre::Result<()> {
     setup.init_keygen(oprf_key_id).await?;
     let _oprf_public_key =
         keygen_asserts::all_have_key(&key_gens, oprf_key_id, ShareEpoch::default()).await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn test_keygen_works_when_init_before_start() -> eyre::Result<()> {
+    let setup =
+        TestSetup::with_mine_strategy(DeploySetup::TwoThree, MineStrategy::Interval(1)).await?;
+    let oprf_key_id = OprfKeyId::new(U160::from(42));
+    setup.init_keygen(oprf_key_id).await?;
+    let key_gens = TestKeyGen::start_three_with_backfill(&setup).await?;
+    let _oprf_public_key =
+        keygen_asserts::all_have_key(&key_gens, oprf_key_id, ShareEpoch::default()).await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn test_keygen_works_when_crashing_in_between() -> eyre::Result<()> {
+    let setup =
+        TestSetup::with_mine_strategy(DeploySetup::TwoThree, MineStrategy::Interval(1)).await?;
+    // start only two key-gens so that we don't go over round 1
+    let (keygen0, keygen1) =
+        tokio::join!(TestKeyGen::start(0, &setup), TestKeyGen::start(1, &setup));
+    // init a key-gen and wait for the two KeyGenConfirmations
+    let oprf_key_id = OprfKeyId::new(U160::from(42));
+    let round1_confirmations = setup
+        .expect_event(OprfKeyRegistry::KeyGenConfirmation::SIGNATURE_HASH, 2)
+        .await?;
+    setup.init_keygen(oprf_key_id).await?;
+    round1_confirmations.await?;
+    // cancel the key-gens
+    let keygen0 = keygen0?;
+    let keygen1 = keygen1?;
+
+    let (keygen0_restart, keygen1_restart) =
+        tokio::join!(keygen0.restart(&setup), keygen1.restart(&setup));
+
+    // start the third one
+    let keygen2 = TestKeyGenBuilder::new(2, &setup)
+        .skip_backfill(SkipBackfill::No)
+        .starting_cursor(ChainCursor::new(0, 1))
+        .build()
+        .await;
+
+    let key_gens = [keygen0_restart?, keygen1_restart?, keygen2?];
+    let _oprf_public_key =
+        keygen_asserts::all_have_key(&key_gens, oprf_key_id, ShareEpoch::default()).await?;
+
     Ok(())
 }
 
@@ -286,7 +451,7 @@ async fn test_reshare_emits_stuck_if_two_consumer() -> eyre::Result<()> {
     key_gens[1].secret_manager.clear();
 
     let signal = setup
-        .expect_event(OprfKeyRegistry::NotEnoughProducers::SIGNATURE_HASH)
+        .expect_event(OprfKeyRegistry::NotEnoughProducers::SIGNATURE_HASH, 1)
         .await?;
     setup.init_reshare(oprf_key_id).await?;
     signal.await.expect("Should receive signal");
@@ -378,5 +543,83 @@ async fn key_gen_dies_on_cancellation() -> eyre::Result<()> {
         .await
         .expect("Can shutdown in time")
         .expect("Was a graceful shutdown");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn test_keygen_works_when_all_three_crash() -> eyre::Result<()> {
+    let setup =
+        TestSetup::with_mine_strategy(DeploySetup::TwoThree, MineStrategy::Interval(1)).await?;
+    let (keygen0, keygen1, keygen2) = tokio::join!(
+        TestKeyGen::start(0, &setup),
+        TestKeyGen::start(1, &setup),
+        TestKeyGen::start(2, &setup)
+    );
+    let oprf_key_id = OprfKeyId::new(U160::from(42));
+    let round1_done = setup
+        .expect_event(OprfKeyRegistry::KeyGenConfirmation::SIGNATURE_HASH, 2)
+        .await?;
+    setup.init_keygen(oprf_key_id).await?;
+    round1_done.await?;
+    let (r0, r1, r2) = tokio::join!(
+        keygen0?.restart(&setup),
+        keygen1?.restart(&setup),
+        keygen2?.restart(&setup),
+    );
+    let key_gens = [r0?, r1?, r2?];
+    keygen_asserts::all_have_key(&key_gens, oprf_key_id, ShareEpoch::default()).await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn test_keygen_replays_deletion_via_backfill() -> eyre::Result<()> {
+    let setup =
+        TestSetup::with_mine_strategy(DeploySetup::TwoThree, MineStrategy::Interval(1)).await?;
+    let key_gens = TestKeyGen::start_three(&setup).await?;
+    let oprf_key_id = OprfKeyId::new(U160::from(42));
+    setup.init_keygen(oprf_key_id).await?;
+    keygen_asserts::all_have_key(&key_gens, oprf_key_id, ShareEpoch::default()).await?;
+
+    let [keygen0, _, _] = key_gens;
+    let (party_id, secret_manager, cursor_service) = keygen0.shutdown().await?;
+
+    setup.delete_oprf_key(oprf_key_id).await?;
+
+    let keygen0 = TestKeyGenBuilder::new(party_id, &setup)
+        .skip_backfill(SkipBackfill::No)
+        .secret_manager(secret_manager)
+        .cursor_service(cursor_service)
+        .build()
+        .await?;
+    keygen0
+        .secret_manager
+        .is_key_id_not_stored(oprf_key_id)
+        .await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn test_reshare_replayed_via_backfill() -> eyre::Result<()> {
+    let setup =
+        TestSetup::with_mine_strategy(DeploySetup::TwoThree, MineStrategy::Interval(1)).await?;
+    let key_gens = TestKeyGen::start_three(&setup).await?;
+    let oprf_key_id = OprfKeyId::new(U160::from(42));
+    setup.init_keygen(oprf_key_id).await?;
+    keygen_asserts::all_have_key(&key_gens, oprf_key_id, ShareEpoch::default()).await?;
+
+    let [keygen0, keygen1, keygen2] = key_gens;
+    let (party_id, secret_manager, cursor_service) = keygen0.shutdown().await?;
+
+    let epoch1 = ShareEpoch::default().next();
+    setup.init_reshare(oprf_key_id).await?;
+
+    let keygen0 = TestKeyGenBuilder::new(party_id, &setup)
+        .skip_backfill(SkipBackfill::No)
+        .secret_manager(secret_manager)
+        .cursor_service(cursor_service)
+        .build()
+        .await?;
+
+    keygen_asserts::all_have_key(&[keygen0, keygen1, keygen2], oprf_key_id, epoch1).await?;
     Ok(())
 }

--- a/oprf-key-gen/src/tests/mod.rs
+++ b/oprf-key-gen/src/tests/mod.rs
@@ -12,6 +12,7 @@ use oprf_test_utils::{OPRF_PEER_ADDRESS_0, TEST_TIMEOUT};
 use oprf_types::{OprfKeyId, ShareEpoch, chain::OprfKeyRegistry};
 use tokio_util::sync::CancellationToken;
 
+use crate::tests::keygen_test_secret_manager::TestChainCursorService;
 use crate::{
     KeyGenTasks,
     config::{OprfKeyGenServiceConfig, OprfKeyGenServiceConfigMandatoryValues},
@@ -82,6 +83,7 @@ impl TestKeyGen {
         let (router, key_gen_task) = start(
             config,
             keygen_secret_manager,
+            TestChainCursorService::service(),
             started_services.clone(),
             child_token.clone(),
         )

--- a/oprf-service/examples/deploy/docker-compose.yml
+++ b/oprf-service/examples/deploy/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     stop_grace_period: 1s
     ports:
       - "8545:8545"
-    command: anvil
+    entrypoint: []
+    command: anvil ${ANVIL_ARGS:-}
     environment:
       ANVIL_IP_ADDR: 0.0.0.0
 

--- a/oprf-service/src/services/secret_manager/postgres/tests.rs
+++ b/oprf-service/src/services/secret_manager/postgres/tests.rs
@@ -1,9 +1,9 @@
 use crate::secret_manager::{SecretManager, postgres::PostgresSecretManager};
 use alloy::primitives::U160;
 use ark_serialize::CanonicalSerialize;
-use nodes_common::postgres::PostgresConfig;
+use nodes_common::postgres::{PostgresConfig, SanitizedSchema};
 use oprf_core::ddlog_equality::shamir::DLogShareShamir;
-use oprf_test_utils::{OPRF_PEER_ADDRESS_0, TEST_SCHEMA};
+use oprf_test_utils::OPRF_PEER_ADDRESS_0;
 use oprf_types::{OprfKeyId, ShareEpoch, crypto::OprfPublicKey};
 use secrecy::SecretString;
 use sqlx::PgConnection;
@@ -15,17 +15,20 @@ fn to_db_ark_serialize_uncompressed<T: CanonicalSerialize>(t: &T) -> Vec<u8> {
     bytes
 }
 
-async fn postgres_secret_manager(connection_string: &str) -> eyre::Result<PostgresSecretManager> {
-    let mut pg_connection =
-        oprf_test_utils::open_pg_connection(connection_string, TEST_SCHEMA).await?;
+async fn postgres_secret_manager()
+-> eyre::Result<(PostgresSecretManager, &'static str, SanitizedSchema)> {
+    let conn = oprf_test_utils::shared_postgres_testcontainer().await?;
+    let schema = oprf_test_utils::next_test_schema();
+    let mut pg_connection = oprf_test_utils::open_pg_connection(conn, &schema.to_string()).await?;
     sqlx::migrate!("../oprf-key-gen/migrations")
         .run(&mut pg_connection)
         .await?;
-    PostgresSecretManager::init(&PostgresConfig::with_default_values(
-        SecretString::from(connection_string),
-        TEST_SCHEMA.parse().expect("Is a valid schema"),
+    let mgr = PostgresSecretManager::init(&PostgresConfig::with_default_values(
+        SecretString::from(conn.to_owned()),
+        schema.clone(),
     ))
-    .await
+    .await?;
+    Ok((mgr, conn, schema))
 }
 
 async fn insert_row(
@@ -82,8 +85,7 @@ async fn insert_address(address: &str, connection: &mut PgConnection) -> eyre::R
 
 #[tokio::test]
 async fn test_load_all_secret_empty() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
+    let (secret_manager, _, _) = postgres_secret_manager().await?;
     let key_material_store = secret_manager.load_secrets().await?;
     assert!(key_material_store.is_empty());
     Ok(())
@@ -91,8 +93,7 @@ async fn test_load_all_secret_empty() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn load_address_empty() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
+    let (secret_manager, _, _) = postgres_secret_manager().await?;
     let report = secret_manager
         .load_address()
         .await
@@ -106,10 +107,10 @@ async fn load_address_empty() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn load_address_corrupt() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
+    let (secret_manager, connection_string, schema) = postgres_secret_manager().await?;
 
-    let mut conn = oprf_test_utils::open_pg_connection(&connection_string, TEST_SCHEMA).await?;
+    let mut conn =
+        oprf_test_utils::open_pg_connection(connection_string, &schema.to_string()).await?;
     insert_address("SomethingThatIsNotAnAddress", &mut conn).await?;
 
     let report = secret_manager
@@ -122,11 +123,11 @@ async fn load_address_corrupt() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn load_address_success() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
+    let (secret_manager, connection_string, schema) = postgres_secret_manager().await?;
 
     let should_address = OPRF_PEER_ADDRESS_0;
-    let mut conn = oprf_test_utils::open_pg_connection(&connection_string, TEST_SCHEMA).await?;
+    let mut conn =
+        oprf_test_utils::open_pg_connection(connection_string, &schema.to_string()).await?;
     insert_address(&should_address.to_string(), &mut conn).await?;
 
     let is_address = secret_manager.load_address().await.expect("Should work");
@@ -136,11 +137,9 @@ async fn load_address_success() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn test_load_all_secret_three_shares() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    // runs migrations
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
-
-    let mut conn = oprf_test_utils::open_pg_connection(&connection_string, TEST_SCHEMA).await?;
+    let (secret_manager, connection_string, schema) = postgres_secret_manager().await?;
+    let mut conn =
+        oprf_test_utils::open_pg_connection(connection_string, &schema.to_string()).await?;
 
     let oprf_key_id0 = OprfKeyId::new(U160::from(42));
     let oprf_key_id1 = OprfKeyId::new(U160::from(128));
@@ -181,11 +180,9 @@ async fn test_load_all_secret_three_shares() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn test_get_oprf_key_material() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    // runs migrations
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
-
-    let mut conn = oprf_test_utils::open_pg_connection(&connection_string, TEST_SCHEMA).await?;
+    let (secret_manager, connection_string, schema) = postgres_secret_manager().await?;
+    let mut conn =
+        oprf_test_utils::open_pg_connection(connection_string, &schema.to_string()).await?;
 
     let oprf_key_id0 = OprfKeyId::new(U160::from(42));
     let oprf_key_id1 = OprfKeyId::new(U160::from(128));
@@ -251,8 +248,7 @@ async fn test_get_oprf_key_material() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn test_load_all_secret_with_deleted() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
+    let (secret_manager, connection_string, schema) = postgres_secret_manager().await?;
     let oprf_key_id0 = OprfKeyId::new(U160::from(42));
     let oprf_key_id1 = OprfKeyId::new(U160::from(128));
     let oprf_key_id2 = OprfKeyId::new(U160::from(6891));
@@ -266,7 +262,8 @@ async fn test_load_all_secret_with_deleted() -> eyre::Result<()> {
     let share1 = DLogShareShamir::from(rand::random::<ark_babyjubjub::Fr>());
     let share2 = DLogShareShamir::from(rand::random::<ark_babyjubjub::Fr>());
 
-    let mut conn = oprf_test_utils::open_pg_connection(&connection_string, TEST_SCHEMA).await?;
+    let mut conn =
+        oprf_test_utils::open_pg_connection(connection_string, &schema.to_string()).await?;
     insert_row(oprf_key_id0, share0.clone(), epoch0, public_key0, &mut conn).await?;
     insert_row(oprf_key_id1, share1.clone(), epoch1, public_key1, &mut conn).await?;
     insert_row(oprf_key_id2, share2.clone(), epoch2, public_key2, &mut conn).await?;
@@ -295,14 +292,14 @@ async fn test_load_all_secret_with_deleted() -> eyre::Result<()> {
 
 #[tokio::test]
 async fn test_get_deleted_secret() -> eyre::Result<()> {
-    let (_postgres, connection_string) = oprf_test_utils::postgres_testcontainer().await?;
-    let secret_manager = postgres_secret_manager(&connection_string).await?;
+    let (secret_manager, connection_string, schema) = postgres_secret_manager().await?;
     let oprf_key_id = OprfKeyId::new(U160::from(42));
     let public_key = OprfPublicKey::new(rand::random());
     let epoch = ShareEpoch::new(42);
     let share = DLogShareShamir::from(rand::random::<ark_babyjubjub::Fr>());
 
-    let mut conn = oprf_test_utils::open_pg_connection(&connection_string, TEST_SCHEMA).await?;
+    let mut conn =
+        oprf_test_utils::open_pg_connection(connection_string, &schema.to_string()).await?;
     insert_row(oprf_key_id, share.clone(), epoch, public_key, &mut conn).await?;
 
     delete_row(oprf_key_id, &mut conn).await?;

--- a/oprf-test-utils/Cargo.toml
+++ b/oprf-test-utils/Cargo.toml
@@ -38,6 +38,7 @@ futures = { workspace = true }
 groth16-material = { workspace = true, optional = true }
 groth16-sol = { workspace = true, optional = true }
 itertools.workspace = true
+nodes-common = { workspace = true, features = ["postgres"], optional = true }
 nodes-observability = { workspace = true, optional = true }
 oprf-core = { package = "taceo-oprf-core", path = "../oprf-core", version = "0.5" }
 oprf-types = { package = "taceo-oprf-types", path = "../oprf-types", version = "0.13" }
@@ -75,4 +76,4 @@ generate-test-transcript = [
   "dep:groth16-sol",
   "dep:nodes-observability"
 ]
-postgres-test-container = ["dep:sqlx", "dep:testcontainers-modules"]
+postgres-test-container = ["dep:sqlx", "dep:testcontainers-modules", "dep:nodes-common"]

--- a/oprf-test-utils/src/lib.rs
+++ b/oprf-test-utils/src/lib.rs
@@ -20,6 +20,6 @@ pub use secret_manager::postgres::*;
 #[cfg(feature = "ci")]
 pub const TEST_TIMEOUT: Duration = Duration::from_secs(120);
 #[cfg(not(feature = "ci"))]
-pub const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+pub const TEST_TIMEOUT: Duration = Duration::from_secs(20);
 
 pub use secret_manager::test_secret_manager;

--- a/oprf-test-utils/src/secret_manager.rs
+++ b/oprf-test-utils/src/secret_manager.rs
@@ -2,15 +2,49 @@ pub mod test_secret_manager;
 
 #[cfg(feature = "postgres-test-container")]
 pub mod postgres {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
     use eyre::Context as _;
+    use nodes_common::postgres::SanitizedSchema;
     use sqlx::{Connection as _, Executor as _, PgConnection};
     use testcontainers_modules::postgres::Postgres;
     use testcontainers_modules::testcontainers::ContainerAsync;
+    use tokio::sync::OnceCell;
 
     pub const TEST_ETH_PRIVATE_KEY: &str =
         "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba";
     pub const TEST_ETH_ADDRESS: &str = "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc";
-    pub const TEST_SCHEMA: &str = "test";
+
+    struct SharedPg {
+        _container: ContainerAsync<Postgres>,
+        connection_string: String,
+    }
+
+    static SHARED_PG: OnceCell<SharedPg> = OnceCell::const_new();
+    static SCHEMA_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    /// Returns a connection string to a process-wide shared Postgres container.
+    /// Started lazily on the first call; the container lives until process exit.
+    pub async fn shared_postgres_testcontainer() -> eyre::Result<&'static str> {
+        let shared = SHARED_PG
+            .get_or_try_init(|| async {
+                let (container, conn) = postgres_testcontainer().await?;
+                Ok::<_, eyre::Report>(SharedPg {
+                    _container: container,
+                    connection_string: conn,
+                })
+            })
+            .await?;
+        Ok(&shared.connection_string)
+    }
+
+    /// Returns a unique schema name for one test (`test_0`, `test_1`, …).
+    pub fn next_test_schema() -> SanitizedSchema {
+        let n = SCHEMA_COUNTER.fetch_add(1, Ordering::Relaxed);
+        format!("test_{n}")
+            .parse()
+            .expect("synthesized schema is always valid")
+    }
 
     pub async fn open_pg_connection(
         connection_string: &str,

--- a/oprf-test-utils/src/setup.rs
+++ b/oprf-test-utils/src/setup.rs
@@ -9,7 +9,7 @@ use alloy::{
     network::EthereumWallet,
     node_bindings::{Anvil, AnvilInstance},
     primitives::{Address, FixedBytes},
-    providers::{DynProvider, Provider as _, ProviderBuilder},
+    providers::{DynProvider, Provider as _, ProviderBuilder, ext::AnvilApi},
     rpc::types::Filter,
     signers::local::PrivateKeySigner,
 };
@@ -68,10 +68,24 @@ pub struct TestSetup {
     pub oprf_key_registry: Address,
     pub cancellation_token: CancellationToken,
     pub setup: DeploySetup,
+    pub mine_strategy: MineStrategy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MineStrategy {
+    Auto,
+    Interval(u64),
 }
 
 impl TestSetup {
     pub async fn new(setup: DeploySetup) -> eyre::Result<TestSetup> {
+        Self::with_mine_strategy(setup, MineStrategy::Auto).await
+    }
+
+    pub async fn with_mine_strategy(
+        setup: DeploySetup,
+        mine_strategy: MineStrategy,
+    ) -> eyre::Result<TestSetup> {
         let anvil = Anvil::new().spawn();
         let private_key = PrivateKeySigner::from_str(TACEO_ADMIN_PRIVATE_KEY)?;
         let wallet = EthereumWallet::from(private_key);
@@ -81,6 +95,7 @@ impl TestSetup {
             .await
             .context("while connecting to RPC")?
             .erased();
+
         let oprf_key_registry = match setup {
             DeploySetup::TwoThree => {
                 crate::deploy_oprf_key_registry_13(provider.clone(), TACEO_ADMIN_ADDRESS).await?
@@ -91,11 +106,19 @@ impl TestSetup {
         };
         crate::register_oprf_nodes(provider.clone(), oprf_key_registry, setup.addresses()).await?;
         let cancellation_token = CancellationToken::new();
+        // default is Auto
+        if let MineStrategy::Interval(secs) = mine_strategy {
+            provider
+                .anvil_set_interval_mining(secs)
+                .await
+                .context("while setting interval mining")?;
+        }
         Ok(TestSetup {
             anvil,
             provider,
             oprf_key_registry,
             cancellation_token,
+            mine_strategy,
             setup,
         })
     }
@@ -136,6 +159,7 @@ impl TestSetup {
     pub async fn expect_event(
         &self,
         signature_hash: FixedBytes<32>,
+        times: usize,
     ) -> eyre::Result<oneshot::Receiver<()>> {
         let filter = Filter::new()
             .address(self.oprf_key_registry)
@@ -145,13 +169,20 @@ impl TestSetup {
         let mut stream = sub.into_stream();
         let (tx, rx) = oneshot::channel();
         tokio::task::spawn(async move {
-            tokio::select! {
-                _ = stream.next() => {
-                    let _ = tx.send(());
+            let observed = tokio::time::timeout(crate::TEST_TIMEOUT, async {
+                let mut count = 0;
+                while stream.next().await.is_some() {
+                    count += 1;
+                    if count >= times {
+                        return true;
+                    }
                 }
-                _ = tokio::time::sleep(crate::TEST_TIMEOUT) => {
+                false
+            })
+            .await;
 
-                }
+            if observed == Ok(true) {
+                let _ = tx.send(());
             }
         });
         Ok(rx)


### PR DESCRIPTION
- **build(contract): bumped contracts to latest version**
- **refactor(key-gen)!: add backfill logic and restructure DB**
- **test: added backfill test script**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces persistent event backfill and restructures key-gen Postgres storage, which can affect correctness of on-chain event processing and state recovery across restarts. Risk is mitigated by new integration/unit tests but still touches core runtime behavior and DB migrations.
> 
> **Overview**
> **Key-gen now resumes missed on-chain events after restarts.** The key-gen `key_event_watcher` switches from ad-hoc `start_block` handling to `nodes_common::web3::event_stream`, loading a persisted `ChainCursor` on startup and storing an updated cursor after each processed log.
> 
> **Postgres storage is refactored and extended.** A new `chain_cursor` table/migration is added, a `ChainCursorStorage` trait (`services/event_cursor_store`) is introduced, and `oprf-key-gen` replaces the dedicated secret-manager DB type with a unified `PostgresDb` that implements both `SecretManager` and cursor persistence.
> 
> **Config/tests/deps updated accordingly.** `OprfKeyGenServiceConfig` gains `backfill` (`EventStreamConfig`) and removes `start_block`; binaries wire in the new cursor store; tests add crash/restart/backfill scenarios and move to a shared Postgres testcontainer with per-test schemas; workspace bumps `taceo-nodes-common`/`taceo-nodes-observability` and the deploy `docker-compose` allows passing `ANVIL_ARGS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74bca350fe366b3e3fc6a9e166d7f2a9f82a1b84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->