### PR TITLE
themis/cursor checkpoint

### DIFF
--- a/oprf-key-gen/src/config.rs
+++ b/oprf-key-gen/src/config.rs
@@ -119,6 +119,15 @@ pub struct OprfKeyGenServiceConfig {
     #[serde(default = "OprfKeyGenServiceConfig::default_i_am_alive_interval")]
     #[serde(with = "humantime_serde")]
     pub i_am_alive_interval: Duration,
+
+    /// Interval in which we persist a [`ChainCursor`] checkpoint.
+    ///
+    /// The implementation will fetch the current block number, then sleep for this configured period, and then call [`ChainCursorService::store_chain_cursor`] with the fetched block number. This should prevent very large backfills in case of idle key-gens.
+    ///
+    /// Defaults to `1 day`.
+    #[serde(default = "OprfKeyGenServiceConfig::default_cursor_checkpoint_interval")]
+    #[serde(with = "humantime_serde")]
+    pub cursor_checkpoint_interval: Duration,
 }
 
 /// Subset of [`OprfKeyGenServiceConfig`] containing all values that must be
@@ -197,6 +206,11 @@ impl OprfKeyGenServiceConfig {
         Duration::from_mins(1)
     }
 
+    /// Default cursor checkpoint interval (`1 day`).
+    fn default_cursor_checkpoint_interval() -> Duration {
+        Duration::from_hours(24)
+    }
+
     /// Construct with all default values except required fields.
     #[must_use]
     pub fn with_default_values(args: OprfKeyGenServiceConfigMandatoryValues) -> Self {
@@ -229,6 +243,7 @@ impl OprfKeyGenServiceConfig {
             max_tries_fetching_receipt: Self::default_max_tries_fetching_receipt(),
             sleep_between_get_receipt: Self::default_sleep_between_get_receipt(),
             event_stream_config: EventStreamConfig::default(),
+            cursor_checkpoint_interval: Self::default_cursor_checkpoint_interval(),
         }
     }
 }

--- a/oprf-key-gen/src/config.rs
+++ b/oprf-key-gen/src/config.rs
@@ -120,9 +120,9 @@ pub struct OprfKeyGenServiceConfig {
     #[serde(with = "humantime_serde")]
     pub i_am_alive_interval: Duration,
 
-    /// Interval in which we persist a [`ChainCursor`] checkpoint.
+    /// Interval in which we persist a [`ChainCursor`](nodes_common::web3::event_stream::ChainCursor) checkpoint.
     ///
-    /// The implementation will fetch the current block number, then sleep for this configured period, and then call [`ChainCursorService::store_chain_cursor`] with the fetched block number. This should prevent very large backfills in case of idle key-gens.
+    /// The implementation will fetch the current block number, then sleep for this configured period, and then call [`ChainCursorStorage::store_chain_cursor`](crate::event_cursor_store::ChainCursorStorage::store_chain_cursor) with the fetched block number. This should prevent very large backfills in case of idle key-gens.
     ///
     /// Defaults to `1 day`.
     #[serde(default = "OprfKeyGenServiceConfig::default_cursor_checkpoint_interval")]

--- a/oprf-key-gen/src/lib.rs
+++ b/oprf-key-gen/src/lib.rs
@@ -48,7 +48,7 @@ use alloy::{
 };
 use eyre::Context as _;
 use groth16_material::circom::CircomGroth16MaterialBuilder;
-use nodes_common::web3::{self};
+use nodes_common::web3::{self, event_stream::ChainCursor};
 use oprf_types::{chain::OprfKeyRegistry, crypto::PartyId};
 use secrecy::ExposeSecret;
 use tokio_util::sync::CancellationToken;
@@ -70,6 +70,8 @@ pub use services::secret_manager;
 /// The tasks spawned by the key-gen library. Should call [`KeyGenTasks::join`] when shutting down for graceful shutdown.
 pub struct KeyGenTasks {
     key_event_watcher: tokio::task::JoinHandle<eyre::Result<()>>,
+    i_am_alive_task: tokio::task::JoinHandle<()>,
+    cursor_checkpoint_task: tokio::task::JoinHandle<()>,
 
     // keep the providers alive as long as the tasks are
     _http_rpc_provider: web3::HttpRpcProvider,
@@ -83,6 +85,8 @@ impl KeyGenTasks {
     /// Returns the error from the inner tasks or an error if the task panicked.
     pub async fn join(self) -> eyre::Result<()> {
         self.key_event_watcher.await??;
+        self.i_am_alive_task.await?;
+        self.cursor_checkpoint_task.await?;
         Ok(())
     }
 }
@@ -256,7 +260,7 @@ pub async fn start(
                 ws_rpc_provider: ws_rpc_provider.clone(),
                 contract_address,
                 dlog_secret_gen_service,
-                chain_cursor_service,
+                chain_cursor_service: chain_cursor_service.clone(),
                 start_signal: started_services.new_service(),
                 transaction_handler,
                 event_stream_config: config.event_stream_config,
@@ -267,9 +271,16 @@ pub async fn start(
 
     let key_gen_router = api::routes(address, started_services.clone());
 
-    tokio::task::spawn(start_i_am_alive_task(
+    let i_am_alive_task = tokio::task::spawn(start_i_am_alive_task(
         started_services,
         config.i_am_alive_interval,
+        cancellation_token.clone(),
+    ));
+
+    let cursor_checkpoint_task = tokio::task::spawn(start_cursor_checkpoint_task(
+        config.cursor_checkpoint_interval,
+        http_rpc_provider.clone(),
+        chain_cursor_service,
         cancellation_token,
     ));
 
@@ -277,10 +288,54 @@ pub async fn start(
         key_gen_router,
         KeyGenTasks {
             key_event_watcher,
+            i_am_alive_task,
+            cursor_checkpoint_task,
             _http_rpc_provider: http_rpc_provider,
             _ws_rpc_provider: ws_rpc_provider,
         },
     ))
+}
+
+async fn start_cursor_checkpoint_task(
+    checkpoint_interval: Duration,
+    rpc_provider: web3::HttpRpcProvider,
+    chain_cursor_service: ChainCursorService,
+    cancellation_token: CancellationToken,
+) {
+    let mut interval = tokio::time::interval(checkpoint_interval);
+    // first interval ticks immediately
+    interval.tick().await;
+    tracing::info!("starting cursor checkpoint task");
+    loop {
+        let checkpoint = match rpc_provider.get_block_number().await {
+            Ok(checkpoint) => Some(ChainCursor::new(checkpoint, 0)),
+            Err(err) => {
+                tracing::warn!(%err, "cannot fetch checkpoint for cursor");
+                tracing::warn!("tying again in {checkpoint_interval:?}");
+                None
+            }
+        };
+        tokio::select! {
+            _ = interval.tick() => {
+            }
+            () = cancellation_token.cancelled() => {
+                break;
+            }
+        }
+        if let Some(checkpoint) = checkpoint {
+            tracing::info!("persisting chain-cursor checkpoint: {checkpoint}");
+            match chain_cursor_service.store_chain_cursor(checkpoint).await {
+                Ok(()) => {
+                    tracing::info!("successfully called store_chain_cursor");
+                }
+                Err(err) => {
+                    tracing::warn!(%err, "cannot persist checkpoint to DB");
+                    tracing::warn!("tying again in {checkpoint_interval:?}");
+                }
+            }
+        }
+    }
+    tracing::info!("shutting down cursor checkpoint task");
 }
 
 async fn start_i_am_alive_task(

--- a/oprf-key-gen/src/postgres.rs
+++ b/oprf-key-gen/src/postgres.rs
@@ -137,11 +137,13 @@ impl ChainCursorStorage for PostgresDb {
             .await?)
     }
 
+    #[instrument(level = "debug", skip_all, fields(chain_cursor=%chain_cursor))]
     #[allow(
         clippy::cast_possible_wrap,
         reason = "We want to wrap the value because sqlx can only store i64, but we have u64"
     )]
     async fn store_chain_cursor(&self, chain_cursor: ChainCursor) -> eyre::Result<()> {
+        tracing::trace!("trying to store chain cursor...");
         let store_chain_cursor = || async {
             Ok(sqlx::query(
                 "
@@ -161,7 +163,7 @@ impl ChainCursorStorage for PostgresDb {
             .with_retry("store-chain-cursor", store_chain_cursor)
             .await?;
         if rows_affected == 0 {
-            tracing::warn!("did not update chain-event cursor - refusing to rollback");
+            tracing::info!("did not update chain-event cursor - refusing to rollback");
         }
         Ok(())
     }

--- a/oprf-key-gen/src/tests/mod.rs
+++ b/oprf-key-gen/src/tests/mod.rs
@@ -656,6 +656,7 @@ async fn test_cursor_checkpoint_persists() -> eyre::Result<()> {
         }
         eyre::Ok(())
     })
-    .await??;
+    .await
+    .context("while waiting for cursor-service to store checkpoint")??;
     Ok(())
 }

--- a/oprf-key-gen/src/tests/mod.rs
+++ b/oprf-key-gen/src/tests/mod.rs
@@ -17,6 +17,7 @@ use oprf_test_utils::TEST_TIMEOUT;
 use oprf_types::{OprfKeyId, ShareEpoch, chain::OprfKeyRegistry};
 use tokio_util::sync::CancellationToken;
 
+use crate::services::event_cursor_store::ChainCursorStorage;
 use crate::tests::keygen_test_secret_manager::TestChainCursorService;
 use crate::{
     KeyGenTasks,
@@ -43,6 +44,7 @@ pub(crate) struct TestKeyGenBuilder<'a> {
     secret_manager: Option<TestKeyGenSecretManager>,
     skip_backfill: SkipBackfill,
     cursor_service: TestChainCursorService,
+    cursor_checkpoint_interval: Option<Duration>,
 }
 
 impl<'a> TestKeyGenBuilder<'a> {
@@ -53,6 +55,7 @@ impl<'a> TestKeyGenBuilder<'a> {
             secret_manager: None,
             skip_backfill: SkipBackfill::Yes,
             cursor_service: TestChainCursorService::default(),
+            cursor_checkpoint_interval: None,
         }
     }
 
@@ -76,6 +79,11 @@ impl<'a> TestKeyGenBuilder<'a> {
         self
     }
 
+    pub(crate) fn cursor_checkpoint_interval(mut self, interval: Duration) -> Self {
+        self.cursor_checkpoint_interval = Some(interval);
+        self
+    }
+
     pub(crate) async fn build(self) -> eyre::Result<TestKeyGen> {
         TestKeyGen::start_inner(
             self.party_id,
@@ -84,6 +92,7 @@ impl<'a> TestKeyGenBuilder<'a> {
             self.secret_manager
                 .unwrap_or_else(|| TestKeyGenSecretManager::new(PEER_PRIVATE_KEYS[self.party_id])),
             self.cursor_service,
+            self.cursor_checkpoint_interval,
         )
         .await
     }
@@ -104,6 +113,7 @@ impl TestKeyGen {
         skip_backfill: SkipBackfill,
         secret_manager: TestKeyGenSecretManager,
         cursor_service: TestChainCursorService,
+        cursor_checkpoint_interval: Option<Duration>,
     ) -> eyre::Result<Self> {
         let TestSetup {
             anvil,
@@ -141,6 +151,9 @@ impl TestKeyGen {
         config.event_stream_config.skip_backfill = skip_backfill;
         config.event_stream_config.confirmations_after_sync_block =
             NonZeroUsize::try_from(2).expect("2 is non-zero");
+        if let Some(interval) = cursor_checkpoint_interval {
+            config.cursor_checkpoint_interval = interval;
+        }
 
         let started_services = StartedServices::new();
         let (router, key_gen_task) = start(
@@ -621,5 +634,28 @@ async fn test_reshare_replayed_via_backfill() -> eyre::Result<()> {
         .await?;
 
     keygen_asserts::all_have_key(&[keygen0, keygen1, keygen2], oprf_key_id, epoch1).await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_cursor_checkpoint_persists() -> eyre::Result<()> {
+    let setup =
+        TestSetup::with_mine_strategy(DeploySetup::TwoThree, MineStrategy::Interval(1)).await?;
+    let key_gen = TestKeyGenBuilder::new(0, &setup)
+        .cursor_checkpoint_interval(Duration::from_millis(100))
+        .build()
+        .await?;
+
+    let cursor_service = key_gen.cursor_service.clone();
+    tokio::time::timeout(TEST_TIMEOUT, async {
+        loop {
+            if cursor_service.load_chain_cursor().await?.block() > 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        eyre::Ok(())
+    })
+    .await??;
     Ok(())
 }

--- a/scripts/run-setup.sh
+++ b/scripts/run-setup.sh
@@ -32,11 +32,10 @@ main() {
     require_setup_commands
     validate_peer_config
     reset_log_dir
-
-    compose_up_anvil_postgres
-
+    
     trap setup_teardown EXIT SIGINT SIGTERM
 
+    compose_up_anvil_postgres
     run_deploy
 
     if [[ "$RUN_MODE" == "e2e-test" ]]; then


### PR DESCRIPTION
- **feat(key-gen): add cursor checkpoint task**
- **test(key-gen): add test for cursor checkpoint**
- **chore: move trap in run-setup before docker-compose**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new background task that periodically queries the chain head and writes cursor checkpoints to Postgres, which could affect backfill behavior and introduce extra RPC/DB load if misconfigured.
> 
> **Overview**
> Adds a configurable `cursor_checkpoint_interval` (default **1 day**) to periodically persist a chain cursor checkpoint, reducing large backfills after long idle periods.
> 
> `start()` now spawns and tracks a new cursor-checkpoint task (alongside the existing liveness task) that fetches the current block number and calls `store_chain_cursor` until cancelled. Postgres cursor writes get extra instrumentation and downgrade the “refusing to rollback” log from warn to info.
> 
> Tests extend the key-gen test builder to override the checkpoint interval and add a new test ensuring checkpoints are persisted, and `run-setup.sh` moves the teardown trap earlier to cover docker-compose startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4945568583e04150b63ef341b8a0a506277dcf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->