### PR TITLE
themis/transaction handlerv12[TAC-593][TAC-130]

### DIFF
--- a/oprf-key-gen/src/config.rs
+++ b/oprf-key-gen/src/config.rs
@@ -24,6 +24,7 @@
 //! | `max_tries_fetching_receipt`             | 5           |
 //! | `sleep_between_get_receipt`              | 5 s         |
 //! | `i_am_alive_interval`                    | 60 s        |
+//! | `cursor_checkpoint_interval`             | 1 day       |
 
 use std::num::NonZeroU16;
 use std::{path::PathBuf, time::Duration};
@@ -123,6 +124,8 @@ pub struct OprfKeyGenServiceConfig {
     /// Interval in which we persist a [`ChainCursor`](nodes_common::web3::event_stream::ChainCursor) checkpoint.
     ///
     /// The implementation will fetch the current block number, then sleep for this configured period, and then call [`ChainCursorStorage::store_chain_cursor`](crate::event_cursor_store::ChainCursorStorage::store_chain_cursor) with the fetched block number. This should prevent very large backfills in case of idle key-gens.
+    ///
+    /// This should not be smaller than 12 hours. The implementation expect that the block fetched in this interval is for sure already handled. Setting this to a small value (like 5 seconds) might result in loss of events.
     ///
     /// Defaults to `1 day`.
     #[serde(default = "OprfKeyGenServiceConfig::default_cursor_checkpoint_interval")]

--- a/oprf-key-gen/src/lib.rs
+++ b/oprf-key-gen/src/lib.rs
@@ -248,6 +248,7 @@ pub async fn start(
         max_gas_per_transaction: config.max_gas_per_transaction,
         rpc_provider: http_rpc_provider.clone(),
         wallet_address: address,
+        contract_address: config.oprf_key_registry_contract,
     });
 
     tracing::info!("spawning key event watcher..");

--- a/oprf-key-gen/src/lib.rs
+++ b/oprf-key-gen/src/lib.rs
@@ -265,6 +265,7 @@ pub async fn start(
                 start_signal: started_services.new_service(),
                 transaction_handler,
                 event_stream_config: config.event_stream_config,
+                threshold: config.expected_threshold,
                 cancellation_token,
             },
         )

--- a/oprf-key-gen/src/lib.rs
+++ b/oprf-key-gen/src/lib.rs
@@ -29,9 +29,6 @@ use std::{str::FromStr as _, time::Duration};
 
 use crate::{
     config::OprfKeyGenServiceConfig,
-    metrics::{
-        METRICS_ATTRID_WALLET_ADDRESS, METRICS_ID_I_AM_ALIVE, METRICS_ID_KEY_GEN_WALLET_BALANCE,
-    },
     services::{
         event_cursor_store::ChainCursorService,
         secret_gen::DLogSecretGenService,
@@ -40,7 +37,6 @@ use crate::{
     },
 };
 use alloy::{
-    consensus::constants::ETH_TO_WEI,
     network::EthereumWallet,
     primitives::Address,
     providers::{DynProvider, Provider as _, ProviderBuilder, WsConnect},
@@ -216,13 +212,10 @@ pub async fn start(
         .get_balance(address)
         .await
         .context("while get_balance")?;
-    tracing::info!(
-        "wallet balance: {} ETH",
-        alloy::primitives::utils::format_ether(balance)
-    );
-    #[allow(clippy::cast_precision_loss,reason="we must use f64 due to API limitations")]
-    ::metrics::gauge!(METRICS_ID_KEY_GEN_WALLET_BALANCE, METRICS_ATTRID_WALLET_ADDRESS => address.to_string())
-        .set(f64::from(balance) / ETH_TO_WEI as f64);
+    let balance = alloy::primitives::utils::format_ether(balance);
+
+    tracing::info!("wallet balance: {balance} ETH");
+    metrics::wallet::set_wallet_balance(&balance);
 
     contract_sanity_checks(&http_rpc_provider, address, &config)
         .await
@@ -351,7 +344,7 @@ async fn start_i_am_alive_task(
         tokio::select! {
            _ = interval.tick() => {
                 if started_services.all_started() {
-                    ::metrics::counter!(METRICS_ID_I_AM_ALIVE).increment(1);
+                    metrics::health::inc_i_am_alive();
                 }
            },
            () = cancellation_token.cancelled() => {

--- a/oprf-key-gen/src/metrics.rs
+++ b/oprf-key-gen/src/metrics.rs
@@ -1,132 +1,155 @@
-//! Metrics definitions for the OPRF service.
+//! Metrics definitions for the OPRF key-gen service.
 //!
-//! This module defines all metrics keys used by the service and
+//! This module defines all metrics keys used by the key-gen node and
 //! provides a helper [`describe_metrics`] to set metadata for
 //! each metric using the `metrics` crate.
-
-/// Attribute ID attached to `KEY_GEN_ROUND`* metrics distinguishing `key_gen` vs reshare
-pub(crate) const METRICS_ATTRID_PROTOCOL: &str = "protocol";
-/// Attribute ID attached to `KEY_GEN_ROUND`* metrics distinguishing producer vs consumer
-pub(crate) const METRICS_ATTRID_ROLE: &str = "role";
-/// Attribute ID attached to `METRICS_ID_KEY_GEN_WALLET_BALANCE` metric to easily see wallet address
-pub(crate) const METRICS_ATTRID_WALLET_ADDRESS: &str = "wallet_address";
-
-/// Attribute value for ROLE describing a producer
-pub(crate) const METRICS_ATTRVAL_ROLE_PRODUCER: &str = "producer";
-/// Attribute value for ROLE describing a consumer
-pub(crate) const METRICS_ATTRVAL_ROLE_CONSUMER: &str = "consumer";
-
-/// Attribute value for PROTOCOL describing `key_gen`
-pub(crate) const METRICS_ATTRVAL_PROTOCOL_KEY_GEN: &str = "key_gen";
-/// Attribute value for PROTOCOL describing reshare
-pub(crate) const METRICS_ATTRVAL_PROTOCOL_RESHARE: &str = "reshare";
-
-/// Event signaling that the key-gen is alive
-pub(crate) const METRICS_ID_I_AM_ALIVE: &str = "taceo.oprf.key_gen.i.am.alive";
-
-/// Observed event for start of round 1
-pub(crate) const METRICS_ID_KEY_GEN_ROUND_1_START: &str = "taceo.oprf.key_gen.round_1.start";
-/// Finished processing round 1 on our side
-pub(crate) const METRICS_ID_KEY_GEN_ROUND_1_FINISH: &str = "taceo.oprf.key_gen.round_1.finish";
-/// Observed event for start of round 2
-pub(crate) const METRICS_ID_KEY_GEN_ROUND_2_START: &str = "taceo.oprf.key_gen.round_2.start";
-/// Finished processing round 2 on our side
-pub(crate) const METRICS_ID_KEY_GEN_ROUND_2_FINISH: &str = "taceo.oprf.key_gen.round_2.finish";
-/// Observed event for start of round 3
-pub(crate) const METRICS_ID_KEY_GEN_ROUND_3_START: &str = "taceo.oprf.key_gen.round_3.start";
-/// Finished processing round 3 on our side
-pub(crate) const METRICS_ID_KEY_GEN_ROUND_3_FINISH: &str = "taceo.oprf.key_gen.round_3.finish";
-/// Observed event for start of round 4
-pub(crate) const METRICS_ID_KEY_GEN_ROUND_4_START: &str = "taceo.oprf.key_gen.round_4.start";
-/// Finished processing round 4 on our side
-pub(crate) const METRICS_ID_KEY_GEN_ROUND_4_FINISH: &str = "taceo.oprf.key_gen.round_4.finish";
-/// Observed event for start of a deletion
-pub(crate) const METRICS_ID_KEY_GEN_DELETION: &str = "taceo.oprf.key_gen.deletion";
-/// Observed not enough producers event
-pub(crate) const METRICS_ID_KEY_GEN_NOT_ENOUGH_PRODUCERS: &str =
-    "taceo.oprf.key_gen.not_enough_producers";
-
-/// Observed event for keygen abort
-pub(crate) const METRICS_ID_KEY_GEN_ABORT: &str = "taceo.oprf.key_gen.abort";
-
-/// Balance of the wallet used for key generation
-pub(crate) const METRICS_ID_KEY_GEN_WALLET_BALANCE: &str = "taceo.oprf.key_gen.wallet_balance";
-
-/// Gas price from the transactions
-pub(crate) const METRICS_ID_GAS_PRICE: &str = "taceo.oprf.key_gen.transaction.cost.gas_price";
 
 /// Describe all metrics used by the service.
 ///
 /// This calls the `describe_*` functions from the `metrics` crate to set metadata on the different metrics.
 pub fn describe_metrics() {
-    metrics::describe_counter!(
-        METRICS_ID_I_AM_ALIVE,
-        metrics::Unit::Count,
-        "I am alive metric. Used to measure liveness in datadog"
-    );
-    metrics::describe_counter!(
-        METRICS_ID_KEY_GEN_ROUND_1_START,
-        metrics::Unit::Count,
-        "Number of observed round 1 events for key_gen/reshare"
-    );
-    metrics::describe_counter!(
-        METRICS_ID_KEY_GEN_ROUND_1_FINISH,
-        metrics::Unit::Count,
-        "Number of finished round 1 steps of key_gen/reshare"
-    );
-    metrics::describe_counter!(
-        METRICS_ID_KEY_GEN_ROUND_2_START,
-        metrics::Unit::Count,
-        "Number of observed round 2 events for key_gen/reshare"
-    );
-    metrics::describe_counter!(
-        METRICS_ID_KEY_GEN_ROUND_2_FINISH,
-        metrics::Unit::Count,
-        "Number of finished round 2 steps of key_gen/reshare"
-    );
-    metrics::describe_counter!(
-        METRICS_ID_KEY_GEN_ROUND_3_START,
-        metrics::Unit::Count,
-        "Number of observed round 3 events for key_gen/reshare"
-    );
-    metrics::describe_counter!(
-        METRICS_ID_KEY_GEN_ROUND_3_FINISH,
-        metrics::Unit::Count,
-        "Number of finished round 3 steps of key_gen/reshare"
-    );
-    metrics::describe_counter!(
-        METRICS_ID_KEY_GEN_ROUND_4_START,
-        metrics::Unit::Count,
-        "Number of observed round 4 events for key_gen/reshare"
-    );
-    metrics::describe_counter!(
-        METRICS_ID_KEY_GEN_ROUND_4_FINISH,
-        metrics::Unit::Count,
-        "Number of finished round 4 steps of key_gen/reshare"
-    );
-    metrics::describe_counter!(
-        METRICS_ID_KEY_GEN_DELETION,
-        metrics::Unit::Count,
-        "Number of observed deletion events"
-    );
-    metrics::describe_counter!(
-        METRICS_ID_KEY_GEN_NOT_ENOUGH_PRODUCERS,
-        metrics::Unit::Count,
-        "Number of observed not enough producers event"
-    );
-    metrics::describe_counter!(
-        METRICS_ID_KEY_GEN_ABORT,
-        metrics::Unit::Count,
-        "Number of observed abort events"
-    );
-    metrics::describe_gauge!(
-        METRICS_ID_KEY_GEN_WALLET_BALANCE,
-        metrics::Unit::Count,
-        "Balance of the wallet used for key generation in GWEI"
-    );
-    metrics::describe_gauge!(
-        METRICS_ID_GAS_PRICE,
-        metrics::Unit::Count,
-        "Gas price of the transactions in WEI"
-    );
+    health::describe_metrics();
+    wallet::describe_metrics();
+    chain_events::describe_metrics();
+}
+
+pub(crate) mod health {
+
+    const METRICS_ID_I_AM_ALIVE: &str = "taceo.oprf.key_gen.i.am.alive";
+
+    pub(super) fn describe_metrics() {
+        metrics::describe_counter!(
+            METRICS_ID_I_AM_ALIVE,
+            metrics::Unit::Count,
+            "I am alive metric. Used to measure liveness in datadog"
+        );
+    }
+
+    pub(crate) fn inc_i_am_alive() {
+        metrics::counter!(METRICS_ID_I_AM_ALIVE).increment(1);
+    }
+}
+
+pub(crate) mod wallet {
+
+    const METRICS_ID_KEY_GEN_WALLET_BALANCE: &str = "taceo.oprf.key_gen.wallet.balance";
+    const METRICS_ID_GAS_PRICE: &str = "taceo.oprf.key_gen.wallet.transaction.gas_price";
+
+    pub(super) fn describe_metrics() {
+        metrics::describe_gauge!(
+            METRICS_ID_KEY_GEN_WALLET_BALANCE,
+            metrics::Unit::Count,
+            "Balance of the wallet used for key generation in ETH"
+        );
+
+        metrics::describe_gauge!(
+            METRICS_ID_GAS_PRICE,
+            metrics::Unit::Count,
+            "Gas price of the transactions in WEI"
+        );
+    }
+
+    pub(crate) fn set_wallet_balance(balance_eth: &str) {
+        metrics::gauge!(METRICS_ID_KEY_GEN_WALLET_BALANCE)
+            .set(balance_eth.parse::<f64>().unwrap_or(f64::NAN));
+    }
+
+    pub(crate) fn set_gas_price_from_wei(gas_price_wei: u128) {
+        let gas_price_wei = gas_price_wei.to_string().parse::<f64>().unwrap_or(f64::NAN);
+        metrics::gauge!(METRICS_ID_GAS_PRICE).set(gas_price_wei);
+    }
+}
+
+pub(crate) mod chain_events {
+    use nodes_common::web3::event_stream::ChainCursor;
+
+    const METRIC_EVENT_COUNTER: &str = "taceo.oprf.key_gen.chain.events";
+
+    const ATTR_TYPE_EVENT: &str = "type";
+    const ATTR_EVENT_KEYGEN_ROUND1: &str = "round1.keygen";
+    const ATTR_EVENT_RESHARE_ROUND1: &str = "round1.reshare";
+    const ATTR_EVENT_ROUND2: &str = "round2";
+    const ATTR_EVENT_ROUND3: &str = "round3";
+    const ATTR_EVENT_FINALIZE: &str = "finalize";
+    const ATTR_EVENT_DELETE: &str = "delete";
+    const ATTR_EVENT_ABORT: &str = "abort";
+    const ATTR_EVENT_NOT_ENOUGH_PRODUCERS: &str = "not-enough-producers";
+
+    const METRIC_PRODUCER_ROLE: &str = "taceo.oprf.key_gen.role.producer";
+    const METRIC_CONSUMER_ROLE: &str = "taceo.oprf.key_gen.role.consumer";
+    const METRIC_CURRENT_BLOCK: &str = "taceo.oprf.key_gen.block.number";
+
+    pub(super) fn describe_metrics() {
+        metrics::describe_counter!(
+            METRIC_EVENT_COUNTER,
+            metrics::Unit::Count,
+            "Number of observed chain events successfully handled by this node"
+        );
+
+        metrics::describe_counter!(
+            METRIC_PRODUCER_ROLE,
+            metrics::Unit::Count,
+            "Number of time the node participated as PRODUCER in the key-gen protocol"
+        );
+
+        metrics::describe_counter!(
+            METRIC_CONSUMER_ROLE,
+            metrics::Unit::Count,
+            "Number of time the node participated as CONSUMER in the key-gen protocol"
+        );
+
+        metrics::describe_counter!(
+            METRIC_CURRENT_BLOCK,
+            metrics::Unit::Count,
+            "Last block where we observed a key-gen event"
+        );
+    }
+
+    pub(crate) fn inc_keygen_round1() {
+        metrics::counter!(METRIC_EVENT_COUNTER, ATTR_TYPE_EVENT => ATTR_EVENT_KEYGEN_ROUND1)
+            .increment(1);
+    }
+
+    pub(crate) fn inc_reshare_round1() {
+        metrics::counter!(METRIC_EVENT_COUNTER, ATTR_TYPE_EVENT => ATTR_EVENT_RESHARE_ROUND1)
+            .increment(1);
+    }
+
+    pub(crate) fn inc_round2() {
+        metrics::counter!(METRIC_EVENT_COUNTER, ATTR_TYPE_EVENT => ATTR_EVENT_ROUND2).increment(1);
+    }
+
+    pub(crate) fn inc_round3() {
+        metrics::counter!(METRIC_EVENT_COUNTER, ATTR_TYPE_EVENT => ATTR_EVENT_ROUND3).increment(1);
+    }
+
+    pub(crate) fn inc_finalize() {
+        metrics::counter!(METRIC_EVENT_COUNTER, ATTR_TYPE_EVENT => ATTR_EVENT_FINALIZE)
+            .increment(1);
+    }
+
+    pub(crate) fn inc_delete() {
+        metrics::counter!(METRIC_EVENT_COUNTER, ATTR_TYPE_EVENT => ATTR_EVENT_DELETE).increment(1);
+    }
+
+    pub(crate) fn inc_abort() {
+        metrics::counter!(METRIC_EVENT_COUNTER, ATTR_TYPE_EVENT => ATTR_EVENT_ABORT).increment(1);
+    }
+
+    pub(crate) fn inc_not_enough_producers() {
+        metrics::counter!(METRIC_EVENT_COUNTER, ATTR_TYPE_EVENT => ATTR_EVENT_NOT_ENOUGH_PRODUCERS)
+            .increment(1);
+    }
+
+    pub(crate) fn inc_producer() {
+        metrics::counter!(METRIC_PRODUCER_ROLE).increment(1);
+    }
+
+    pub(crate) fn inc_consumer() {
+        metrics::counter!(METRIC_CONSUMER_ROLE).increment(1);
+    }
+
+    pub(crate) fn record_current_block(chain_cursor: ChainCursor) {
+        metrics::counter!(METRIC_CURRENT_BLOCK).absolute(chain_cursor.block());
+    }
 }

--- a/oprf-key-gen/src/metrics.rs
+++ b/oprf-key-gen/src/metrics.rs
@@ -98,7 +98,7 @@ pub(crate) mod chain_events {
             "Number of time the node participated as CONSUMER in the key-gen protocol"
         );
 
-        metrics::describe_counter!(
+        metrics::describe_gauge!(
             METRIC_CURRENT_BLOCK,
             metrics::Unit::Count,
             "Last block where we observed a key-gen event"
@@ -149,7 +149,11 @@ pub(crate) mod chain_events {
         metrics::counter!(METRIC_CONSUMER_ROLE).increment(1);
     }
 
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "We accept precision loss as we don't expect to have a block number > f64::MAX"
+    )]
     pub(crate) fn record_current_block(chain_cursor: ChainCursor) {
-        metrics::counter!(METRIC_CURRENT_BLOCK).absolute(chain_cursor.block());
+        metrics::gauge!(METRIC_CURRENT_BLOCK).set(chain_cursor.block() as f64);
     }
 }

--- a/oprf-key-gen/src/postgres.rs
+++ b/oprf-key-gen/src/postgres.rs
@@ -292,7 +292,7 @@ impl SecretManager for PostgresDb {
         &self,
         oprf_key_id: OprfKeyId,
         pending_epoch: ShareEpoch,
-    ) -> secret_manager::Result<Option<KeyGenIntermediateValues>> {
+    ) -> secret_manager::Result<KeyGenIntermediateValues> {
         tracing::trace!("trying to fetch intermediates...");
 
         let fetch_keygen = || async {
@@ -313,16 +313,10 @@ impl SecretManager for PostgresDb {
             .transpose()
         };
 
-        let maybe_intermediates = self
+        Ok(self
             .with_retry("fetch-keygen-intermediates", fetch_keygen)
-            .await?;
-
-        if maybe_intermediates.is_some() {
-            tracing::trace!("found intermediates!");
-        } else {
-            tracing::trace!("Cannot find intermediates for requested key and epoch");
-        }
-        Ok(maybe_intermediates)
+            .await?
+            .ok_or_else(|| PostgresDbError::MissingIntermediates(oprf_key_id, pending_epoch))?)
     }
 
     #[instrument(level = "debug", skip(self))]

--- a/oprf-key-gen/src/postgres/tests.rs
+++ b/oprf-key-gen/src/postgres/tests.rs
@@ -185,10 +185,17 @@ async fn fetch_keygen_intermediates_missing_returns_none() -> eyre::Result<()> {
     let oprf_key_id = OprfKeyId::new(U160::from(42));
     let epoch = ShareEpoch::new(12);
 
-    let fetched = secret_manager
+    let should_err = secret_manager
         .fetch_keygen_intermediates(oprf_key_id, epoch)
-        .await?;
-    assert!(fetched.is_none());
+        .await
+        .expect_err("Should be an error");
+    assert!(
+        matches!(
+            should_err,
+            SecretManagerError::MissingIntermediates(is_oprf_key, is_epoch) if is_oprf_key == oprf_key_id && is_epoch == epoch
+        ),
+        "Should be MissingIntermediates but is {should_err}"
+    );
     Ok(())
 }
 
@@ -200,23 +207,22 @@ async fn key_gen_round1_is_idempotent() -> eyre::Result<()> {
     let epoch = ShareEpoch::default();
 
     let first_contribution = dlog_secret_gen
-        .key_gen_round1(oprf_key_id, epoch, 2)
+        .key_gen_round1(oprf_key_id, epoch, 2.try_into().expect("2 is non-zero"))
         .await?;
     let intermediates = secret_manager
         .fetch_keygen_intermediates(oprf_key_id, epoch)
-        .await?
-        .expect("intermediates should be present");
+        .await?;
+
     let serialized_intermediates = super::to_db_ark_serialize_uncompressed(&intermediates);
 
     let retried_contribution = dlog_secret_gen
-        .key_gen_round1(oprf_key_id, epoch, 2)
+        .key_gen_round1(oprf_key_id, epoch, 2.try_into().expect("2 is non-zero"))
         .await
         .expect("retrying round 1 should reuse stored intermediates");
 
     let stored_after_retry = secret_manager
         .fetch_keygen_intermediates(oprf_key_id, epoch)
-        .await?
-        .expect("intermediates should still be present");
+        .await?;
 
     assert_eq!(
         serialized_intermediates,
@@ -263,11 +269,14 @@ async fn confirm_without_pending_share_fails() -> eyre::Result<()> {
         .confirm_dlog_share(oprf_key_id, epoch, public_key)
         .await
         .expect_err("confirm without pending share should fail");
-    assert!(matches!(
-        err,
-        SecretManagerError::MissingIntermediates(id, pending_epoch)
-            if id == oprf_key_id && pending_epoch == epoch
-    ));
+    assert!(
+        matches!(
+            err,
+            SecretManagerError::MissingIntermediates(id, pending_epoch)
+                if id == oprf_key_id && pending_epoch == epoch
+        ),
+        "Should be missing intermediates but is {err}"
+    );
     assert_eq!(intermediate_count(oprf_key_id, &mut conn).await?, 1);
     Ok(())
 }

--- a/oprf-key-gen/src/postgres/tests.rs
+++ b/oprf-key-gen/src/postgres/tests.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::too_many_lines, reason = "doesn't matter for tests")]
+use std::num::NonZeroU16;
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -207,7 +208,11 @@ async fn key_gen_round1_is_idempotent() -> eyre::Result<()> {
     let epoch = ShareEpoch::default();
 
     let first_contribution = dlog_secret_gen
-        .key_gen_round1(oprf_key_id, epoch, 2.try_into().expect("2 is non-zero"))
+        .key_gen_round1(
+            oprf_key_id,
+            epoch,
+            NonZeroU16::new(2).expect("2 is non-zero"),
+        )
         .await?;
     let intermediates = secret_manager
         .fetch_keygen_intermediates(oprf_key_id, epoch)
@@ -216,7 +221,11 @@ async fn key_gen_round1_is_idempotent() -> eyre::Result<()> {
     let serialized_intermediates = super::to_db_ark_serialize_uncompressed(&intermediates);
 
     let retried_contribution = dlog_secret_gen
-        .key_gen_round1(oprf_key_id, epoch, 2.try_into().expect("2 is non-zero"))
+        .key_gen_round1(
+            oprf_key_id,
+            epoch,
+            NonZeroU16::new(2).expect("2 is non-zero"),
+        )
         .await
         .expect("retrying round 1 should reuse stored intermediates");
 

--- a/oprf-key-gen/src/services/key_event_watcher.rs
+++ b/oprf-key-gen/src/services/key_event_watcher.rs
@@ -3,11 +3,22 @@
 //! This module provides [`key_event_watcher_task`], a task that can be spawned to monitor an
 //! on-chain `OprfKeyRegistry` contract for key generation events.
 //!
-//! The watcher loads the persisted [`ChainCursor`]
-//! from the [`ChainCursorService`] on startup and
+//! Responsibilities are split across three submodules:
+//!
+//! * **This file** — task loop, cursor management, and soft-error policy
+//!   ([`handle_soft_errors`]).
+//! * **[`events`]** — pure, I/O-free decoding of `Log<LogData>` into the typed
+//!   [`events::KeyRegistryEvent`] enum.
+//! * **[`handler`]** —  that calls [`DLogSecretGenService`],
+//!   reads peer/consumer public keys from the contract, and submits contributions back
+//!   via [`TransactionHandler`].
+//!
+//! The watcher loads the persisted [`ChainCursor`] from [`ChainCursorService`] on startup and
 //! passes it to the event stream so backfill resumes from the last processed `(block, log_index)`.
-//! After each handled log the cursor is stored unconditionally before propagating any handler error.
-//! The watcher subscribes to various key generation events and reports contributions back to the contract.
+//! The cursor is advanced only after an event is handled successfully — either cleanly or via a
+//! soft-error downgrade in [`handle_soft_errors`].  Hard errors propagate immediately and the
+//! cursor is **not** advanced, causing the watcher task to abort and restart from the last
+//! successfully stored position.
 
 use std::{
     num::NonZeroU16,
@@ -19,25 +30,16 @@ use std::{
 
 use crate::{
     event_cursor_store::ChainCursorService,
-    metrics::{
-        METRICS_ATTRID_PROTOCOL, METRICS_ATTRID_ROLE, METRICS_ATTRVAL_PROTOCOL_KEY_GEN,
-        METRICS_ATTRVAL_PROTOCOL_RESHARE, METRICS_ATTRVAL_ROLE_CONSUMER,
-        METRICS_ATTRVAL_ROLE_PRODUCER, METRICS_ID_KEY_GEN_ABORT, METRICS_ID_KEY_GEN_DELETION,
-        METRICS_ID_KEY_GEN_NOT_ENOUGH_PRODUCERS, METRICS_ID_KEY_GEN_ROUND_1_FINISH,
-        METRICS_ID_KEY_GEN_ROUND_1_START, METRICS_ID_KEY_GEN_ROUND_2_FINISH,
-        METRICS_ID_KEY_GEN_ROUND_2_START, METRICS_ID_KEY_GEN_ROUND_3_FINISH,
-        METRICS_ID_KEY_GEN_ROUND_3_START, METRICS_ID_KEY_GEN_ROUND_4_FINISH,
-        METRICS_ID_KEY_GEN_ROUND_4_START,
-    },
     secret_manager::SecretManagerError,
     services::{
-        secret_gen::{Contributions, DLogSecretGenService, SecretGenError},
+        key_event_watcher::{events::KeyRegistryEvent, handler::KeyRegistryEventHandler},
+        secret_gen::{DLogSecretGenService, SecretGenError},
         transaction_handler::TransactionHandler,
     },
 };
 use alloy::{
     network::primitives::TransactionFailedError,
-    primitives::{Address, LogData, U256},
+    primitives::{Address, LogData},
     providers::DynProvider,
     rpc::types::Log,
     sol_types::SolEvent as _,
@@ -49,26 +51,23 @@ use nodes_common::web3::{
     self,
     event_stream::{ChainCursor, EventStreamBuilder, EventStreamConfig},
 };
-use oprf_types::{
-    OprfKeyId, ShareEpoch,
-    chain::{
-        OprfKeyGen::Round2Contribution,
-        OprfKeyRegistry::{
-            self, AlreadySubmitted, OprfKeyRegistryErrors, OprfKeyRegistryInstance, WrongRound,
-        },
-        RevertError,
-        Verifier::VerifierErrors,
-    },
-    crypto::{EphemeralEncryptionPublicKey, OprfPublicKey, SecretGenCiphertext},
+use oprf_types::chain::{
+    OprfKeyRegistry::{self, AlreadySubmitted, DeletedId, OprfKeyRegistryErrors, WrongRound},
+    RevertError,
+    Verifier::VerifierErrors,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
-#[cfg(test)]
-mod tests;
+// #[cfg(test)]
+// mod tests;
+
+mod events;
+mod handler;
 
 type Result<T> = std::result::Result<T, KeyRegistryEventError>;
 
+/// Unified error type for key-registry event handling.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum KeyRegistryEventError {
     #[error("RevertReason: {0}")]
@@ -112,15 +111,29 @@ impl From<alloy::contract::Error> for KeyRegistryEventError {
     }
 }
 
+/// Configuration bundle for [`key_event_watcher_task`].
 pub(crate) struct KeyEventWatcherTaskConfig {
+    /// HTTP provider used to verify contract readiness before subscribing.
     pub(crate) http_rpc_provider: web3::HttpRpcProvider,
+    /// WebSocket provider used to subscribe to contract events.
     pub(crate) ws_rpc_provider: DynProvider,
+    /// Address of the `OprfKeyRegistry` contract to watch.
     pub(crate) contract_address: Address,
+    /// Secret-generation service that mutates local key-gen state in response to events.
     pub(crate) dlog_secret_gen_service: DLogSecretGenService,
+    /// Persistent store for the `(block, log_index)` cursor; read on startup, written after
+    /// each successfully handled log.
     pub(crate) chain_cursor_service: ChainCursorService,
+    /// Set to `true` once the watcher has subscribed and is ready to process events.  Used
+    /// by startup-ordering / health-check logic in the outer service.
     pub(crate) start_signal: Arc<AtomicBool>,
+    /// Transaction handler used to submit round contributions back to the contract.
     pub(crate) transaction_handler: TransactionHandler,
+    /// Filtering and backfill settings forwarded to the event-stream builder.
     pub(crate) event_stream_config: EventStreamConfig,
+    /// MPC threshold; passed to [`DLogSecretGenService`] for each round-1 call.
+    pub(crate) threshold: NonZeroU16,
+    /// Signals the task to shut down cleanly.
     pub(crate) cancellation_token: CancellationToken,
 }
 
@@ -141,6 +154,7 @@ pub(crate) async fn key_event_watcher_task(args: KeyEventWatcherTaskConfig) -> e
         start_signal,
         transaction_handler,
         event_stream_config,
+        threshold,
         cancellation_token,
     } = args;
 
@@ -149,8 +163,10 @@ pub(crate) async fn key_event_watcher_task(args: KeyEventWatcherTaskConfig) -> e
         .load_chain_cursor()
         .await
         .context("while loading chain cursor")?;
-    tracing::info!("chain cursor at: {chain_cursor}");
+
     let contract = OprfKeyRegistry::new(contract_address, http_rpc_provider.inner());
+
+    tracing::info!("chain cursor at: {chain_cursor}");
     let event_signatures = vec![
         OprfKeyRegistry::SecretGenRound1::SIGNATURE_HASH,
         OprfKeyRegistry::SecretGenRound2::SIGNATURE_HASH,
@@ -175,230 +191,117 @@ pub(crate) async fn key_event_watcher_task(args: KeyEventWatcherTaskConfig) -> e
     .await
     .context("while building event-stream")?;
 
+    let event_handler = KeyRegistryEventHandler::new(
+        contract,
+        dlog_secret_gen_service,
+        threshold,
+        transaction_handler,
+    );
+
     start_signal.store(true, Ordering::Relaxed);
     loop {
-        let log = tokio::select! {
+        tokio::select! {
             log = event_stream.next() => {
-                log.ok_or_else(||eyre::eyre!("logs subscribe stream was closed"))?.context("while fetching event from event_stream")?
+                let log = log.ok_or_else(||eyre::eyre!("logs subscribe stream was closed"))?.context("while fetching event from event_stream")?;
+
+                key_gen_event(log, &event_handler, &chain_cursor_service).await?;
             }
             () = cancellation_token.cancelled() => {
                 break;
             }
         };
-        let new_chain_cursor = key_gen_event(
-            log,
-            &contract,
-            &dlog_secret_gen_service,
-            &transaction_handler,
-        )
-        .await?;
-
-        chain_cursor_service
-            .store_chain_cursor(new_chain_cursor)
-            .await
-            .context("while storing new event cursor")?;
     }
 
     tracing::info!("successfully closed key_event_watcher without error");
     Ok(())
 }
 
-#[instrument(level = "info", skip_all, fields(oprf_key_id=tracing::field::Empty, epoch=tracing::field::Empty, event=tracing::field::Empty, block=tracing::field::Empty,index=tracing::field::Empty))]
-#[allow(
-    clippy::too_many_lines,
-    reason = "Is easier to have one large match instead of many single methods"
-)]
+/// Decode a single chain log, dispatch it to the event handler, apply the soft-error policy,
+/// and - on success - advance the chain cursor.
+///
+/// Span fields populated by [`events::KeyRegistryEvent::record_span_fields`]: `oprf_key_id`, `share_epoch`, `event`.
+///
+/// `tx_hash` is recorded inside [`handler::KeyRegistryEventHandler::handle`] after a contribution is submitted.
+#[instrument(
+    level = "info",
+    skip_all,
+    fields(
+        oprf_key_id=tracing::field::Empty,
+        share_epoch=tracing::field::Empty,
+        tx_hash=tracing::field::Empty,
+        event=tracing::field::Empty,
+    ))]
 async fn key_gen_event(
     log: Log<LogData>,
-    contract: &OprfKeyRegistryInstance<DynProvider>,
-    secret_gen: &DLogSecretGenService,
-    transaction_handler: &TransactionHandler,
-) -> Result<ChainCursor> {
-    let block = log
+    event_handler: &KeyRegistryEventHandler,
+    chain_cursor_service: &ChainCursorService,
+) -> Result<()> {
+    tracing::trace!("parsing event...");
+    let event = KeyRegistryEvent::try_decode_log(&log).context("while decoding chain event")?;
+    event.record_span_fields(&tracing::Span::current());
+
+    tracing::trace!("process event...");
+    let result = event_handler.handle(event, &tracing::Span::current()).await;
+
+    tracing::trace!("process result...");
+    handle_soft_errors(result)?;
+
+    tracing::trace!("store chain cursor...");
+    let block_number = log
         .block_number
-        .ok_or_else(|| eyre::eyre!("block number empty in log"))?;
+        .ok_or_else(|| eyre::eyre!("block number missing on log"))?;
     let index = log
         .log_index
-        .ok_or_else(|| eyre::eyre!("index empty in log"))?;
+        .ok_or_else(|| eyre::eyre!("log index missing on log"))?;
+    let chain_cursor = ChainCursor::new(block_number, index);
+    chain_cursor_service
+        .store_chain_cursor(chain_cursor)
+        .await?;
+    Ok(())
+}
 
-    let handle_span = tracing::Span::current();
-    handle_span.record("block", block);
-    handle_span.record("index", index);
-    let result = match log.topic0() {
-        Some(&OprfKeyRegistry::SecretGenRound1::SIGNATURE_HASH) => {
-            let OprfKeyRegistry::SecretGenRound1 {
-                oprfKeyId,
-                threshold,
-            } = log
-                .log_decode()
-                .context("while decoding key-gen round1 event")?
-                .inner
-                .data;
-            handle_span.record("oprf_key_id", oprfKeyId.to_string());
-            handle_span.record("epoch", "0");
-            handle_span.record("event", "key-gen round 1");
-            handle_keygen_round1(
-                OprfKeyId::from(oprfKeyId),
-                threshold,
-                secret_gen,
-                transaction_handler,
-            )
-            .await
-        }
-        Some(&OprfKeyRegistry::SecretGenRound2::SIGNATURE_HASH) => {
-            let OprfKeyRegistry::SecretGenRound2 { oprfKeyId, epoch } = log
-                .log_decode()
-                .context("while decoding key-gen round2 event")?
-                .inner
-                .data;
-            handle_span.record("oprf_key_id", oprfKeyId.to_string());
-            handle_span.record("epoch", epoch.to_string());
-            let epoch = ShareEpoch::from(epoch);
-            if epoch.is_initial_epoch() {
-                handle_span.record("event", "key-gen round 2");
-            } else {
-                handle_span.record("event", "reshare round 2");
-            }
-            handle_round2(
-                OprfKeyId::from(oprfKeyId),
-                epoch,
-                contract,
-                secret_gen,
-                transaction_handler,
-            )
-            .await
-        }
-        Some(&OprfKeyRegistry::SecretGenRound3::SIGNATURE_HASH) => {
-            let OprfKeyRegistry::SecretGenRound3 { oprfKeyId } = log
-                .log_decode()
-                .context("while decoding key-gen round3 event")?
-                .inner
-                .data;
-            let oprf_key_id = OprfKeyId::from(oprfKeyId);
-            handle_span.record("oprf_key_id", oprf_key_id.to_string());
-            handle_span.record("epoch", "0");
-            handle_span.record("event", "key-gen round 3");
-            handle_keygen_round3(oprf_key_id, contract, secret_gen, transaction_handler).await
-        }
-        Some(&OprfKeyRegistry::SecretGenFinalize::SIGNATURE_HASH) => {
-            let OprfKeyRegistry::SecretGenFinalize { oprfKeyId, epoch } = log
-                .log_decode()
-                .context("while decoding finalize event")?
-                .inner
-                .data;
-            let oprf_key_id = OprfKeyId::from(oprfKeyId);
-            let epoch = ShareEpoch::from(epoch);
-            handle_span.record("oprf_key_id", oprf_key_id.to_string());
-            handle_span.record("epoch", epoch.to_string());
-            handle_span.record("event", "finalize");
-            handle_finalize(oprf_key_id, epoch, contract, secret_gen).await
-        }
-        Some(&OprfKeyRegistry::ReshareRound1::SIGNATURE_HASH) => {
-            let OprfKeyRegistry::ReshareRound1 {
-                oprfKeyId,
-                threshold,
-                epoch,
-            } = log
-                .log_decode()
-                .context("while decoding reshare round1 event")?
-                .inner
-                .data;
-            let oprf_key_id = OprfKeyId::from(oprfKeyId);
-            let epoch = ShareEpoch::from(epoch);
-            handle_span.record("oprf_key_id", oprf_key_id.to_string());
-            handle_span.record("epoch", epoch.to_string());
-            handle_span.record("event", "reshare round 1");
-            handle_reshare_round1(
-                oprf_key_id,
-                threshold,
-                epoch,
-                secret_gen,
-                transaction_handler,
-            )
-            .await
-        }
-        Some(&OprfKeyRegistry::ReshareRound3::SIGNATURE_HASH) => {
-            let OprfKeyRegistry::ReshareRound3 {
-                oprfKeyId,
-                lagrange,
-                epoch,
-            } = log
-                .log_decode()
-                .context("while decoding reshare round3 event")?
-                .inner
-                .data;
-            let oprf_key_id = OprfKeyId::from(oprfKeyId);
-            let epoch = ShareEpoch::from(epoch);
-            handle_span.record("oprf_key_id", oprf_key_id.to_string());
-            handle_span.record("epoch", epoch.to_string());
-            handle_span.record("event", "reshare round 3");
-            handle_reshare_round3(
-                oprf_key_id,
-                epoch,
-                lagrange,
-                contract,
-                secret_gen,
-                transaction_handler,
-            )
-            .await
-        }
-        Some(&OprfKeyRegistry::KeyGenAbort::SIGNATURE_HASH) => {
-            let OprfKeyRegistry::KeyGenAbort { oprfKeyId } = log
-                .log_decode()
-                .context("while decoding abort event")?
-                .inner
-                .data;
-            let oprf_key_id = OprfKeyId::from(oprfKeyId);
-            handle_span.record("oprf_key_id", oprf_key_id.to_string());
-            handle_span.record("event", "abort");
-            handle_abort(oprf_key_id, secret_gen).await
-        }
-        Some(&OprfKeyRegistry::KeyDeletion::SIGNATURE_HASH) => {
-            let OprfKeyRegistry::KeyDeletion { oprfKeyId } = log
-                .log_decode()
-                .context("while decoding key-deletion event")?
-                .inner
-                .data;
-            let oprf_key_id = OprfKeyId::from(oprfKeyId);
-            handle_span.record("oprf_key_id", oprf_key_id.to_string());
-            handle_span.record("event", "delete");
-            handle_delete(oprf_key_id, secret_gen).await
-        }
-        Some(&OprfKeyRegistry::NotEnoughProducers::SIGNATURE_HASH) => {
-            let OprfKeyRegistry::NotEnoughProducers { oprfKeyId } = log
-                .log_decode()
-                .context("while decoding not-enough-producers event")?
-                .inner
-                .data;
-            let oprf_key_id = OprfKeyId::from(oprfKeyId);
-            handle_span.record("oprf_key_id", oprf_key_id.to_string());
-            handle_span.record("event", "not enough producers");
-            handle_not_enough_producers(oprf_key_id, secret_gen).await
-        }
-        x => {
-            tracing::warn!("unknown event: {x:?}");
-            Ok(())
-        }
-    };
-    let new_chain_cursor = ChainCursor::new(block, index);
+/// Downgrades known recoverable errors to `Ok(())` so the cursor still advances.
+///
+/// The following cases are treated as soft errors:
+///
+/// * `WrongRound` — the contract rejected the contribution because the key-gen was likely
+///   aborted; we log a warning and continue.
+/// * `DeletedId` — the key was deleted before we could act on an event; logged as an error
+///   (race condition) but not fatal.
+/// * `AlreadySubmitted` — we already contributed in this round (duplicate event or restart);
+///   safe to skip.
+/// * `MissingIntermediates` — the intermediate values for this key/epoch are gone; the key-gen
+///   is stuck and cannot be recovered without a contract-v2 call (see inline TODO).
+/// * `RefusingToRollbackEpoch` — the secret manager detected an out-of-order event; logged
+///   as a warning and skipped.
+///
+/// All other errors are returned as-is and will abort the watcher task.
+fn handle_soft_errors(result: Result<()>) -> Result<()> {
     match result {
-        Ok(()) => Ok(new_chain_cursor),
+        Ok(()) => Ok(()),
         Err(KeyRegistryEventError::Revert(RevertError::OprfKeyRegistry(
             OprfKeyRegistryErrors::WrongRound(WrongRound(round)),
         ))) => {
             tracing::warn!(
                 "Reverted event with wrong round - most likely this key-gen was aborted: we are in {round}"
             );
-            Ok(new_chain_cursor)
+            Ok(())
         }
-
+        Err(KeyRegistryEventError::Revert(RevertError::OprfKeyRegistry(
+            OprfKeyRegistryErrors::DeletedId(DeletedId { id }),
+        ))) => {
+            tracing::error!(
+                "This key was deleted before we could process an event - this is a race condition and should not actually happen during ordinary operations: {id}"
+            );
+            Ok(())
+        }
         Err(KeyRegistryEventError::Revert(RevertError::OprfKeyRegistry(
             OprfKeyRegistryErrors::AlreadySubmitted(AlreadySubmitted),
         ))) => {
             tracing::warn!(
                 "Already submitted for this round - we continue and mark this event as success"
             );
-            Ok(new_chain_cursor)
+            Ok(())
         }
         Err(KeyRegistryEventError::SecretManagerError(
             SecretManagerError::MissingIntermediates(oprf_key_id, epoch),
@@ -407,7 +310,7 @@ async fn key_gen_event(
             tracing::error!(
                 "Cannot find intermediates for key-id {oprf_key_id} in epoch {epoch} - this key-gen is stuck"
             );
-            Ok(new_chain_cursor)
+            Ok(())
         }
 
         Err(KeyRegistryEventError::SecretManagerError(
@@ -416,316 +319,8 @@ async fn key_gen_event(
             tracing::warn!(
                 "SecretManager refusing to rollback to older share - maybe we got an event out of order?"
             );
-            Ok(new_chain_cursor)
+            Ok(())
         }
         Err(err) => Err(err),
     }
-}
-
-async fn handle_keygen_round1(
-    oprf_key_id: OprfKeyId,
-    threshold: U256,
-    secret_gen: &DLogSecretGenService,
-    transaction_handler: &TransactionHandler,
-) -> Result<()> {
-    tracing::trace!("Received KeyGenRound1 event");
-    ::metrics::counter!(METRICS_ID_KEY_GEN_ROUND_1_START,
-        METRICS_ATTRID_PROTOCOL => METRICS_ATTRVAL_PROTOCOL_KEY_GEN)
-    .increment(1);
-
-    // wrap everything in a future to log to log the the potential error inside this span
-    let threshold =
-        NonZeroU16::try_from(u16::try_from(threshold).context("while parsing threshold")?)
-            .context("threshold from contract is zero")?;
-    let contribution = secret_gen
-        .key_gen_round1(oprf_key_id, ShareEpoch::default(), threshold)
-        .await
-        .context("while doing key-gen round1")?;
-    tracing::trace!("finished round1 - now reporting to chain..");
-    transaction_handler
-        .add_round1_keygen_contribution(oprf_key_id, contribution)
-        .await?;
-    ::metrics::counter!(METRICS_ID_KEY_GEN_ROUND_1_FINISH,
-        METRICS_ATTRID_PROTOCOL => METRICS_ATTRVAL_PROTOCOL_KEY_GEN)
-    .increment(1);
-    tracing::info!("Finished key-gen 1 for {oprf_key_id:?}");
-    Ok(())
-}
-
-async fn handle_round2(
-    oprf_key_id: OprfKeyId,
-    epoch: ShareEpoch,
-    contract: &OprfKeyRegistryInstance<DynProvider>,
-    secret_gen: &DLogSecretGenService,
-    transaction_handler: &TransactionHandler,
-) -> Result<()> {
-    tracing::trace!("Received SecretGenRound2 event");
-    let protocol = if epoch.is_initial_epoch() {
-        METRICS_ATTRVAL_PROTOCOL_KEY_GEN
-    } else {
-        METRICS_ATTRVAL_PROTOCOL_RESHARE
-    };
-    // We do not know yet whether this node participates as producer or consumer for this round.
-    ::metrics::counter!(METRICS_ID_KEY_GEN_ROUND_2_START, METRICS_ATTRID_PROTOCOL=> protocol)
-        .increment(1);
-    tracing::trace!("fetching ephemeral public keys from chain..");
-    let nodes = contract
-        .loadPeerPublicKeysForProducers(oprf_key_id.into_inner())
-        .call()
-        .await;
-    // Handle this separately because consumers can legitimately hit `WrongRound` here after
-    // producers have already advanced the contract state.
-    let nodes = match nodes {
-        Ok(nodes) => nodes,
-        Err(err) => {
-            if let Some(WrongRound(round)) = err.as_decoded_error::<OprfKeyRegistry::WrongRound>() {
-                tracing::trace!("reshare is already in round: {round} - we were a consumer");
-                // An empty producer list signals the consumer path below.
-                Vec::new()
-            } else {
-                Err(err)?
-            }
-        }
-    };
-    let role = if nodes.is_empty() {
-        METRICS_ATTRVAL_ROLE_CONSUMER
-    } else {
-        tracing::trace!("got keys from chain - parsing..");
-        let nodes = nodes
-            .into_iter()
-            .map(EphemeralEncryptionPublicKey::try_from)
-            .collect::<eyre::Result<Vec<_>>>()?;
-        let contribution = secret_gen
-            .producer_round2(oprf_key_id, epoch, nodes)
-            .await?;
-        tracing::trace!("finished round 2 - now reporting");
-        let contribution = Round2Contribution::from(contribution);
-        transaction_handler
-            .add_round2_contribution(oprf_key_id, contribution)
-            .await?;
-        METRICS_ATTRVAL_ROLE_PRODUCER
-    };
-    ::metrics::counter!(METRICS_ID_KEY_GEN_ROUND_2_FINISH,
-            METRICS_ATTRID_ROLE => role,
-            METRICS_ATTRID_PROTOCOL=> protocol)
-    .increment(1);
-    tracing::info!("Finished {protocol} 2 for {oprf_key_id:?} and epoch {epoch} as {role}");
-    Ok(())
-}
-
-async fn handle_keygen_round3(
-    oprf_key_id: OprfKeyId,
-    contract: &OprfKeyRegistryInstance<DynProvider>,
-    secret_gen: &DLogSecretGenService,
-    transaction_handler: &TransactionHandler,
-) -> Result<()> {
-    tracing::trace!("Received SecretGenRound3 event");
-    ::metrics::counter!(METRICS_ID_KEY_GEN_ROUND_3_START,
-        METRICS_ATTRID_PROTOCOL => METRICS_ATTRVAL_PROTOCOL_KEY_GEN)
-    .increment(1);
-    handle_round3_inner(
-        oprf_key_id,
-        ShareEpoch::default(),
-        contract,
-        secret_gen,
-        Contributions::Full,
-        transaction_handler,
-    )
-    .await?;
-    ::metrics::counter!(METRICS_ID_KEY_GEN_ROUND_3_FINISH,
-        METRICS_ATTRID_PROTOCOL => METRICS_ATTRVAL_PROTOCOL_KEY_GEN)
-    .increment(1);
-    tracing::info!("Finished key-gen round 3 for {oprf_key_id:?}");
-    Ok(())
-}
-
-async fn handle_finalize(
-    oprf_key_id: OprfKeyId,
-    epoch: ShareEpoch,
-    contract: &OprfKeyRegistryInstance<DynProvider>,
-    secret_gen: &DLogSecretGenService,
-) -> Result<()> {
-    tracing::trace!("Event for {oprf_key_id} with epoch {epoch}");
-    let protocol = if epoch.is_initial_epoch() {
-        METRICS_ATTRVAL_PROTOCOL_KEY_GEN
-    } else {
-        METRICS_ATTRVAL_PROTOCOL_RESHARE
-    };
-    // we don't know yet whether we are key_gen or reshare, FINISH holds this information
-    ::metrics::counter!(METRICS_ID_KEY_GEN_ROUND_4_START,
-        METRICS_ATTRID_PROTOCOL => protocol)
-    .increment(1);
-    let oprf_public_key = match contract
-        .getOprfPublicKey(oprf_key_id.into_inner())
-        .call()
-        .await
-    {
-        Ok(oprf_public_key) => oprf_public_key,
-        Err(err) => {
-            if let Some(OprfKeyRegistry::DeletedId { id: _ }) =
-                err.as_decoded_error::<OprfKeyRegistry::DeletedId>()
-            {
-                tracing::info!(
-                    "Key got deleted in the meantime - we ignore this key for now. Nodes will run into an error, but they will be fine"
-                );
-                return Ok(());
-            }
-            return Err(KeyRegistryEventError::from(err));
-        }
-    };
-    let oprf_public_key = OprfPublicKey::new(oprf_public_key.try_into()?);
-    secret_gen
-        .finalize(oprf_key_id, epoch, oprf_public_key)
-        .await
-        .context("while finalizing secret-gen")?;
-    ::metrics::counter!(METRICS_ID_KEY_GEN_ROUND_4_FINISH,
-            METRICS_ATTRID_PROTOCOL => protocol)
-    .increment(1);
-    tracing::info!("Finished finalize {protocol} for {oprf_key_id:?} with epoch {epoch}");
-    Ok(())
-}
-
-async fn handle_reshare_round1(
-    oprf_key_id: OprfKeyId,
-    threshold: U256,
-    epoch: ShareEpoch,
-    secret_gen: &DLogSecretGenService,
-    transaction_handler: &TransactionHandler,
-) -> Result<()> {
-    tracing::trace!("Received ReshareRound1 event");
-    ::metrics::counter!(METRICS_ID_KEY_GEN_ROUND_1_START,
-        METRICS_ATTRID_PROTOCOL => METRICS_ATTRVAL_PROTOCOL_RESHARE)
-    .increment(1);
-    let threshold = u16::try_from(threshold).context("while parsing threshold")?;
-
-    tracing::trace!("need to load the previous epoch share for reshare");
-    let contribution = secret_gen
-        .reshare_round1(oprf_key_id, epoch, threshold)
-        .await
-        .context("while doing round 1 reshare")?;
-    transaction_handler
-        .add_round1_reshare_contribution(oprf_key_id, contribution)
-        .await?;
-    ::metrics::counter!(METRICS_ID_KEY_GEN_ROUND_1_FINISH,
-            METRICS_ATTRID_PROTOCOL => METRICS_ATTRVAL_PROTOCOL_RESHARE)
-    .increment(1);
-    tracing::info!("Finished reshare round 1 for {oprf_key_id:?} with epoch {epoch}");
-    Ok(())
-}
-
-async fn handle_reshare_round3(
-    oprf_key_id: OprfKeyId,
-    epoch: ShareEpoch,
-    lagrange: Vec<U256>,
-    contract: &OprfKeyRegistryInstance<DynProvider>,
-    secret_gen: &DLogSecretGenService,
-    transaction_handler: &TransactionHandler,
-) -> Result<()> {
-    tracing::trace!("Received ReshareRound3 event");
-    ::metrics::counter!(METRICS_ID_KEY_GEN_ROUND_3_START,
-        METRICS_ATTRID_PROTOCOL => METRICS_ATTRVAL_PROTOCOL_RESHARE)
-    .increment(1);
-    tracing::trace!("parsing lagrange coefficients..");
-    let lagrange = lagrange
-        .into_iter()
-        .filter_map(|x| {
-            if x.is_zero() {
-                // filter the empty coefficients - the smart contract produces lagrange coeffs 0 for the not relevant parties
-                None
-            } else {
-                Some(oprf_types::chain::try_u256_into_bjj_fr(x))
-            }
-        })
-        .collect::<eyre::Result<Vec<_>>>()?;
-    handle_round3_inner(
-        oprf_key_id,
-        epoch,
-        contract,
-        secret_gen,
-        Contributions::Shamir(lagrange),
-        transaction_handler,
-    )
-    .await?;
-    ::metrics::counter!(METRICS_ID_KEY_GEN_ROUND_3_FINISH,
-        METRICS_ATTRID_PROTOCOL => METRICS_ATTRVAL_PROTOCOL_RESHARE)
-    .increment(1);
-    tracing::info!("Finished reshare round 3 for {oprf_key_id:?}");
-    Ok(())
-}
-
-async fn handle_delete(oprf_key_id: OprfKeyId, secret_gen: &DLogSecretGenService) -> Result<()> {
-    tracing::trace!("Received Delete event for {oprf_key_id}");
-    ::metrics::counter!(METRICS_ID_KEY_GEN_DELETION).increment(1);
-    // Delete finalized shares and any associated in-progress state for this key.
-    secret_gen
-        .delete_oprf_key_material(oprf_key_id)
-        .await
-        .with_context(|| format!("while deleting oprf key-material {oprf_key_id}"))?;
-    tracing::info!("successfully deleted {oprf_key_id:?}");
-    Ok(())
-}
-
-async fn handle_abort(oprf_key_id: OprfKeyId, secret_gen: &DLogSecretGenService) -> Result<()> {
-    ::metrics::counter!(METRICS_ID_KEY_GEN_ABORT).increment(1);
-    // In contrast to delete, abort only removes in-progress state and keeps finalized shares.
-    secret_gen
-        .abort_keygen(oprf_key_id)
-        .await
-        .with_context(|| format!("while aborting key-gen {oprf_key_id}"))?;
-    tracing::info!("successfully aborted {oprf_key_id:?}");
-    Ok(())
-}
-
-async fn handle_not_enough_producers(
-    oprf_key_id: OprfKeyId,
-    secret_gen: &DLogSecretGenService,
-) -> Result<()> {
-    ::metrics::counter!(METRICS_ID_KEY_GEN_NOT_ENOUGH_PRODUCERS).increment(1);
-    tracing::warn!("Received not-enough-producers for {oprf_key_id:?}");
-    // Clear the in-progress state associated with this key, but keep the last confirmed share.
-    secret_gen
-        .abort_keygen(oprf_key_id)
-        .await
-        .with_context(|| format!("while handling not-enough-producers {oprf_key_id}"))?;
-    tracing::info!("successfully aborted {oprf_key_id:?}");
-    Ok(())
-}
-
-async fn handle_round3_inner(
-    oprf_key_id: OprfKeyId,
-    epoch: ShareEpoch,
-    contract: &OprfKeyRegistryInstance<DynProvider>,
-    secret_gen: &DLogSecretGenService,
-    contributions: Contributions,
-    transaction_handler: &TransactionHandler,
-) -> Result<()> {
-    tracing::trace!("reading ciphers from chain..");
-    let ciphers = contract
-        .checkIsParticipantAndReturnRound2Ciphers(oprf_key_id.into_inner())
-        .call()
-        .await?;
-
-    tracing::trace!("got ciphers from chain {} - parsing..", ciphers.len());
-    let ciphers = ciphers
-        .into_iter()
-        .map(SecretGenCiphertext::try_from)
-        .collect::<eyre::Result<Vec<_>>>()?;
-    tracing::trace!("getting the public keys from the producers...");
-    let pks = contract
-        .loadPeerPublicKeysForConsumers(oprf_key_id.into_inner())
-        .call()
-        .await?;
-
-    let pks = pks
-        .into_iter()
-        .map(EphemeralEncryptionPublicKey::try_from)
-        .collect::<eyre::Result<Vec<_>>>()?;
-    secret_gen
-        .round3(oprf_key_id, epoch, ciphers, contributions, &pks)
-        .await?;
-    tracing::trace!("finished round 3 - now reporting");
-    transaction_handler
-        .add_round3_contribution(oprf_key_id)
-        .await?;
-    Ok(())
 }

--- a/oprf-key-gen/src/services/key_event_watcher.rs
+++ b/oprf-key-gen/src/services/key_event_watcher.rs
@@ -41,7 +41,7 @@ use crate::{
 use alloy::{
     network::primitives::TransactionFailedError,
     primitives::{Address, LogData},
-    providers::DynProvider,
+    providers::{DynProvider, PendingTransactionError},
     rpc::types::Log,
     sol_types::SolEvent as _,
     transports::TransportErrorKind,
@@ -77,6 +77,8 @@ pub(crate) enum KeyRegistryEventError {
     Contract(#[source] alloy::contract::Error),
     #[error(transparent)]
     Rpc(#[from] alloy::transports::RpcError<TransportErrorKind>),
+    #[error(transparent)]
+    PendingTransactionError(#[from] PendingTransactionError),
     #[error(transparent)]
     TransactionFailedError(#[from] TransactionFailedError),
     #[error("Cannot handle event due to secret-manager error: {0}")]

--- a/oprf-key-gen/src/services/key_event_watcher.rs
+++ b/oprf-key-gen/src/services/key_event_watcher.rs
@@ -30,6 +30,7 @@ use std::{
 
 use crate::{
     event_cursor_store::ChainCursorService,
+    metrics,
     secret_manager::SecretManagerError,
     services::{
         key_event_watcher::{events::KeyRegistryEvent, handler::KeyRegistryEventHandler},
@@ -257,6 +258,7 @@ async fn key_gen_event(
     chain_cursor_service
         .store_chain_cursor(chain_cursor)
         .await?;
+    metrics::chain_events::record_current_block(chain_cursor);
     Ok(())
 }
 

--- a/oprf-key-gen/src/services/key_event_watcher.rs
+++ b/oprf-key-gen/src/services/key_event_watcher.rs
@@ -9,9 +9,12 @@
 //! After each handled log the cursor is stored unconditionally before propagating any handler error.
 //! The watcher subscribes to various key generation events and reports contributions back to the contract.
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
+use std::{
+    num::NonZeroU16,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use crate::{
@@ -26,16 +29,19 @@ use crate::{
         METRICS_ID_KEY_GEN_ROUND_3_START, METRICS_ID_KEY_GEN_ROUND_4_FINISH,
         METRICS_ID_KEY_GEN_ROUND_4_START,
     },
+    secret_manager::SecretManagerError,
     services::{
-        secret_gen::{Contributions, DLogSecretGenService},
+        secret_gen::{Contributions, DLogSecretGenService, SecretGenError},
         transaction_handler::TransactionHandler,
     },
 };
 use alloy::{
+    network::primitives::TransactionFailedError,
     primitives::{Address, LogData, U256},
     providers::DynProvider,
     rpc::types::Log,
     sol_types::SolEvent as _,
+    transports::TransportErrorKind,
 };
 use eyre::Context;
 use futures::StreamExt;
@@ -47,7 +53,9 @@ use oprf_types::{
     OprfKeyId, ShareEpoch,
     chain::{
         OprfKeyGen::Round2Contribution,
-        OprfKeyRegistry::{self, OprfKeyRegistryErrors, OprfKeyRegistryInstance, WrongRound},
+        OprfKeyRegistry::{
+            self, AlreadySubmitted, OprfKeyRegistryErrors, OprfKeyRegistryInstance, WrongRound,
+        },
         RevertError,
         Verifier::VerifierErrors,
     },
@@ -59,26 +67,47 @@ use tracing::instrument;
 #[cfg(test)]
 mod tests;
 
-type Result<T> = std::result::Result<T, TransactionError>;
+type Result<T> = std::result::Result<T, KeyRegistryEventError>;
 
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum TransactionError {
+pub(crate) enum KeyRegistryEventError {
     #[error("RevertReason: {0}")]
     Revert(RevertError),
+    #[error("Error when interacting with contract - source: {0}")]
+    Contract(#[source] alloy::contract::Error),
     #[error(transparent)]
-    Rpc(#[from] eyre::Report),
+    Rpc(#[from] alloy::transports::RpcError<TransportErrorKind>),
+    #[error(transparent)]
+    TransactionFailedError(#[from] TransactionFailedError),
+    #[error("Cannot handle event due to secret-manager error: {0}")]
+    SecretManagerError(#[source] SecretManagerError),
+    #[error(transparent)]
+    Internal(#[from] eyre::Report),
 }
 
-impl From<alloy::contract::Error> for TransactionError {
+impl From<SecretGenError> for KeyRegistryEventError {
+    fn from(value: SecretGenError) -> Self {
+        match value {
+            SecretGenError::SecretManagerError(secret_manager_error) => {
+                if let SecretManagerError::Internal(report) = secret_manager_error {
+                    Self::Internal(report)
+                } else {
+                    Self::SecretManagerError(secret_manager_error)
+                }
+            }
+            SecretGenError::Internal(report) => Self::Internal(report),
+        }
+    }
+}
+
+impl From<alloy::contract::Error> for KeyRegistryEventError {
     fn from(value: alloy::contract::Error) -> Self {
         if let Some(err) = value.as_decoded_interface_error::<OprfKeyRegistryErrors>() {
-            TransactionError::Revert(RevertError::OprfKeyRegistry(err))
+            KeyRegistryEventError::Revert(RevertError::OprfKeyRegistry(err))
         } else if let Some(err) = value.as_decoded_interface_error::<VerifierErrors>() {
-            TransactionError::Revert(RevertError::Verifier(err))
+            KeyRegistryEventError::Revert(RevertError::Verifier(err))
         } else {
-            TransactionError::Rpc(eyre::eyre!(
-                "cannot finish transaction and call afterwards failed as well: {value:?}"
-            ))
+            KeyRegistryEventError::Contract(value)
         }
     }
 }
@@ -156,14 +185,18 @@ pub(crate) async fn key_event_watcher_task(args: KeyEventWatcherTaskConfig) -> e
                 break;
             }
         };
-        key_gen_event(
+        let new_chain_cursor = key_gen_event(
             log,
             &contract,
             &dlog_secret_gen_service,
-            &chain_cursor_service,
             &transaction_handler,
         )
         .await?;
+
+        chain_cursor_service
+            .store_chain_cursor(new_chain_cursor)
+            .await
+            .context("while storing new event cursor")?;
     }
 
     tracing::info!("successfully closed key_event_watcher without error");
@@ -179,16 +212,14 @@ async fn key_gen_event(
     log: Log<LogData>,
     contract: &OprfKeyRegistryInstance<DynProvider>,
     secret_gen: &DLogSecretGenService,
-    chain_cursor_service: &ChainCursorService,
     transaction_handler: &TransactionHandler,
-) -> Result<()> {
+) -> Result<ChainCursor> {
     let block = log
         .block_number
         .ok_or_else(|| eyre::eyre!("block number empty in log"))?;
     let index = log
         .log_index
         .ok_or_else(|| eyre::eyre!("index empty in log"))?;
-    let new_chain_cursor = ChainCursor::new(block, index);
 
     let handle_span = tracing::Span::current();
     handle_span.record("block", block);
@@ -209,7 +240,6 @@ async fn key_gen_event(
             handle_keygen_round1(
                 OprfKeyId::from(oprfKeyId),
                 threshold,
-                contract,
                 secret_gen,
                 transaction_handler,
             )
@@ -282,7 +312,6 @@ async fn key_gen_event(
                 oprf_key_id,
                 threshold,
                 epoch,
-                contract,
                 secret_gen,
                 transaction_handler,
             )
@@ -348,36 +377,54 @@ async fn key_gen_event(
         }
         x => {
             tracing::warn!("unknown event: {x:?}");
-            return Ok(());
-        }
-    };
-    // we store the chain_event_cursor irrelevant if we encountered an error or not.
-    // TODO This needs some fine tuning in a follow up PR though.
-    chain_cursor_service
-        .store_chain_cursor(new_chain_cursor)
-        .await
-        .context("while storing new event cursor")?;
-    match result {
-        Ok(()) => Ok(()),
-        Err(TransactionError::Revert(RevertError::OprfKeyRegistry(
-            OprfKeyRegistryErrors::WrongRound(WrongRound(round)),
-        ))) => {
-            tracing::info!(
-                "Reverted event with wrong round - most likely this key-gen was aborted: we are in {round}"
-            );
             Ok(())
         }
-        Err(err) => {
-            tracing::error!("{err}; {err:?}");
-            Err(err)
+    };
+    let new_chain_cursor = ChainCursor::new(block, index);
+    match result {
+        Ok(()) => Ok(new_chain_cursor),
+        Err(KeyRegistryEventError::Revert(RevertError::OprfKeyRegistry(
+            OprfKeyRegistryErrors::WrongRound(WrongRound(round)),
+        ))) => {
+            tracing::warn!(
+                "Reverted event with wrong round - most likely this key-gen was aborted: we are in {round}"
+            );
+            Ok(new_chain_cursor)
         }
+
+        Err(KeyRegistryEventError::Revert(RevertError::OprfKeyRegistry(
+            OprfKeyRegistryErrors::AlreadySubmitted(AlreadySubmitted),
+        ))) => {
+            tracing::warn!(
+                "Already submitted for this round - we continue and mark this event as success"
+            );
+            Ok(new_chain_cursor)
+        }
+        Err(KeyRegistryEventError::SecretManagerError(
+            SecretManagerError::MissingIntermediates(oprf_key_id, epoch),
+        )) => {
+            // TODO as soon as we release contract version 2 we call the appropriate function to mark this key-gen as stuck
+            tracing::error!(
+                "Cannot find intermediates for key-id {oprf_key_id} in epoch {epoch} - this key-gen is stuck"
+            );
+            Ok(new_chain_cursor)
+        }
+
+        Err(KeyRegistryEventError::SecretManagerError(
+            SecretManagerError::RefusingToRollbackEpoch,
+        )) => {
+            tracing::warn!(
+                "SecretManager refusing to rollback to older share - maybe we got an event out of order?"
+            );
+            Ok(new_chain_cursor)
+        }
+        Err(err) => Err(err),
     }
 }
 
 async fn handle_keygen_round1(
     oprf_key_id: OprfKeyId,
     threshold: U256,
-    contract: &OprfKeyRegistryInstance<DynProvider>,
     secret_gen: &DLogSecretGenService,
     transaction_handler: &TransactionHandler,
 ) -> Result<()> {
@@ -387,16 +434,16 @@ async fn handle_keygen_round1(
     .increment(1);
 
     // wrap everything in a future to log to log the the potential error inside this span
-    let threshold = u16::try_from(threshold).context("while parsing threshold")?;
+    let threshold =
+        NonZeroU16::try_from(u16::try_from(threshold).context("while parsing threshold")?)
+            .context("threshold from contract is zero")?;
     let contribution = secret_gen
         .key_gen_round1(oprf_key_id, ShareEpoch::default(), threshold)
         .await
         .context("while doing key-gen round1")?;
     tracing::trace!("finished round1 - now reporting to chain..");
     transaction_handler
-        .attempt_transaction(|| {
-            contract.addRound1KeyGenContribution(oprf_key_id.into_inner(), contribution.clone())
-        })
+        .add_round1_keygen_contribution(oprf_key_id, contribution)
         .await?;
     ::metrics::counter!(METRICS_ID_KEY_GEN_ROUND_1_FINISH,
         METRICS_ATTRID_PROTOCOL => METRICS_ATTRVAL_PROTOCOL_KEY_GEN)
@@ -448,20 +495,13 @@ async fn handle_round2(
             .into_iter()
             .map(EphemeralEncryptionPublicKey::try_from)
             .collect::<eyre::Result<Vec<_>>>()?;
-        let res = secret_gen
+        let contribution = secret_gen
             .producer_round2(oprf_key_id, epoch, nodes)
-            .await
-            .context("while doing round2")?;
-        let contribution = res.ok_or_else(|| {
-            // TODO here we will report that the key-gen is stuck, but this will happen in a dedicated PR
-            eyre::eyre!("key-gen is stuck in round2")
-        })?;
+            .await?;
         tracing::trace!("finished round 2 - now reporting");
         let contribution = Round2Contribution::from(contribution);
         transaction_handler
-            .attempt_transaction(|| {
-                contract.addRound2Contribution(oprf_key_id.into_inner(), contribution.clone())
-            })
+            .add_round2_contribution(oprf_key_id, contribution)
             .await?;
         METRICS_ATTRVAL_ROLE_PRODUCER
     };
@@ -530,7 +570,7 @@ async fn handle_finalize(
                 );
                 return Ok(());
             }
-            return Err(TransactionError::from(err));
+            return Err(KeyRegistryEventError::from(err));
         }
     };
     let oprf_public_key = OprfPublicKey::new(oprf_public_key.try_into()?);
@@ -549,7 +589,6 @@ async fn handle_reshare_round1(
     oprf_key_id: OprfKeyId,
     threshold: U256,
     epoch: ShareEpoch,
-    contract: &OprfKeyRegistryInstance<DynProvider>,
     secret_gen: &DLogSecretGenService,
     transaction_handler: &TransactionHandler,
 ) -> Result<()> {
@@ -565,9 +604,7 @@ async fn handle_reshare_round1(
         .await
         .context("while doing round 1 reshare")?;
     transaction_handler
-        .attempt_transaction(|| {
-            contract.addRound1ReshareContribution(oprf_key_id.into_inner(), contribution.clone())
-        })
+        .add_round1_reshare_contribution(oprf_key_id, contribution)
         .await?;
     ::metrics::counter!(METRICS_ID_KEY_GEN_ROUND_1_FINISH,
             METRICS_ATTRID_PROTOCOL => METRICS_ATTRVAL_PROTOCOL_RESHARE)
@@ -685,14 +722,10 @@ async fn handle_round3_inner(
         .collect::<eyre::Result<Vec<_>>>()?;
     secret_gen
         .round3(oprf_key_id, epoch, ciphers, contributions, &pks)
-        .await
-        .context("while doing round3")?
-        .ok_or_else(||
-            // TODO here we will report that the key-gen is stuck, but this will happen in a dedicated PR
-            eyre::eyre!("key-gen is stuck in round3"))?;
+        .await?;
     tracing::trace!("finished round 3 - now reporting");
     transaction_handler
-        .attempt_transaction(|| contract.addRound3Contribution(oprf_key_id.into_inner()))
+        .add_round3_contribution(oprf_key_id)
         .await?;
     Ok(())
 }

--- a/oprf-key-gen/src/services/key_event_watcher.rs
+++ b/oprf-key-gen/src/services/key_event_watcher.rs
@@ -59,8 +59,8 @@ use oprf_types::chain::{
 use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
-// #[cfg(test)]
-// mod tests;
+#[cfg(test)]
+mod tests;
 
 mod events;
 mod handler;

--- a/oprf-key-gen/src/services/key_event_watcher/events.rs
+++ b/oprf-key-gen/src/services/key_event_watcher/events.rs
@@ -1,0 +1,208 @@
+use alloy::{primitives::LogData, rpc::types::Log, sol_types::SolEvent as _};
+use eyre::Context as _;
+use oprf_types::chain::OprfKeyRegistry;
+use oprf_types::{OprfKeyId, ShareEpoch};
+
+use crate::services::secret_gen::Contributions;
+
+/// Typed representation of a decoded `OprfKeyRegistry` log.
+///
+/// Constructed exclusively via [`KeyRegistryEvent::try_decode_log`].
+pub(super) enum KeyRegistryEvent {
+    KeyGenRound1 {
+        key_id: OprfKeyId,
+    },
+    Round2 {
+        key_id: OprfKeyId,
+        epoch: ShareEpoch,
+    },
+    Round3 {
+        key_id: OprfKeyId,
+        epoch: ShareEpoch,
+        contributions: Contributions,
+    },
+    Finalize {
+        key_id: OprfKeyId,
+        epoch: ShareEpoch,
+    },
+    ReshareRound1 {
+        key_id: OprfKeyId,
+        epoch: ShareEpoch,
+    },
+    Delete {
+        key_id: OprfKeyId,
+    },
+    Abort {
+        key_id: OprfKeyId,
+    },
+    NotEnoughProducers {
+        key_id: OprfKeyId,
+    },
+    Unknown,
+}
+
+impl KeyRegistryEvent {
+    /// Decode a raw chain log into a typed [`KeyRegistryEvent`].
+    ///
+    /// Dispatches on `topic0` (the event signature hash).  Returns `Self::Unknown` for any
+    /// unrecognised topic rather than erroring, so the watcher can skip irrelevant events.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the ABI fields cannot be decoded (malformed log data) or if
+    /// a `ReshareRound3` log contains a Lagrange coefficient that cannot be parsed as a
+    /// `BabyJubJub` scalar.
+    pub(super) fn try_decode_log(log: &Log<LogData>) -> eyre::Result<Self> {
+        macro_rules! decode {
+            () => {
+                log.log_decode()
+                    .context("while decoding log-event")?
+                    .inner
+                    .data
+            };
+        }
+        tracing::trace!("trying to decode log...");
+        let event = match log.topic0() {
+            Some(&OprfKeyRegistry::SecretGenRound1::SIGNATURE_HASH) => {
+                let OprfKeyRegistry::SecretGenRound1 { oprfKeyId, .. } = decode!();
+
+                Self::KeyGenRound1 {
+                    key_id: OprfKeyId::from(oprfKeyId),
+                }
+            }
+            Some(&OprfKeyRegistry::SecretGenRound2::SIGNATURE_HASH) => {
+                let OprfKeyRegistry::SecretGenRound2 { oprfKeyId, epoch } = decode!();
+                Self::Round2 {
+                    key_id: OprfKeyId::from(oprfKeyId),
+                    epoch: ShareEpoch::from(epoch),
+                }
+            }
+            Some(&OprfKeyRegistry::SecretGenRound3::SIGNATURE_HASH) => {
+                let OprfKeyRegistry::SecretGenRound3 { oprfKeyId } = decode!();
+                Self::Round3 {
+                    key_id: OprfKeyId::from(oprfKeyId),
+                    epoch: ShareEpoch::default(),
+                    contributions: Contributions::Full,
+                }
+            }
+            Some(&OprfKeyRegistry::SecretGenFinalize::SIGNATURE_HASH) => {
+                let OprfKeyRegistry::SecretGenFinalize { oprfKeyId, epoch } = decode!();
+                Self::Finalize {
+                    key_id: OprfKeyId::from(oprfKeyId),
+                    epoch: ShareEpoch::from(epoch),
+                }
+            }
+            Some(&OprfKeyRegistry::ReshareRound1::SIGNATURE_HASH) => {
+                let OprfKeyRegistry::ReshareRound1 {
+                    oprfKeyId, epoch, ..
+                } = decode!();
+                Self::ReshareRound1 {
+                    key_id: OprfKeyId::from(oprfKeyId),
+                    epoch: ShareEpoch::from(epoch),
+                }
+            }
+            Some(&OprfKeyRegistry::ReshareRound3::SIGNATURE_HASH) => {
+                let OprfKeyRegistry::ReshareRound3 {
+                    oprfKeyId,
+                    lagrange,
+                    epoch,
+                } = decode!();
+                tracing::trace!("parsing lagrange contributions..");
+                let lagrange = lagrange
+                    .into_iter()
+                    .filter_map(|x| {
+                        if x.is_zero() {
+                            // filter the empty coefficients - the smart contract produces lagrange coeffs 0 for the not relevant parties
+                            None
+                        } else {
+                            Some(oprf_types::chain::try_u256_into_bjj_fr(x))
+                        }
+                    })
+                    .collect::<eyre::Result<Vec<_>>>()
+                    .context("while parsing lagrange coeffs from chain")?;
+                Self::Round3 {
+                    key_id: OprfKeyId::from(oprfKeyId),
+                    epoch: ShareEpoch::from(epoch),
+                    contributions: Contributions::Shamir(lagrange),
+                }
+            }
+            Some(&OprfKeyRegistry::KeyGenAbort::SIGNATURE_HASH) => {
+                let OprfKeyRegistry::KeyGenAbort { oprfKeyId } = decode!();
+                Self::Abort {
+                    key_id: OprfKeyId::from(oprfKeyId),
+                }
+            }
+            Some(&OprfKeyRegistry::KeyDeletion::SIGNATURE_HASH) => {
+                let OprfKeyRegistry::KeyDeletion { oprfKeyId } = decode!();
+                Self::Delete {
+                    key_id: OprfKeyId::from(oprfKeyId),
+                }
+            }
+            Some(&OprfKeyRegistry::NotEnoughProducers::SIGNATURE_HASH) => {
+                let OprfKeyRegistry::NotEnoughProducers { oprfKeyId } = decode!();
+                Self::NotEnoughProducers {
+                    key_id: OprfKeyId::from(oprfKeyId),
+                }
+            }
+            x => {
+                tracing::warn!("unknown event: {x:?}");
+                Self::Unknown
+            }
+        };
+        Ok(event)
+    }
+}
+
+impl KeyRegistryEvent {
+    /// Populate the current tracing span with event-specific fields.
+    ///
+    /// Fields recorded (subject to variant):
+    /// * `oprf_key_id` — always recorded.
+    /// * `share_epoch` — recorded for variants that carry an epoch (`Round2`, `Round3`,
+    ///   `Finalize`, `ReshareRound1`).
+    /// * `event` — always recorded; the value is a static string name for the event type
+    ///   (e.g. `"keygen-round1"`, `"round2"`, …).
+    pub(super) fn record_span_fields(&self, span: &tracing::Span) {
+        match self {
+            KeyRegistryEvent::KeyGenRound1 { key_id }
+            | KeyRegistryEvent::Delete { key_id }
+            | KeyRegistryEvent::Abort { key_id }
+            | KeyRegistryEvent::NotEnoughProducers { key_id } => {
+                record_oprf_key_id(*key_id, span);
+            }
+            KeyRegistryEvent::Round2 { key_id, epoch }
+            | KeyRegistryEvent::Finalize { key_id, epoch }
+            | KeyRegistryEvent::ReshareRound1 { key_id, epoch }
+            | KeyRegistryEvent::Round3 { key_id, epoch, .. } => {
+                record_oprf_key_id(*key_id, span);
+                record_share_epoch(*epoch, span);
+            }
+            KeyRegistryEvent::Unknown => {}
+        }
+        span.record("event", self.event_type());
+    }
+
+    fn event_type(&self) -> &'static str {
+        match self {
+            Self::KeyGenRound1 { .. } => "keygen-round1",
+            Self::Round2 { .. } => "round2",
+            Self::Round3 { .. } => "round3",
+            Self::Finalize { .. } => "finalize",
+            Self::ReshareRound1 { .. } => "reshare-round1",
+            Self::Delete { .. } => "delete",
+            Self::Abort { .. } => "abort",
+            Self::NotEnoughProducers { .. } => "not-enough-producers",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[inline]
+fn record_oprf_key_id(oprf_key_id: OprfKeyId, span: &tracing::Span) {
+    span.record("oprf_key_id", oprf_key_id.to_string());
+}
+
+#[inline]
+fn record_share_epoch(epoch: ShareEpoch, span: &tracing::Span) {
+    span.record("share_epoch", epoch.to_string());
+}

--- a/oprf-key-gen/src/services/key_event_watcher/handler.rs
+++ b/oprf-key-gen/src/services/key_event_watcher/handler.rs
@@ -11,6 +11,7 @@ use oprf_types::{
     crypto::{EphemeralEncryptionPublicKey, OprfPublicKey, SecretGenCiphertext},
 };
 
+use crate::metrics;
 use crate::services::{
     key_event_watcher::{KeyRegistryEvent, KeyRegistryEventError},
     secret_gen::{Contributions, DLogSecretGenService},
@@ -71,13 +72,14 @@ impl KeyRegistryEventHandler {
             } => self.round3(key_id, epoch, contributions, event_span).await,
             KeyRegistryEvent::Finalize { key_id, epoch } => self.finalize(key_id, epoch).await,
             KeyRegistryEvent::ReshareRound1 { key_id, epoch } => {
-                self.reshare_round1(key_id, epoch).await
+                self.reshare_round1(key_id, epoch, event_span).await
             }
             KeyRegistryEvent::Delete { key_id } => self.delete(key_id).await,
             KeyRegistryEvent::Abort { key_id } => self.abort(key_id).await,
             KeyRegistryEvent::NotEnoughProducers { key_id } => {
                 // we simply log an error to trigger a page
                 tracing::error!("Received not-enough-producers for {key_id:?}");
+                metrics::chain_events::inc_not_enough_producers();
                 Ok(())
             }
             KeyRegistryEvent::Unknown => {
@@ -102,7 +104,9 @@ impl KeyRegistryEventHandler {
             .tx
             .add_round1_keygen_contribution(oprf_key_id, contribution)
             .await?;
+
         record_tx_hash(tx_hash, event_span);
+        metrics::chain_events::inc_keygen_round1();
         tracing::info!("Finished key-gen 1 for {oprf_key_id}");
         Ok(())
     }
@@ -116,6 +120,7 @@ impl KeyRegistryEventHandler {
         tracing::trace!("Received SecretGenRound2 event");
         let nodes = self.fetch_producer_public_keys(oprf_key_id).await?;
         if nodes.is_empty() {
+            metrics::chain_events::inc_consumer();
             tracing::info!("Finished round 2 for {oprf_key_id} and epoch {epoch} as producer");
         } else {
             let contribution = self
@@ -129,8 +134,10 @@ impl KeyRegistryEventHandler {
                 .add_round2_contribution(oprf_key_id, contribution)
                 .await?;
             record_tx_hash(tx_hash, event_span);
+            metrics::chain_events::inc_producer();
             tracing::info!("Finished round 2 for {oprf_key_id} and epoch {epoch} as producer");
         }
+        metrics::chain_events::inc_round2();
         Ok(())
     }
 
@@ -152,6 +159,7 @@ impl KeyRegistryEventHandler {
         tracing::trace!("finished round 3 - now reporting");
         let tx_hash = self.tx.add_round3_contribution(oprf_key_id).await?;
         record_tx_hash(tx_hash, event_span);
+        metrics::chain_events::inc_round3();
         tracing::info!("Finished round 3 for {oprf_key_id} and epoch {epoch} as producer");
 
         Ok(())
@@ -168,18 +176,27 @@ impl KeyRegistryEventHandler {
         } else {
             tracing::info!("Received finalize on deleted key - continue and mark as done");
         }
+        metrics::chain_events::inc_finalize();
         Ok(())
     }
 
-    async fn reshare_round1(&self, oprf_key_id: OprfKeyId, epoch: ShareEpoch) -> Result<()> {
+    async fn reshare_round1(
+        &self,
+        oprf_key_id: OprfKeyId,
+        epoch: ShareEpoch,
+        event_span: &tracing::Span,
+    ) -> Result<()> {
         tracing::trace!("Received ReshareRound1 event");
         let contribution = self
             .secret_gen
             .reshare_round1(oprf_key_id, epoch, self.threshold)
             .await?;
-        self.tx
+        let tx_hash = self
+            .tx
             .add_round1_reshare_contribution(oprf_key_id, contribution)
             .await?;
+        record_tx_hash(tx_hash, event_span);
+        metrics::chain_events::inc_reshare_round1();
         tracing::info!("Finished reshare round 1 for {oprf_key_id:?} with epoch {epoch}");
         Ok(())
     }
@@ -190,6 +207,7 @@ impl KeyRegistryEventHandler {
         self.secret_gen
             .delete_oprf_key_material(oprf_key_id)
             .await?;
+        metrics::chain_events::inc_delete();
         tracing::info!("successfully deleted {oprf_key_id:?}");
         Ok(())
     }
@@ -197,6 +215,7 @@ impl KeyRegistryEventHandler {
     async fn abort(&self, oprf_key_id: OprfKeyId) -> Result<()> {
         // In contrast to delete, abort only removes in-progress state and keeps finalized shares.
         self.secret_gen.abort_keygen(oprf_key_id).await?;
+        metrics::chain_events::inc_abort();
         tracing::info!("successfully aborted {oprf_key_id:?}");
         Ok(())
     }

--- a/oprf-key-gen/src/services/key_event_watcher/handler.rs
+++ b/oprf-key-gen/src/services/key_event_watcher/handler.rs
@@ -121,7 +121,7 @@ impl KeyRegistryEventHandler {
         let nodes = self.fetch_producer_public_keys(oprf_key_id).await?;
         if nodes.is_empty() {
             metrics::chain_events::inc_consumer();
-            tracing::info!("Finished round 2 for {oprf_key_id} and epoch {epoch} as producer");
+            tracing::info!("Finished round 2 for {oprf_key_id} and epoch {epoch} as CONSUMER");
         } else {
             let contribution = self
                 .secret_gen
@@ -135,7 +135,7 @@ impl KeyRegistryEventHandler {
                 .await?;
             record_tx_hash(tx_hash, event_span);
             metrics::chain_events::inc_producer();
-            tracing::info!("Finished round 2 for {oprf_key_id} and epoch {epoch} as producer");
+            tracing::info!("Finished round 2 for {oprf_key_id} and epoch {epoch} as PRODUCER");
         }
         metrics::chain_events::inc_round2();
         Ok(())

--- a/oprf-key-gen/src/services/key_event_watcher/handler.rs
+++ b/oprf-key-gen/src/services/key_event_watcher/handler.rs
@@ -1,0 +1,314 @@
+use std::num::NonZeroU16;
+
+use alloy::{primitives::TxHash, providers::DynProvider};
+use eyre::Context;
+use oprf_types::{
+    OprfKeyId, ShareEpoch,
+    chain::{
+        OprfKeyGen::Round2Contribution,
+        OprfKeyRegistry::{self, OprfKeyRegistryInstance, WrongRound},
+    },
+    crypto::{EphemeralEncryptionPublicKey, OprfPublicKey, SecretGenCiphertext},
+};
+
+use crate::services::{
+    key_event_watcher::{KeyRegistryEvent, KeyRegistryEventError},
+    secret_gen::{Contributions, DLogSecretGenService},
+    transaction_handler::TransactionHandler,
+};
+
+use super::Result;
+
+/// Dispatches decoded [`KeyRegistryEvent`]s to the appropriate protocol-round handler.
+pub(super) struct KeyRegistryEventHandler {
+    contract: OprfKeyRegistryInstance<DynProvider>,
+    secret_gen: DLogSecretGenService,
+    threshold: NonZeroU16,
+    tx: TransactionHandler,
+}
+
+impl KeyRegistryEventHandler {
+    /// Construct a new handler.
+    ///
+    /// # Arguments
+    ///
+    /// * `contract` - A connected `OprfKeyRegistry` instance used for view calls (public-key
+    ///   fetches) and round submissions.
+    /// * `secret_gen` - Manages local key-gen intermediates and computes contributions.
+    /// * `threshold` - MPC threshold forwarded to round-1 calls.
+    /// * `tx` - Submits contribution transactions and waits for confirmations.
+    pub(super) fn new(
+        contract: OprfKeyRegistryInstance<DynProvider>,
+        secret_gen: DLogSecretGenService,
+        threshold: NonZeroU16,
+        tx: TransactionHandler,
+    ) -> Self {
+        Self {
+            contract,
+            secret_gen,
+            threshold,
+            tx,
+        }
+    }
+
+    /// Dispatch a decoded event to the appropriate protocol-round handler.
+    pub(super) async fn handle(
+        &self,
+        event: KeyRegistryEvent,
+        event_span: &tracing::Span,
+    ) -> Result<()> {
+        match event {
+            KeyRegistryEvent::KeyGenRound1 { key_id } => {
+                self.keygen_round1(key_id, event_span).await
+            }
+            KeyRegistryEvent::Round2 { key_id, epoch } => {
+                self.round2(key_id, epoch, event_span).await
+            }
+            KeyRegistryEvent::Round3 {
+                key_id,
+                epoch,
+                contributions,
+            } => self.round3(key_id, epoch, contributions, event_span).await,
+            KeyRegistryEvent::Finalize { key_id, epoch } => self.finalize(key_id, epoch).await,
+            KeyRegistryEvent::ReshareRound1 { key_id, epoch } => {
+                self.reshare_round1(key_id, epoch).await
+            }
+            KeyRegistryEvent::Delete { key_id } => self.delete(key_id).await,
+            KeyRegistryEvent::Abort { key_id } => self.abort(key_id).await,
+            KeyRegistryEvent::NotEnoughProducers { key_id } => {
+                // we simply log an error to trigger a page
+                tracing::error!("Received not-enough-producers for {key_id:?}");
+                Ok(())
+            }
+            KeyRegistryEvent::Unknown => {
+                tracing::warn!("cannot handle unknown event - ignoring");
+                Ok(())
+            }
+        }
+    }
+
+    async fn keygen_round1(
+        &self,
+        oprf_key_id: OprfKeyId,
+        event_span: &tracing::Span,
+    ) -> Result<()> {
+        tracing::trace!("Received KeyGenRound1 event");
+        let contribution = self
+            .secret_gen
+            .key_gen_round1(oprf_key_id, ShareEpoch::default(), self.threshold)
+            .await?;
+        tracing::trace!("finished round1 - now reporting to chain..");
+        let tx_hash = self
+            .tx
+            .add_round1_keygen_contribution(oprf_key_id, contribution)
+            .await?;
+        record_tx_hash(tx_hash, event_span);
+        tracing::info!("Finished key-gen 1 for {oprf_key_id}");
+        Ok(())
+    }
+
+    async fn round2(
+        &self,
+        oprf_key_id: OprfKeyId,
+        epoch: ShareEpoch,
+        event_span: &tracing::Span,
+    ) -> Result<()> {
+        tracing::trace!("Received SecretGenRound2 event");
+        let nodes = self.fetch_producer_public_keys(oprf_key_id).await?;
+        if nodes.is_empty() {
+            tracing::info!("Finished round 2 for {oprf_key_id} and epoch {epoch} as producer");
+        } else {
+            let contribution = self
+                .secret_gen
+                .producer_round2(oprf_key_id, epoch, nodes)
+                .await?;
+            tracing::trace!("finished round 2 - now reporting");
+            let contribution = Round2Contribution::from(contribution);
+            let tx_hash = self
+                .tx
+                .add_round2_contribution(oprf_key_id, contribution)
+                .await?;
+            record_tx_hash(tx_hash, event_span);
+            tracing::info!("Finished round 2 for {oprf_key_id} and epoch {epoch} as producer");
+        }
+        Ok(())
+    }
+
+    async fn round3(
+        &self,
+        oprf_key_id: OprfKeyId,
+        epoch: ShareEpoch,
+        contributions: Contributions,
+        event_span: &tracing::Span,
+    ) -> Result<()> {
+        tracing::trace!("Round 3 event for {oprf_key_id} with epoch {epoch}");
+        let (ciphers, pks) = tokio::join!(
+            self.fetch_round2_ciphers(oprf_key_id),
+            self.fetch_consumer_public_keys(oprf_key_id)
+        );
+        self.secret_gen
+            .round3(oprf_key_id, epoch, ciphers?, contributions, &pks?)
+            .await?;
+        tracing::trace!("finished round 3 - now reporting");
+        let tx_hash = self.tx.add_round3_contribution(oprf_key_id).await?;
+        record_tx_hash(tx_hash, event_span);
+        tracing::info!("Finished round 3 for {oprf_key_id} and epoch {epoch} as producer");
+
+        Ok(())
+    }
+
+    async fn finalize(&self, oprf_key_id: OprfKeyId, epoch: ShareEpoch) -> Result<()> {
+        tracing::trace!("Finalize event for {oprf_key_id} with epoch {epoch}");
+        let oprf_public_key = self.fetch_oprf_public_key(oprf_key_id).await?;
+        if let Some(oprf_public_key) = oprf_public_key {
+            self.secret_gen
+                .finalize(oprf_key_id, epoch, oprf_public_key)
+                .await?;
+            tracing::info!("Finished finalize for {oprf_key_id:?} with epoch {epoch}");
+        } else {
+            tracing::info!("Received finalize on deleted key - continue and mark as done");
+        }
+        Ok(())
+    }
+
+    async fn reshare_round1(&self, oprf_key_id: OprfKeyId, epoch: ShareEpoch) -> Result<()> {
+        tracing::trace!("Received ReshareRound1 event");
+        let contribution = self
+            .secret_gen
+            .reshare_round1(oprf_key_id, epoch, self.threshold)
+            .await?;
+        self.tx
+            .add_round1_reshare_contribution(oprf_key_id, contribution)
+            .await?;
+        tracing::info!("Finished reshare round 1 for {oprf_key_id:?} with epoch {epoch}");
+        Ok(())
+    }
+
+    async fn delete(&self, oprf_key_id: OprfKeyId) -> Result<()> {
+        tracing::trace!("Received Delete event for {oprf_key_id}");
+        // Delete finalized shares and any associated in-progress state for this key.
+        self.secret_gen
+            .delete_oprf_key_material(oprf_key_id)
+            .await?;
+        tracing::info!("successfully deleted {oprf_key_id:?}");
+        Ok(())
+    }
+
+    async fn abort(&self, oprf_key_id: OprfKeyId) -> Result<()> {
+        // In contrast to delete, abort only removes in-progress state and keeps finalized shares.
+        self.secret_gen.abort_keygen(oprf_key_id).await?;
+        tracing::info!("successfully aborted {oprf_key_id:?}");
+        Ok(())
+    }
+
+    // ================== HELPER FUNCTIONS ==================
+
+    /// Calls `OprfKeyRegistry::loadPeerPublicKeysForProducers` and parses the result.
+    ///
+    /// Returns an empty `Vec` if the contract responds with `WrongRound`, which signals that
+    /// this node is a consumer and the contract has already advanced past the producer phase.
+    async fn fetch_producer_public_keys(
+        &self,
+        oprf_key_id: OprfKeyId,
+    ) -> Result<Vec<EphemeralEncryptionPublicKey>> {
+        tracing::trace!("fetching ephemeral public keys from chain..");
+        let nodes = self
+            .contract
+            .loadPeerPublicKeysForProducers(oprf_key_id.into_inner())
+            .call()
+            .await;
+        // Handle this separately because consumers can legitimately hit `WrongRound` here after
+        // producers have already advanced the contract state.
+        let nodes = match nodes {
+            Ok(nodes) => nodes,
+            Err(err) => {
+                if let Some(WrongRound(round)) =
+                    err.as_decoded_error::<OprfKeyRegistry::WrongRound>()
+                {
+                    tracing::trace!("reshare is already in round: {round} - we were a consumer");
+                    // An empty producer list signals the consumer path below.
+                    Vec::new()
+                } else {
+                    Err(err)?
+                }
+            }
+        };
+        let nodes = nodes
+            .into_iter()
+            .map(EphemeralEncryptionPublicKey::try_from)
+            .collect::<eyre::Result<Vec<_>>>()?;
+        Ok(nodes)
+    }
+
+    /// Calls `OprfKeyRegistry::getOprfPublicKey` and parses the result.
+    ///
+    /// Returns `None` if the contract responds with `DeletedId`, indicating the key was removed
+    /// between event emission and handling; the caller should no-op in that case.
+    async fn fetch_oprf_public_key(&self, oprf_key_id: OprfKeyId) -> Result<Option<OprfPublicKey>> {
+        tracing::trace!("fetching oprf public key from chain");
+        let oprf_public_key = match self
+            .contract
+            .getOprfPublicKey(oprf_key_id.into_inner())
+            .call()
+            .await
+        {
+            Ok(oprf_public_key) => oprf_public_key,
+            Err(err) => {
+                if let Some(OprfKeyRegistry::DeletedId { id: _ }) =
+                    err.as_decoded_error::<OprfKeyRegistry::DeletedId>()
+                {
+                    tracing::info!(
+                        "Key got deleted in the meantime - we ignore this key for now. Nodes will run into an error, but they will be fine"
+                    );
+                    return Ok(None);
+                }
+                return Err(KeyRegistryEventError::from(err));
+            }
+        };
+        Ok(Some(OprfPublicKey::new(
+            ark_babyjubjub::EdwardsAffine::try_from(oprf_public_key)?,
+        )))
+    }
+
+    async fn fetch_round2_ciphers(
+        &self,
+        oprf_key_id: OprfKeyId,
+    ) -> Result<Vec<SecretGenCiphertext>> {
+        tracing::trace!("reading ciphers from chain..");
+        let ciphers = self
+            .contract
+            .checkIsParticipantAndReturnRound2Ciphers(oprf_key_id.into_inner())
+            .call()
+            .await?;
+
+        tracing::trace!("got ciphers from chain {} - parsing..", ciphers.len());
+        Ok(ciphers
+            .into_iter()
+            .map(SecretGenCiphertext::try_from)
+            .collect::<eyre::Result<Vec<_>>>()
+            .context("while parsing round 2 ciphers")?)
+    }
+
+    async fn fetch_consumer_public_keys(
+        &self,
+        oprf_key_id: OprfKeyId,
+    ) -> Result<Vec<EphemeralEncryptionPublicKey>> {
+        tracing::trace!("getting the public keys from the producers...");
+        let pks = self
+            .contract
+            .loadPeerPublicKeysForConsumers(oprf_key_id.into_inner())
+            .call()
+            .await?;
+
+        Ok(pks
+            .into_iter()
+            .map(EphemeralEncryptionPublicKey::try_from)
+            .collect::<eyre::Result<Vec<_>>>()
+            .context("while parsing consumer public keys")?)
+    }
+}
+
+#[inline]
+fn record_tx_hash(tx_hash: TxHash, span: &tracing::Span) {
+    span.record("tx_hash", tx_hash.to_string());
+}

--- a/oprf-key-gen/src/services/key_event_watcher/tests.rs
+++ b/oprf-key-gen/src/services/key_event_watcher/tests.rs
@@ -118,7 +118,11 @@ async fn test_delete() -> eyre::Result<()> {
         &mut rand::thread_rng(),
     );
     secret_gen
-        .reshare_round1(oprf_key_id, pending_epoch, 2)
+        .reshare_round1(
+            oprf_key_id,
+            pending_epoch,
+            2.try_into().expect("2 is non-zero"),
+        )
         .await?;
     secret_manager
         .store_pending_dlog_share(oprf_key_id, pending_epoch, random_share())
@@ -227,7 +231,11 @@ async fn test_abort() -> eyre::Result<()> {
         &mut rand::thread_rng(),
     );
     secret_gen
-        .reshare_round1(oprf_key_id, pending_epoch, 2)
+        .reshare_round1(
+            oprf_key_id,
+            pending_epoch,
+            2.try_into().expect("2 is non-zero"),
+        )
         .await?;
     secret_manager
         .store_pending_dlog_share(oprf_key_id, pending_epoch, random_share())
@@ -292,7 +300,11 @@ async fn test_not_enough_producers() -> eyre::Result<()> {
         &mut rand::thread_rng(),
     );
     secret_gen
-        .reshare_round1(oprf_key_id, pending_epoch, 2)
+        .reshare_round1(
+            oprf_key_id,
+            pending_epoch,
+            2.try_into().expect("2 is non-zero"),
+        )
         .await?;
     secret_manager
         .store_pending_dlog_share(oprf_key_id, pending_epoch, random_share())

--- a/oprf-key-gen/src/services/key_event_watcher/tests.rs
+++ b/oprf-key-gen/src/services/key_event_watcher/tests.rs
@@ -1,11 +1,9 @@
 use std::{str::FromStr, time::Duration};
 
 use crate::{
-    secret_manager::{SecretManager, SecretManagerError, SecretManagerService},
+    secret_manager::{SecretManager, SecretManagerError},
     services::{
-        key_event_watcher::{
-            KeyRegistryEventError, handle_abort, handle_delete, handle_not_enough_producers,
-        },
+        key_event_watcher::{KeyRegistryEventError, handler::KeyRegistryEventHandler},
         secret_gen::DLogSecretGenService,
         transaction_handler::{TransactionHandler, TransactionHandlerArgs},
     },
@@ -19,11 +17,23 @@ use oprf_test_utils::{DeploySetup, OPRF_PEER_PRIVATE_KEY_0, PEER_ADDRESSES, Test
 use oprf_types::{
     OprfKeyId, ShareEpoch,
     chain::{OprfKeyRegistry, RevertError, Verifier::VerifierErrors},
-    crypto::OprfPublicKey,
 };
 
-const INVALID_PROOF_KEY: usize = 43;
-const WRONG_ROUND_LOAD_PEER_PUBLIC_KEYS: usize = 44;
+use super::events::KeyRegistryEvent;
+
+// Key IDs that trigger special behaviour in TestOprfKeyRegistry:
+//   43 → loadPeerPublicKeysForProducers returns hardcoded EPKs; addRound2Contribution runs the
+//        verifier with all-zero public inputs so any real proof yields ProofInvalid.
+//   44 → loadPeerPublicKeysForProducers reverts with WrongRound, exercising the consumer path.
+const INVALID_PROOF_KEY: u32 = 43;
+const WRONG_ROUND_LOAD_PEER_PUBLIC_KEYS: u32 = 44;
+
+struct HandlerFixture {
+    handler: KeyRegistryEventHandler,
+    secret_manager: TestKeyGenSecretManager,
+    secret_gen: DLogSecretGenService,
+}
+
 fn key_gen_material(deploy_setup: DeploySetup) -> CircomGroth16Material {
     CircomGroth16MaterialBuilder::new()
         .bbf_inv()
@@ -32,19 +42,11 @@ fn key_gen_material(deploy_setup: DeploySetup) -> CircomGroth16Material {
         .expect("Can build key_gen_material")
 }
 
-fn test_secret_manager() -> TestKeyGenSecretManager {
-    TestKeyGenSecretManager::new(OPRF_PEER_PRIVATE_KEY_0)
-}
+fn fixture(setup: &TestSetup) -> HandlerFixture {
+    let secret_manager = TestKeyGenSecretManager::new(OPRF_PEER_PRIVATE_KEY_0);
+    let secret_gen =
+        DLogSecretGenService::init(key_gen_material(setup.setup), secret_manager.service());
 
-fn random_share() -> DLogShareShamir {
-    DLogShareShamir::from(rand::random::<ark_babyjubjub::Fr>())
-}
-
-fn random_public_key() -> OprfPublicKey {
-    OprfPublicKey::new(rand::random())
-}
-
-fn test_config(setup: &TestSetup) -> (CircomGroth16Material, TransactionHandler) {
     let rpc_provider =
         HttpRpcProviderBuilder::with_default_values(vec![setup.anvil.endpoint_url()])
             .environment(Environment::Dev)
@@ -66,33 +68,44 @@ fn test_config(setup: &TestSetup) -> (CircomGroth16Material, TransactionHandler)
         contract_address: setup.oprf_key_registry,
     });
 
-    (key_gen_material(setup.setup), transaction_handler)
+    let contract = OprfKeyRegistry::new(setup.oprf_key_registry, setup.provider.clone());
+    let threshold = 2.try_into().expect("non-zero");
+    let handler =
+        KeyRegistryEventHandler::new(contract, secret_gen.clone(), threshold, transaction_handler);
+
+    HandlerFixture {
+        handler,
+        secret_manager,
+        secret_gen,
+    }
+}
+
+fn random_share() -> DLogShareShamir {
+    DLogShareShamir::from(rand::random::<ark_babyjubjub::Fr>())
 }
 
 #[tokio::test]
-async fn test_send_invalid_proof() -> eyre::Result<()> {
+async fn test_round2_invalid_proof() -> eyre::Result<()> {
     let setup = TestSetup::new(DeploySetup::TwoThree).await?;
-    let (key_gen_material, transaction_handler) = test_config(&setup);
-    let secret_manager = test_secret_manager();
-    let secret_manager_service: SecretManagerService = secret_manager.service();
-    let secret_gen = DLogSecretGenService::init(key_gen_material, secret_manager_service);
-    let key_id = U160::from(INVALID_PROOF_KEY);
-    secret_gen
-        .key_gen_round1(
-            key_id.into(),
-            ShareEpoch::default(),
-            2.try_into().expect("1 is non-zero"),
-        )
+    let fx = fixture(&setup);
+    let key_id = OprfKeyId::from(U160::from(INVALID_PROOF_KEY));
+    let epoch = ShareEpoch::default();
+
+    // Generate local intermediates (TestOprfKeyRegistry returns hardcoded EPKs for key 43,
+    // so producer_round2 will produce a proof whose public inputs mismatch on-chain → ProofInvalid).
+    fx.secret_gen
+        .key_gen_round1(key_id, epoch, 2.try_into().expect("non-zero"))
         .await?;
-    let error = super::handle_round2(
-        OprfKeyId::from(key_id),
-        ShareEpoch::from(0u32),
-        &OprfKeyRegistry::new(setup.oprf_key_registry, setup.provider.clone()),
-        &secret_gen,
-        &transaction_handler,
-    )
-    .await
-    .expect_err("should fail");
+
+    let error = fx
+        .handler
+        .handle(
+            KeyRegistryEvent::Round2 { key_id, epoch },
+            &tracing::Span::none(),
+        )
+        .await
+        .expect_err("should fail with ProofInvalid");
+
     assert!(matches!(
         error,
         KeyRegistryEventError::Revert(RevertError::Verifier(VerifierErrors::ProofInvalid(_)))
@@ -101,111 +114,31 @@ async fn test_send_invalid_proof() -> eyre::Result<()> {
 }
 
 #[tokio::test]
-async fn test_delete() -> eyre::Result<()> {
-    let secret_manager = test_secret_manager();
-    let secret_manager_service: SecretManagerService = secret_manager.service();
-    let secret_gen = DLogSecretGenService::init(
-        key_gen_material(DeploySetup::TwoThree),
-        secret_manager_service,
-    );
-
-    let oprf_key_id = OprfKeyId::new(U160::from(42));
-    let confirmed_epoch = ShareEpoch::default();
-    let pending_epoch = confirmed_epoch.next();
-    secret_manager.add_random_key_material_with_id_epoch(
-        oprf_key_id,
-        confirmed_epoch,
-        &mut rand::thread_rng(),
-    );
-    secret_gen
-        .reshare_round1(
-            oprf_key_id,
-            pending_epoch,
-            2.try_into().expect("2 is non-zero"),
-        )
-        .await?;
-    secret_manager
-        .store_pending_dlog_share(oprf_key_id, pending_epoch, random_share())
-        .await?;
-
-    assert!(
-        secret_manager
-            .get_share_by_epoch(oprf_key_id, confirmed_epoch)
-            .await?
-            .is_some()
-    );
-    secret_manager
-        .fetch_keygen_intermediates(oprf_key_id, pending_epoch)
-        .await?;
-
-    handle_delete(oprf_key_id, &secret_gen)
-        .await
-        .expect("Works");
-
-    assert!(
-        secret_manager
-            .get_share_by_epoch(oprf_key_id, confirmed_epoch)
-            .await?
-            .is_none()
-    );
-    let should_err = secret_manager
-        .fetch_keygen_intermediates(oprf_key_id, pending_epoch)
-        .await
-        .expect_err("Should have missing intermediates");
-
-    assert!(
-        matches!(
-            should_err,
-            SecretManagerError::MissingIntermediates(is_oprf_key, is_epoch) if is_oprf_key == oprf_key_id && is_epoch == pending_epoch
-        ),
-        "Should be MissingIntermediates but is {should_err}"
-    );
-
-    let error = secret_manager
-        .confirm_dlog_share(oprf_key_id, pending_epoch, random_public_key())
-        .await
-        .expect_err("delete must clear pending shares");
-    assert!(matches!(
-        error,
-        SecretManagerError::MissingIntermediates(id, epoch)
-            if id == oprf_key_id && epoch == pending_epoch
-    ));
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn test_round2_in_wrong_round_during_load_public_keys() -> eyre::Result<()> {
+async fn test_round2_consumer_path_when_contract_in_wrong_round() -> eyre::Result<()> {
     let setup = TestSetup::new(DeploySetup::TwoThree).await?;
-    let (key_gen_material, transaction_handler) = test_config(&setup);
-    let secret_manager = test_secret_manager();
-    let secret_manager_service: SecretManagerService = secret_manager.service();
-    let secret_gen = DLogSecretGenService::init(key_gen_material, secret_manager_service);
+    let fx = fixture(&setup);
     let key_id = OprfKeyId::from(U160::from(WRONG_ROUND_LOAD_PEER_PUBLIC_KEYS));
     let epoch = ShareEpoch::default();
 
-    secret_gen
-        .key_gen_round1(key_id, epoch, 2.try_into().expect("2 is non-zero"))
-        .await?;
-    secret_manager
-        .fetch_keygen_intermediates(key_id, epoch)
+    fx.secret_gen
+        .key_gen_round1(key_id, epoch, 2.try_into().expect("non-zero"))
         .await?;
 
-    super::handle_round2(
-        key_id,
-        epoch,
-        &OprfKeyRegistry::new(setup.oprf_key_registry, setup.provider.clone()),
-        &secret_gen,
-        &transaction_handler,
-    )
-    .await
-    .expect("Should still work");
+    // TestOprfKeyRegistry reverts with WrongRound for key 44; handler takes the consumer path → Ok(()).
+    fx.handler
+        .handle(
+            KeyRegistryEvent::Round2 { key_id, epoch },
+            &tracing::Span::none(),
+        )
+        .await
+        .expect("consumer path should succeed");
 
-    secret_manager
+    // Intermediates survive; no share was confirmed.
+    fx.secret_manager
         .fetch_keygen_intermediates(key_id, epoch)
         .await?;
     assert!(
-        secret_manager
+        fx.secret_manager
             .get_share_by_epoch(key_id, epoch)
             .await?
             .is_none()
@@ -214,140 +147,103 @@ async fn test_round2_in_wrong_round_during_load_public_keys() -> eyre::Result<()
 }
 
 #[tokio::test]
-async fn test_abort() -> eyre::Result<()> {
-    let secret_manager = test_secret_manager();
-    let secret_manager_service: SecretManagerService = secret_manager.service();
-    let secret_gen = DLogSecretGenService::init(
-        key_gen_material(DeploySetup::TwoThree),
-        secret_manager_service,
-    );
-
-    let oprf_key_id = OprfKeyId::new(U160::from(142));
+async fn test_delete() -> eyre::Result<()> {
+    let setup = TestSetup::new(DeploySetup::TwoThree).await?;
+    let fx = fixture(&setup);
+    let key_id = OprfKeyId::new(U160::from(42u32));
     let confirmed_epoch = ShareEpoch::default();
     let pending_epoch = confirmed_epoch.next();
-    secret_manager.add_random_key_material_with_id_epoch(
-        oprf_key_id,
+
+    fx.secret_manager.add_random_key_material_with_id_epoch(
+        key_id,
         confirmed_epoch,
         &mut rand::thread_rng(),
     );
-    secret_gen
-        .reshare_round1(
-            oprf_key_id,
-            pending_epoch,
-            2.try_into().expect("2 is non-zero"),
-        )
+    fx.secret_gen
+        .reshare_round1(key_id, pending_epoch, 2.try_into().expect("non-zero"))
         .await?;
-    secret_manager
-        .store_pending_dlog_share(oprf_key_id, pending_epoch, random_share())
+    fx.secret_manager
+        .store_pending_dlog_share(key_id, pending_epoch, random_share())
         .await?;
 
-    secret_manager
-        .fetch_keygen_intermediates(oprf_key_id, pending_epoch)
-        .await?;
     assert!(
-        secret_manager
-            .get_share_by_epoch(oprf_key_id, confirmed_epoch)
+        fx.secret_manager
+            .get_share_by_epoch(key_id, confirmed_epoch)
             .await?
             .is_some()
     );
+    fx.secret_manager
+        .fetch_keygen_intermediates(key_id, pending_epoch)
+        .await?;
 
-    handle_abort(oprf_key_id, &secret_gen).await?;
-
-    let error = secret_manager
-        .fetch_keygen_intermediates(oprf_key_id, pending_epoch)
+    fx.handler
+        .handle(KeyRegistryEvent::Delete { key_id }, &tracing::Span::none())
         .await
-        .expect_err("Intermediates must be gone now");
-    assert!(matches!(
-        error,
-        SecretManagerError::MissingIntermediates(id, epoch)
-            if id == oprf_key_id && epoch == pending_epoch
-    ));
+        .expect("delete should succeed");
+
+    // Confirmed share removed.
     assert!(
-        secret_manager
-            .get_share_by_epoch(oprf_key_id, confirmed_epoch)
+        fx.secret_manager
+            .get_share_by_epoch(key_id, confirmed_epoch)
             .await?
-            .is_some()
+            .is_none()
     );
 
-    let error = secret_manager
-        .confirm_dlog_share(oprf_key_id, pending_epoch, random_public_key())
+    // Intermediates cleared.
+    let err = fx
+        .secret_manager
+        .fetch_keygen_intermediates(key_id, pending_epoch)
         .await
-        .expect_err("abort must clear pending shares");
-    assert!(matches!(
-        error,
-        SecretManagerError::MissingIntermediates(id, epoch)
-            if id == oprf_key_id && epoch == pending_epoch
-    ));
+        .expect_err("intermediates must be gone");
+    assert!(
+        matches!(err, SecretManagerError::MissingIntermediates(id, ep) if id == key_id && ep == pending_epoch),
+        "unexpected error: {err}"
+    );
 
     Ok(())
 }
 
 #[tokio::test]
-async fn test_not_enough_producers() -> eyre::Result<()> {
-    let secret_manager = test_secret_manager();
-    let secret_manager_service: SecretManagerService = secret_manager.service();
-    let secret_gen = DLogSecretGenService::init(
-        key_gen_material(DeploySetup::TwoThree),
-        secret_manager_service,
-    );
-
-    let oprf_key_id = OprfKeyId::new(U160::from(242));
+async fn test_abort() -> eyre::Result<()> {
+    let setup = TestSetup::new(DeploySetup::TwoThree).await?;
+    let fx = fixture(&setup);
+    let key_id = OprfKeyId::new(U160::from(142u32));
     let confirmed_epoch = ShareEpoch::default();
     let pending_epoch = confirmed_epoch.next();
-    secret_manager.add_random_key_material_with_id_epoch(
-        oprf_key_id,
+
+    fx.secret_manager.add_random_key_material_with_id_epoch(
+        key_id,
         confirmed_epoch,
         &mut rand::thread_rng(),
     );
-    secret_gen
-        .reshare_round1(
-            oprf_key_id,
-            pending_epoch,
-            2.try_into().expect("2 is non-zero"),
-        )
+    fx.secret_gen
+        .reshare_round1(key_id, pending_epoch, 2.try_into().expect("non-zero"))
         .await?;
-    secret_manager
-        .store_pending_dlog_share(oprf_key_id, pending_epoch, random_share())
+    fx.secret_manager
+        .store_pending_dlog_share(key_id, pending_epoch, random_share())
         .await?;
 
-    secret_manager
-        .fetch_keygen_intermediates(oprf_key_id, pending_epoch)
+    fx.handler
+        .handle(KeyRegistryEvent::Abort { key_id }, &tracing::Span::none())
         .await?;
+
+    // In-progress state cleared.
+    let err = fx
+        .secret_manager
+        .fetch_keygen_intermediates(key_id, pending_epoch)
+        .await
+        .expect_err("intermediates must be gone");
     assert!(
-        secret_manager
-            .get_share_by_epoch(oprf_key_id, confirmed_epoch)
+        matches!(err, SecretManagerError::MissingIntermediates(id, ep) if id == key_id && ep == pending_epoch),
+        "unexpected error: {err}"
+    );
+
+    // Confirmed share preserved.
+    assert!(
+        fx.secret_manager
+            .get_share_by_epoch(key_id, confirmed_epoch)
             .await?
             .is_some()
     );
-
-    handle_not_enough_producers(oprf_key_id, &secret_gen).await?;
-
-    let error = secret_manager
-        .fetch_keygen_intermediates(oprf_key_id, pending_epoch)
-        .await
-        .expect_err("Should be an error");
-
-    assert!(matches!(
-        error,
-        SecretManagerError::MissingIntermediates(id, epoch)
-            if id == oprf_key_id && epoch == pending_epoch
-    ));
-    assert!(
-        secret_manager
-            .get_share_by_epoch(oprf_key_id, confirmed_epoch)
-            .await?
-            .is_some()
-    );
-
-    let error = secret_manager
-        .confirm_dlog_share(oprf_key_id, pending_epoch, random_public_key())
-        .await
-        .expect_err("not-enough-producers must clear pending shares");
-    assert!(matches!(
-        error,
-        SecretManagerError::MissingIntermediates(id, epoch)
-            if id == oprf_key_id && epoch == pending_epoch
-    ));
-
     Ok(())
 }

--- a/oprf-key-gen/src/services/key_event_watcher/tests.rs
+++ b/oprf-key-gen/src/services/key_event_watcher/tests.rs
@@ -4,7 +4,7 @@ use crate::{
     secret_manager::{SecretManager, SecretManagerError, SecretManagerService},
     services::{
         key_event_watcher::{
-            TransactionError, handle_abort, handle_delete, handle_not_enough_producers,
+            KeyRegistryEventError, handle_abort, handle_delete, handle_not_enough_producers,
         },
         secret_gen::DLogSecretGenService,
         transaction_handler::{TransactionHandler, TransactionHandlerArgs},
@@ -63,6 +63,7 @@ fn test_config(setup: &TestSetup) -> (CircomGroth16Material, TransactionHandler)
         max_gas_per_transaction: 10_000_000,
         rpc_provider,
         wallet_address: PEER_ADDRESSES[0],
+        contract_address: setup.oprf_key_registry,
     });
 
     (key_gen_material(setup.setup), transaction_handler)
@@ -77,7 +78,11 @@ async fn test_send_invalid_proof() -> eyre::Result<()> {
     let secret_gen = DLogSecretGenService::init(key_gen_material, secret_manager_service);
     let key_id = U160::from(INVALID_PROOF_KEY);
     secret_gen
-        .key_gen_round1(key_id.into(), ShareEpoch::default(), 2)
+        .key_gen_round1(
+            key_id.into(),
+            ShareEpoch::default(),
+            2.try_into().expect("1 is non-zero"),
+        )
         .await?;
     let error = super::handle_round2(
         OprfKeyId::from(key_id),
@@ -90,7 +95,7 @@ async fn test_send_invalid_proof() -> eyre::Result<()> {
     .expect_err("should fail");
     assert!(matches!(
         error,
-        TransactionError::Revert(RevertError::Verifier(VerifierErrors::ProofInvalid(_)))
+        KeyRegistryEventError::Revert(RevertError::Verifier(VerifierErrors::ProofInvalid(_)))
     ));
     Ok(())
 }
@@ -125,12 +130,9 @@ async fn test_delete() -> eyre::Result<()> {
             .await?
             .is_some()
     );
-    assert!(
-        secret_manager
-            .fetch_keygen_intermediates(oprf_key_id, pending_epoch)
-            .await?
-            .is_some()
-    );
+    secret_manager
+        .fetch_keygen_intermediates(oprf_key_id, pending_epoch)
+        .await?;
 
     handle_delete(oprf_key_id, &secret_gen)
         .await
@@ -142,11 +144,17 @@ async fn test_delete() -> eyre::Result<()> {
             .await?
             .is_none()
     );
+    let should_err = secret_manager
+        .fetch_keygen_intermediates(oprf_key_id, pending_epoch)
+        .await
+        .expect_err("Should have missing intermediates");
+
     assert!(
-        secret_manager
-            .fetch_keygen_intermediates(oprf_key_id, pending_epoch)
-            .await?
-            .is_none()
+        matches!(
+            should_err,
+            SecretManagerError::MissingIntermediates(is_oprf_key, is_epoch) if is_oprf_key == oprf_key_id && is_epoch == pending_epoch
+        ),
+        "Should be MissingIntermediates but is {should_err}"
     );
 
     let error = secret_manager
@@ -172,13 +180,12 @@ async fn test_round2_in_wrong_round_during_load_public_keys() -> eyre::Result<()
     let key_id = OprfKeyId::from(U160::from(WRONG_ROUND_LOAD_PEER_PUBLIC_KEYS));
     let epoch = ShareEpoch::default();
 
-    secret_gen.key_gen_round1(key_id, epoch, 2).await?;
-    assert!(
-        secret_manager
-            .fetch_keygen_intermediates(key_id, epoch)
-            .await?
-            .is_some()
-    );
+    secret_gen
+        .key_gen_round1(key_id, epoch, 2.try_into().expect("2 is non-zero"))
+        .await?;
+    secret_manager
+        .fetch_keygen_intermediates(key_id, epoch)
+        .await?;
 
     super::handle_round2(
         key_id,
@@ -190,13 +197,9 @@ async fn test_round2_in_wrong_round_during_load_public_keys() -> eyre::Result<()
     .await
     .expect("Should still work");
 
-    assert!(
-        secret_manager
-            .fetch_keygen_intermediates(key_id, epoch)
-            .await?
-            .is_some(),
-        "consumer path must keep round-1 intermediates for round 3"
-    );
+    secret_manager
+        .fetch_keygen_intermediates(key_id, epoch)
+        .await?;
     assert!(
         secret_manager
             .get_share_by_epoch(key_id, epoch)
@@ -230,12 +233,9 @@ async fn test_abort() -> eyre::Result<()> {
         .store_pending_dlog_share(oprf_key_id, pending_epoch, random_share())
         .await?;
 
-    assert!(
-        secret_manager
-            .fetch_keygen_intermediates(oprf_key_id, pending_epoch)
-            .await?
-            .is_some()
-    );
+    secret_manager
+        .fetch_keygen_intermediates(oprf_key_id, pending_epoch)
+        .await?;
     assert!(
         secret_manager
             .get_share_by_epoch(oprf_key_id, confirmed_epoch)
@@ -245,12 +245,15 @@ async fn test_abort() -> eyre::Result<()> {
 
     handle_abort(oprf_key_id, &secret_gen).await?;
 
-    assert!(
-        secret_manager
-            .fetch_keygen_intermediates(oprf_key_id, pending_epoch)
-            .await?
-            .is_none()
-    );
+    let error = secret_manager
+        .fetch_keygen_intermediates(oprf_key_id, pending_epoch)
+        .await
+        .expect_err("Intermediates must be gone now");
+    assert!(matches!(
+        error,
+        SecretManagerError::MissingIntermediates(id, epoch)
+            if id == oprf_key_id && epoch == pending_epoch
+    ));
     assert!(
         secret_manager
             .get_share_by_epoch(oprf_key_id, confirmed_epoch)
@@ -295,12 +298,9 @@ async fn test_not_enough_producers() -> eyre::Result<()> {
         .store_pending_dlog_share(oprf_key_id, pending_epoch, random_share())
         .await?;
 
-    assert!(
-        secret_manager
-            .fetch_keygen_intermediates(oprf_key_id, pending_epoch)
-            .await?
-            .is_some()
-    );
+    secret_manager
+        .fetch_keygen_intermediates(oprf_key_id, pending_epoch)
+        .await?;
     assert!(
         secret_manager
             .get_share_by_epoch(oprf_key_id, confirmed_epoch)
@@ -310,12 +310,16 @@ async fn test_not_enough_producers() -> eyre::Result<()> {
 
     handle_not_enough_producers(oprf_key_id, &secret_gen).await?;
 
-    assert!(
-        secret_manager
-            .fetch_keygen_intermediates(oprf_key_id, pending_epoch)
-            .await?
-            .is_none()
-    );
+    let error = secret_manager
+        .fetch_keygen_intermediates(oprf_key_id, pending_epoch)
+        .await
+        .expect_err("Should be an error");
+
+    assert!(matches!(
+        error,
+        SecretManagerError::MissingIntermediates(id, epoch)
+            if id == oprf_key_id && epoch == pending_epoch
+    ));
     assert!(
         secret_manager
             .get_share_by_epoch(oprf_key_id, confirmed_epoch)

--- a/oprf-key-gen/src/services/key_event_watcher/tests.rs
+++ b/oprf-key-gen/src/services/key_event_watcher/tests.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, time::Duration};
+use std::{num::NonZeroU16, str::FromStr, time::Duration};
 
 use crate::{
     secret_manager::{SecretManager, SecretManagerError},
@@ -69,7 +69,7 @@ fn fixture(setup: &TestSetup) -> HandlerFixture {
     });
 
     let contract = OprfKeyRegistry::new(setup.oprf_key_registry, setup.provider.clone());
-    let threshold = 2.try_into().expect("non-zero");
+    let threshold = NonZeroU16::new(2).expect("2 is non-zero");
     let handler =
         KeyRegistryEventHandler::new(contract, secret_gen.clone(), threshold, transaction_handler);
 
@@ -94,7 +94,7 @@ async fn test_round2_invalid_proof() -> eyre::Result<()> {
     // Generate local intermediates (TestOprfKeyRegistry returns hardcoded EPKs for key 43,
     // so producer_round2 will produce a proof whose public inputs mismatch on-chain → ProofInvalid).
     fx.secret_gen
-        .key_gen_round1(key_id, epoch, 2.try_into().expect("non-zero"))
+        .key_gen_round1(key_id, epoch, NonZeroU16::new(2).expect("non-zero"))
         .await?;
 
     let error = fx
@@ -121,7 +121,7 @@ async fn test_round2_consumer_path_when_contract_in_wrong_round() -> eyre::Resul
     let epoch = ShareEpoch::default();
 
     fx.secret_gen
-        .key_gen_round1(key_id, epoch, 2.try_into().expect("non-zero"))
+        .key_gen_round1(key_id, epoch, NonZeroU16::new(2).expect("non-zero"))
         .await?;
 
     // TestOprfKeyRegistry reverts with WrongRound for key 44; handler takes the consumer path → Ok(()).
@@ -160,7 +160,7 @@ async fn test_delete() -> eyre::Result<()> {
         &mut rand::thread_rng(),
     );
     fx.secret_gen
-        .reshare_round1(key_id, pending_epoch, 2.try_into().expect("non-zero"))
+        .reshare_round1(key_id, pending_epoch, NonZeroU16::new(2).expect("non-zero"))
         .await?;
     fx.secret_manager
         .store_pending_dlog_share(key_id, pending_epoch, random_share())
@@ -217,7 +217,7 @@ async fn test_abort() -> eyre::Result<()> {
         &mut rand::thread_rng(),
     );
     fx.secret_gen
-        .reshare_round1(key_id, pending_epoch, 2.try_into().expect("non-zero"))
+        .reshare_round1(key_id, pending_epoch, NonZeroU16::new(2).expect("non-zero"))
         .await?;
     fx.secret_manager
         .store_pending_dlog_share(key_id, pending_epoch, random_share())

--- a/oprf-key-gen/src/services/secret_gen.rs
+++ b/oprf-key-gen/src/services/secret_gen.rs
@@ -72,6 +72,7 @@ pub(crate) enum Contributions {
 /// Service for managing the distributed key-gen/reshare protocol.
 ///
 /// **Note:** Must only be used in a single-owner context. Do not share across tasks.
+#[derive(Clone)]
 pub(crate) struct DLogSecretGenService {
     secret_manager: SecretManagerService,
     key_gen_material: Arc<CircomGroth16Material>,

--- a/oprf-key-gen/src/services/secret_gen.rs
+++ b/oprf-key-gen/src/services/secret_gen.rs
@@ -17,7 +17,7 @@
 //! generation protocol.
 
 use core::fmt;
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, num::NonZeroU16, sync::Arc};
 
 use alloy::primitives::U256;
 use ark_ec::{AffineRepr as _, CurveGroup as _};
@@ -45,6 +45,17 @@ use crate::secret_manager::{SecretManagerError, SecretManagerService};
 
 #[cfg(test)]
 mod tests;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SecretGenError {
+    #[error(transparent)]
+    SecretManagerError(#[from] SecretManagerError),
+    #[error(transparent)]
+    Internal(#[from] eyre::Report),
+}
+
+// Cannot use type alias Result because CanonicalSerialize/CanonicalDeserialize yield compiler errors in that case
+type SecretGenResult<T> = std::result::Result<T, SecretGenError>;
 
 /// Defines how many contributions we need to reconstruct the received [`DLogShareShamir`].
 ///
@@ -191,18 +202,17 @@ impl DLogSecretGenService {
     pub(crate) async fn delete_oprf_key_material(
         &self,
         oprf_key_id: OprfKeyId,
-    ) -> Result<(), SecretManagerError> {
+    ) -> SecretGenResult<()> {
         self.secret_manager
             .delete_oprf_key_material(oprf_key_id)
-            .await
+            .await?;
+        Ok(())
     }
 
     /// Aborts an in-process keygen.
-    pub(crate) async fn abort_keygen(
-        &self,
-        oprf_key_id: OprfKeyId,
-    ) -> Result<(), SecretManagerError> {
-        self.secret_manager.abort_keygen(oprf_key_id).await
+    pub(crate) async fn abort_keygen(&self, oprf_key_id: OprfKeyId) -> SecretGenResult<()> {
+        self.secret_manager.abort_keygen(oprf_key_id).await?;
+        Ok(())
     }
 
     /// Executes round 1 of the key-gen protocol.
@@ -218,16 +228,15 @@ impl DLogSecretGenService {
         &self,
         oprf_key_id: OprfKeyId,
         pending_epoch: ShareEpoch,
-        threshold: u16,
-    ) -> eyre::Result<Round1Contribution> {
+        threshold: NonZeroU16,
+    ) -> SecretGenResult<Round1Contribution> {
         tracing::trace!("secret gen round1 - creating new intermediates");
-        let degree = usize::from(threshold - 1);
+        let degree = usize::from(threshold.get() - 1);
         let intermediates = KeyGenIntermediateValues::new(degree, &mut rand::thread_rng());
         let intermediates = self
             .secret_manager
             .try_store_keygen_intermediates(oprf_key_id, pending_epoch, intermediates)
-            .await
-            .context("while storing key-gen intermediates")?;
+            .await?;
         Ok(intermediates.build_round1_contribution())
     }
 
@@ -245,16 +254,11 @@ impl DLogSecretGenService {
         oprf_key_id: OprfKeyId,
         pending_epoch: ShareEpoch,
         pks: Vec<EphemeralEncryptionPublicKey>,
-    ) -> eyre::Result<Option<SecretGenCiphertexts>> {
+    ) -> SecretGenResult<SecretGenCiphertexts> {
         let intermediate_values = self
             .secret_manager
             .fetch_keygen_intermediates(oprf_key_id, pending_epoch)
-            .await
-            .context("while fetching intermediate values")?;
-        let Some(intermediate_values) = intermediate_values else {
-            tracing::warn!("no intermediate values stored for round 2 - this key-gen is stuck");
-            return Ok(None);
-        };
+            .await?;
         let key_gen_material = Arc::clone(&self.key_gen_material);
         let contribution = tokio::task::spawn_blocking(move || {
             compute_keygen_proof(&key_gen_material, intermediate_values, &pks)
@@ -262,7 +266,7 @@ impl DLogSecretGenService {
         .await
         .context("while joining compute key-gen")?
         .context("while computing proof for round2")?;
-        Ok(Some(contribution))
+        Ok(contribution)
     }
 
     /// Decrypts received ciphertexts and stores the resulting pending share for this party.
@@ -279,25 +283,19 @@ impl DLogSecretGenService {
         ciphers: Vec<SecretGenCiphertext>,
         sharing_type: Contributions,
         pks: &[EphemeralEncryptionPublicKey],
-    ) -> eyre::Result<Option<()>> {
+    ) -> SecretGenResult<()> {
         tracing::trace!("calling round3 with {}", ciphers.len());
         let intermediate_values = self
             .secret_manager
             .fetch_keygen_intermediates(oprf_key_id, pending_epoch)
-            .await
-            .context("while fetching intermediate values")?;
-        let Some(intermediate_values) = intermediate_values else {
-            tracing::warn!("no intermediate values stored for round 3 - this key-gen is stuck");
-            return Ok(None);
-        };
+            .await?;
         let share = decrypt_key_gen_ciphertexts(ciphers, intermediate_values, sharing_type, pks)
             .context("while computing DLogShare")?;
         // Store the computed share as pending until the finalize event confirms it.
         self.secret_manager
             .store_pending_dlog_share(oprf_key_id, pending_epoch, share)
-            .await
-            .context("while storing pending share")?;
-        Ok(Some(()))
+            .await?;
+        Ok(())
     }
 
     /// Marks the generated secret as finished.
@@ -311,11 +309,11 @@ impl DLogSecretGenService {
         oprf_key_id: OprfKeyId,
         epoch: ShareEpoch,
         public_key: OprfPublicKey,
-    ) -> eyre::Result<()> {
+    ) -> SecretGenResult<()> {
         self.secret_manager
             .confirm_dlog_share(oprf_key_id, epoch, public_key)
-            .await
-            .context("while confirming dlog share")
+            .await?;
+        Ok(())
     }
 
     /// Executes round 1 of the reshare protocol.
@@ -333,13 +331,12 @@ impl DLogSecretGenService {
         oprf_key_id: OprfKeyId,
         pending_epoch: ShareEpoch,
         threshold: u16,
-    ) -> eyre::Result<Round1Contribution> {
+    ) -> SecretGenResult<Round1Contribution> {
         tracing::trace!("creating new intermediates");
         let old_share = self
             .secret_manager
             .get_share_by_epoch(oprf_key_id, pending_epoch.prev())
-            .await
-            .context("while loading previous epoch share for reshare")?;
+            .await?;
         let intermediates = if let Some(old_share) = old_share {
             tracing::trace!("found share - we want to be PRODUCER");
             let mut rng = rand::thread_rng();
@@ -354,8 +351,7 @@ impl DLogSecretGenService {
         let intermediates = self
             .secret_manager
             .try_store_keygen_intermediates(oprf_key_id, pending_epoch, intermediates)
-            .await
-            .context("while storing key-gen intermediates")?;
+            .await?;
         Ok(intermediates.build_round1_contribution())
     }
 }

--- a/oprf-key-gen/src/services/secret_gen.rs
+++ b/oprf-key-gen/src/services/secret_gen.rs
@@ -46,6 +46,7 @@ use crate::secret_manager::{SecretManagerError, SecretManagerService};
 #[cfg(test)]
 mod tests;
 
+/// Error type returned by [`DLogSecretGenService`] methods.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum SecretGenError {
     #[error(transparent)]
@@ -330,7 +331,7 @@ impl DLogSecretGenService {
         &self,
         oprf_key_id: OprfKeyId,
         pending_epoch: ShareEpoch,
-        threshold: u16,
+        threshold: NonZeroU16,
     ) -> SecretGenResult<Round1Contribution> {
         tracing::trace!("creating new intermediates");
         let old_share = self
@@ -340,7 +341,7 @@ impl DLogSecretGenService {
         let intermediates = if let Some(old_share) = old_share {
             tracing::trace!("found share - we want to be PRODUCER");
             let mut rng = rand::thread_rng();
-            let degree = usize::from(threshold - 1);
+            let degree = usize::from(threshold.get() - 1);
             KeyGenIntermediateValues::reshare(old_share, degree, &mut rng)
         } else {
             tracing::trace!("did not find share - we want to be CONSUMER");

--- a/oprf-key-gen/src/services/secret_gen/tests.rs
+++ b/oprf-key-gen/src/services/secret_gen/tests.rs
@@ -63,7 +63,7 @@ fn build_public_inputs(
 async fn test_secret_gen() -> eyre::Result<()> {
     let mut rng = rand::thread_rng();
     let oprf_key_id = OprfKeyId::new(rng.r#gen());
-    let threshold = 2;
+    let threshold = 2.try_into().expect("2 is non-zero");
     let graph =
         PathBuf::from(std::env!("CARGO_MANIFEST_DIR")).join("../artifacts/OPRFKeyGenGraph.13.bin");
     let graph = std::fs::read(graph)?;
@@ -154,35 +154,29 @@ async fn test_secret_gen() -> eyre::Result<()> {
         dlog_secret_gen1.producer_round2(oprf_key_id, epoch, pks.clone()),
         dlog_secret_gen2.producer_round2(oprf_key_id, epoch, pks.clone())
     );
-    let dlog_secret_gen0_round2 = dlog_secret_gen0_round2
-        .context("while doing round2")?
-        .expect("Should be Some");
-    let dlog_secret_gen1_round2 = dlog_secret_gen1_round2
-        .context("while doing round2")?
-        .expect("Should be Some");
-    let dlog_secret_gen2_round2 = dlog_secret_gen2_round2
-        .context("while doing round2")?
-        .expect("Should be Some");
+    let dlog_secret_gen0_round2 = dlog_secret_gen0_round2.context("while doing round2")?;
+    let dlog_secret_gen1_round2 = dlog_secret_gen1_round2.context("while doing round2")?;
+    let dlog_secret_gen2_round2 = dlog_secret_gen2_round2.context("while doing round2")?;
 
     let [pk0, pk1, pk2] = pks.clone().try_into().expect("Should be three keys");
     // verify the proofs
     // build public inputs for proof0
     let public_inputs0 = build_public_inputs(
-        threshold - 1,
+        threshold.get() - 1,
         pk0,
         &dlog_secret_gen0_round2,
         &flattened_pks,
         &commitments0,
     );
     let public_inputs1 = build_public_inputs(
-        threshold - 1,
+        threshold.get() - 1,
         pk1,
         &dlog_secret_gen1_round2,
         &flattened_pks,
         &commitments1,
     );
     let public_inputs2 = build_public_inputs(
-        threshold - 1,
+        threshold.get() - 1,
         pk2,
         &dlog_secret_gen2_round2,
         &flattened_pks,
@@ -207,16 +201,13 @@ async fn test_secret_gen() -> eyre::Result<()> {
     let [ciphers0, ciphers1, ciphers2] = ciphers.try_into().expect("len is 3");
     dlog_secret_gen0
         .round3(oprf_key_id, epoch, ciphers0, Contributions::Full, &pks)
-        .await?
-        .expect("Should be Some");
+        .await?;
     dlog_secret_gen1
         .round3(oprf_key_id, epoch, ciphers1, Contributions::Full, &pks)
-        .await?
-        .expect("Should be Some");
+        .await?;
     dlog_secret_gen2
         .round3(oprf_key_id, epoch, ciphers2, Contributions::Full, &pks)
-        .await?
-        .expect("Should be Some");
+        .await?;
 
     // finalize round
     dlog_secret_gen0
@@ -254,27 +245,33 @@ async fn test_secret_gen() -> eyre::Result<()> {
 
     assert_eq!(is_public_key, should_public_key);
     // check that shares are removed correctly
-    assert!(
-        secret_manager0
-            .fetch_keygen_intermediates(oprf_key_id, epoch)
-            .await?
-            .is_none(),
-        "Intermediates must be gone now"
-    );
-    assert!(
-        secret_manager1
-            .fetch_keygen_intermediates(oprf_key_id, epoch)
-            .await?
-            .is_none(),
-        "Intermediates must be gone now"
-    );
-    assert!(
-        secret_manager2
-            .fetch_keygen_intermediates(oprf_key_id, epoch)
-            .await?
-            .is_none(),
-        "Intermediates must be gone now"
-    );
+    let error0 = secret_manager0
+        .fetch_keygen_intermediates(oprf_key_id, epoch)
+        .await
+        .expect_err("Intermediates must be gone now");
+    let error1 = secret_manager1
+        .fetch_keygen_intermediates(oprf_key_id, epoch)
+        .await
+        .expect_err("Intermediates must be gone now");
+    let error2 = secret_manager2
+        .fetch_keygen_intermediates(oprf_key_id, epoch)
+        .await
+        .expect_err("Intermediates must be gone now");
+    assert!(matches!(
+        error0,
+        SecretManagerError::MissingIntermediates(id, epoch)
+            if id == oprf_key_id && epoch == epoch
+    ));
+    assert!(matches!(
+        error1,
+        SecretManagerError::MissingIntermediates(id, epoch)
+            if id == oprf_key_id && epoch == epoch
+    ));
+    assert!(matches!(
+        error2,
+        SecretManagerError::MissingIntermediates(id, epoch)
+            if id == oprf_key_id && epoch == epoch
+    ));
 
     Ok(())
 }

--- a/oprf-key-gen/src/services/secret_gen/tests.rs
+++ b/oprf-key-gen/src/services/secret_gen/tests.rs
@@ -257,21 +257,30 @@ async fn test_secret_gen() -> eyre::Result<()> {
         .fetch_keygen_intermediates(oprf_key_id, epoch)
         .await
         .expect_err("Intermediates must be gone now");
-    assert!(matches!(
-        error0,
-        SecretManagerError::MissingIntermediates(id, epoch)
-            if id == oprf_key_id && epoch == epoch
-    ));
-    assert!(matches!(
-        error1,
-        SecretManagerError::MissingIntermediates(id, epoch)
-            if id == oprf_key_id && epoch == epoch
-    ));
-    assert!(matches!(
-        error2,
-        SecretManagerError::MissingIntermediates(id, epoch)
-            if id == oprf_key_id && epoch == epoch
-    ));
+    assert!(
+        matches!(
+            error0,
+            SecretManagerError::MissingIntermediates(id, is_epoch)
+                if id == oprf_key_id && epoch == is_epoch
+        ),
+        "should be Missing Intermediates but is {error0}"
+    );
+    assert!(
+        matches!(
+            error1,
+            SecretManagerError::MissingIntermediates(id, is_epoch)
+                if id == oprf_key_id && epoch == is_epoch
+        ),
+        "should be Missing Intermediates but is {error1}"
+    );
+    assert!(
+        matches!(
+            error2,
+            SecretManagerError::MissingIntermediates(id, is_epoch)
+                if id == oprf_key_id && epoch == is_epoch
+        ),
+        "should be Missing Intermediates but is {error2}"
+    );
 
     Ok(())
 }

--- a/oprf-key-gen/src/services/secret_gen/tests.rs
+++ b/oprf-key-gen/src/services/secret_gen/tests.rs
@@ -63,7 +63,7 @@ fn build_public_inputs(
 async fn test_secret_gen() -> eyre::Result<()> {
     let mut rng = rand::thread_rng();
     let oprf_key_id = OprfKeyId::new(rng.r#gen());
-    let threshold = 2.try_into().expect("2 is non-zero");
+    let threshold = NonZeroU16::new(2).expect("2 is non-zero");
     let graph =
         PathBuf::from(std::env!("CARGO_MANIFEST_DIR")).join("../artifacts/OPRFKeyGenGraph.13.bin");
     let graph = std::fs::read(graph)?;

--- a/oprf-key-gen/src/services/secret_manager.rs
+++ b/oprf-key-gen/src/services/secret_manager.rs
@@ -97,7 +97,7 @@ pub trait SecretManager {
         &self,
         oprf_key_id: OprfKeyId,
         pending_epoch: ShareEpoch,
-    ) -> Result<Option<KeyGenIntermediateValues>>;
+    ) -> Result<KeyGenIntermediateValues>;
 
     /// Stores a pending share for the given key/epoch pair.
     ///

--- a/oprf-key-gen/src/services/secret_manager.rs
+++ b/oprf-key-gen/src/services/secret_manager.rs
@@ -92,7 +92,10 @@ pub trait SecretManager {
 
     /// Retrieves the intermediate values needed for key generation (or reshare).
     ///
-    /// Returns `None` if no intermediate values are stored for the provided key/epoch pair.
+    /// # Errors
+    ///
+    /// Returns [`SecretManagerError::MissingIntermediates`]`(oprf_key_id, epoch)` when no
+    /// intermediate values are stored for the provided key/epoch pair.
     async fn fetch_keygen_intermediates(
         &self,
         oprf_key_id: OprfKeyId,

--- a/oprf-key-gen/src/services/transaction_handler.rs
+++ b/oprf-key-gen/src/services/transaction_handler.rs
@@ -4,9 +4,9 @@ use alloy::{
     contract::{CallBuilder, CallDecoder},
     network::ReceiptResponse,
     primitives::{Address, TxHash},
-    providers::{DynProvider, Provider},
+    providers::{DynProvider, PendingTransactionError, Provider, WatchTxError},
     rpc::types::TransactionReceipt,
-    transports::TransportError,
+    transports::{RpcError, TransportError},
 };
 use backon::{BackoffBuilder as _, ConstantBackoff, ConstantBuilder, Retryable as _};
 use nodes_common::web3;
@@ -127,13 +127,14 @@ impl TransactionHandler {
             .with_required_confirmations(self.confirmations_for_transaction)
             .with_timeout(Some(self.max_wait_time_watch_transaction));
         let tx_hash = pending_transaction.tx_hash().to_owned();
-        let current_span = tracing::Span::current();
-        current_span.record("tx_hash", tx_hash.to_string());
         let get_receipt_result = pending_transaction.get_receipt().await;
         match get_receipt_result {
             Ok(receipt) => Ok(receipt),
-            Err(err) => {
-                tracing::warn!(%err, "initial get_receipt failed - starting backon");
+            Err(
+                err @ (PendingTransactionError::TransportError(RpcError::NullResp)
+                | PendingTransactionError::TxWatcher(WatchTxError::Timeout)),
+            ) => {
+                tracing::warn!(%err, "initial get_receipt failed - starting backoff");
                 let receipt = (|| async {
                     self.rpc_provider
                         .get_transaction_receipt(tx_hash)
@@ -152,6 +153,7 @@ impl TransactionHandler {
                 tracing::info!("successfully fetched receipt after initial fail");
                 Ok(receipt)
             }
+            Err(err) => Err(KeyRegistryEventError::from(err)),
         }
     }
 

--- a/oprf-key-gen/src/services/transaction_handler.rs
+++ b/oprf-key-gen/src/services/transaction_handler.rs
@@ -19,12 +19,7 @@ use oprf_types::{
 };
 use tracing::instrument;
 
-use crate::{
-    metrics::{
-        METRICS_ATTRID_WALLET_ADDRESS, METRICS_ID_GAS_PRICE, METRICS_ID_KEY_GEN_WALLET_BALANCE,
-    },
-    services::key_event_watcher::KeyRegistryEventError,
-};
+use crate::{metrics, services::key_event_watcher::KeyRegistryEventError};
 
 /// Service that handles transaction submission and receipt confirmation.
 ///
@@ -172,8 +167,7 @@ impl TransactionHandler {
         if let Ok(balance) = self.rpc_provider.get_balance(self.wallet_address).await {
             let balance_eth = alloy::primitives::utils::format_ether(balance);
             tracing::trace!("current wallet balance: {balance_eth} ETH",);
-            ::metrics::gauge!(METRICS_ID_KEY_GEN_WALLET_BALANCE, METRICS_ATTRID_WALLET_ADDRESS => self.wallet_address.to_string())
-                    .set(balance_eth.parse::<f64>().unwrap_or(f64::NAN));
+            metrics::wallet::set_wallet_ballance(&balance_eth);
         } else {
             tracing::warn!("could not fetch current wallet balance");
         }
@@ -184,16 +178,11 @@ impl TransactionHandler {
             .unwrap_or(f64::NAN);
         let cost_eth = alloy::primitives::utils::format_ether(receipt.cost());
         // we do this to_string -> parse hop to have easy way to call to NAN if too large
-        let gas_price_wei = receipt
-            .effective_gas_price()
-            .to_string()
-            .parse::<f64>()
-            .unwrap_or(f64::NAN);
         let gas_price_eth = alloy::primitives::utils::format_ether(receipt.effective_gas_price());
         tracing::trace!(
             "gas used: {gas_used}; transaction cost: {cost_eth} ETH; transaction gas price: {gas_price_eth} ETH"
         );
-        metrics::gauge!(METRICS_ID_GAS_PRICE).set(gas_price_wei);
+        metrics::wallet::set_gas_price_from_wei(receipt.effective_gas_price());
         Ok(())
     }
 

--- a/oprf-key-gen/src/services/transaction_handler.rs
+++ b/oprf-key-gen/src/services/transaction_handler.rs
@@ -2,21 +2,28 @@ use std::{f64, time::Duration};
 
 use alloy::{
     contract::{CallBuilder, CallDecoder},
-    network::{Network, ReceiptResponse},
+    network::ReceiptResponse,
     primitives::Address,
-    providers::{PendingTransactionError, Provider},
+    providers::{DynProvider, Provider},
+    rpc::types::TransactionReceipt,
     transports::TransportError,
 };
 use backon::{BackoffBuilder as _, ConstantBackoff, ConstantBuilder, Retryable as _};
-use eyre::Context as _;
 use nodes_common::web3;
+use oprf_types::{
+    OprfKeyId,
+    chain::{
+        OprfKeyGen::Round1Contribution, OprfKeyGen::Round2Contribution,
+        OprfKeyRegistry::OprfKeyRegistryInstance,
+    },
+};
 use tracing::instrument;
 
 use crate::{
     metrics::{
         METRICS_ATTRID_WALLET_ADDRESS, METRICS_ID_GAS_PRICE, METRICS_ID_KEY_GEN_WALLET_BALANCE,
     },
-    services::key_event_watcher::TransactionError,
+    services::key_event_watcher::KeyRegistryEventError,
 };
 
 /// Service that handles transaction submission and receipt confirmation.
@@ -33,6 +40,7 @@ pub(crate) struct TransactionHandler {
     max_gas_per_transaction: u64,
     rpc_provider: web3::HttpRpcProvider,
     wallet_address: Address,
+    contract: OprfKeyRegistryInstance<DynProvider>,
 }
 
 pub(crate) struct TransactionHandlerArgs {
@@ -43,6 +51,7 @@ pub(crate) struct TransactionHandlerArgs {
     pub(crate) max_gas_per_transaction: u64,
     pub(crate) rpc_provider: web3::HttpRpcProvider,
     pub(crate) wallet_address: Address,
+    pub(crate) contract_address: Address,
 }
 
 impl From<TransactionHandlerArgs> for TransactionHandler {
@@ -55,6 +64,7 @@ impl From<TransactionHandlerArgs> for TransactionHandler {
             max_gas_per_transaction,
             rpc_provider,
             wallet_address,
+            contract_address,
         } = value;
         Self {
             max_wait_time_watch_transaction,
@@ -62,8 +72,9 @@ impl From<TransactionHandlerArgs> for TransactionHandler {
             sleep_between_get_receipt,
             max_tries_fetching_receipt,
             max_gas_per_transaction,
-            rpc_provider,
             wallet_address,
+            contract: OprfKeyRegistryInstance::new(contract_address, rpc_provider.inner()),
+            rpc_provider,
         }
     }
 }
@@ -80,60 +91,40 @@ impl TransactionHandler {
             .build()
     }
 
-    /// Attempts to send a transaction and waits for the receipt.
-    ///
-    /// Broadcasts the transaction to the network and waits for the configured number of
-    /// confirmations, up to `max_wait_time`. If the receipt indicates success, returns `Ok`.
-    /// If the receipt indicates failure, performs a static call to extract revert data for
-    /// diagnostics (this is best-effort and should not be taken at face value).
-    ///
-    /// If the transaction could not be sent or the confirmation times out, returns an error.
-    ///
-    /// Takes an `Fn` that produces a `CallBuilder`. This can be done e.g., with
-    /// ```rust,ignore
-    /// transaction_handler
-    ///     .attempt_transaction(|| {
-    ///         contract.addRound1KeyGenContribution(
-    ///             oprf_key_id.into_inner(),
-    ///             contribution.clone().into(),
-    ///         )
-    ///     })
-    ///     .await?;
-    /// ```
-    #[instrument(level = "info", skip_all, fields(tx_hash = tracing::field::Empty))]
-    pub(crate) async fn attempt_transaction<P, D, N, F>(
+    async fn simulate_transaction<D>(
         &self,
-        transaction: F,
-    ) -> Result<(), TransactionError>
+        transaction: CallBuilder<&DynProvider, D>,
+    ) -> Result<(), KeyRegistryEventError>
     where
-        P: Provider<N>,
         D: CallDecoder + Unpin,
-        N: Network,
-        F: Fn() -> CallBuilder<P, D, N>,
     {
-        let pending_transaction = transaction()
+        tracing::trace!("simulating transaction before submitting");
+        transaction.gas(self.max_gas_per_transaction).call().await?;
+        Ok(())
+    }
+
+    async fn send_transaction<D>(
+        &self,
+        transaction: CallBuilder<&DynProvider, D>,
+    ) -> Result<TransactionReceipt, KeyRegistryEventError>
+    where
+        D: CallDecoder + Unpin,
+    {
+        tracing::trace!("sending transaction");
+        let pending_transaction = transaction
             .gas(self.max_gas_per_transaction)
             .send()
-            .await
-            .context("while broadcasting to network")?
+            .await?
             .with_required_confirmations(self.confirmations_for_transaction)
             .with_timeout(Some(self.max_wait_time_watch_transaction));
         let tx_hash = pending_transaction.tx_hash().to_owned();
         let current_span = tracing::Span::current();
         current_span.record("tx_hash", tx_hash.to_string());
-        let receipt_result = pending_transaction.get_receipt().await;
-
-        if let Ok(balance) = self.rpc_provider.get_balance(self.wallet_address).await {
-            let balance_eth = alloy::primitives::utils::format_ether(balance);
-            tracing::trace!("current wallet balance: {balance_eth} ETH",);
-            ::metrics::gauge!(METRICS_ID_KEY_GEN_WALLET_BALANCE, METRICS_ATTRID_WALLET_ADDRESS => self.wallet_address.to_string())
-                    .set(balance_eth.parse::<f64>().unwrap_or(f64::NAN));
-        } else {
-            tracing::warn!("could not fetch current wallet balance");
-        }
-        match receipt_result {
-            Ok(receipt) => check_receipt(transaction, &receipt).await,
-            Err(PendingTransactionError::TransportError(TransportError::NullResp)) => {
+        let get_receipt_result = pending_transaction.get_receipt().await;
+        match get_receipt_result {
+            Ok(receipt) => Ok(receipt),
+            Err(err) => {
+                tracing::warn!(%err, "initial get_receipt failed - starting backon");
                 let receipt = (|| async {
                     self.rpc_provider
                         .get_transaction_receipt(tx_hash)
@@ -148,56 +139,105 @@ impl TransactionHandler {
                         "Retrying eth_getTransactionReceipt in {duration:?} due to NullResp"
                     );
                 })
-                .await
-                .context("while fetching getReceipt")?;
-                check_receipt(transaction, &receipt).await
+                .await?;
+                tracing::info!("successfully fetched receipt after initial fail");
+                Ok(receipt)
             }
-            Err(err) => Err(TransactionError::Rpc(eyre::Report::from(err))),
         }
     }
-}
 
-async fn check_receipt<P, D, N, F, R>(transaction: F, receipt: &R) -> Result<(), TransactionError>
-where
-    P: Provider<N>,
-    D: CallDecoder + Unpin,
-    N: Network,
-    F: Fn() -> CallBuilder<P, D, N>,
-    R: ReceiptResponse + std::fmt::Debug,
-{
-    if receipt.status() {
-        handle_success_receipt(receipt);
+    async fn record_metrics(
+        &self,
+        receipt: TransactionReceipt,
+    ) -> Result<(), KeyRegistryEventError> {
+        tracing::trace!(
+            "transaction with hash: {} confirmed",
+            receipt.transaction_hash()
+        );
+
+        if let Ok(balance) = self.rpc_provider.get_balance(self.wallet_address).await {
+            let balance_eth = alloy::primitives::utils::format_ether(balance);
+            tracing::trace!("current wallet balance: {balance_eth} ETH",);
+            ::metrics::gauge!(METRICS_ID_KEY_GEN_WALLET_BALANCE, METRICS_ATTRID_WALLET_ADDRESS => self.wallet_address.to_string())
+                    .set(balance_eth.parse::<f64>().unwrap_or(f64::NAN));
+        } else {
+            tracing::warn!("could not fetch current wallet balance");
+        }
+        let gas_used = receipt
+            .gas_used()
+            .to_string()
+            .parse::<f64>()
+            .unwrap_or(f64::NAN);
+        let cost_eth = alloy::primitives::utils::format_ether(receipt.cost());
+        // we do this to_string -> parse hop to have easy way to call to NAN if too large
+        let gas_price_wei = receipt
+            .effective_gas_price()
+            .to_string()
+            .parse::<f64>()
+            .unwrap_or(f64::NAN);
+        let gas_price_eth = alloy::primitives::utils::format_ether(receipt.effective_gas_price());
+        tracing::trace!(
+            "gas used: {gas_used}; transaction cost: {cost_eth} ETH; transaction gas price: {gas_price_eth} ETH"
+        );
+        metrics::gauge!(METRICS_ID_GAS_PRICE).set(gas_price_wei);
         Ok(())
-    } else {
-        tracing::debug!("could not send transaction - do a call to get revert data");
-        transaction().call().await?;
-        // if we are here the call afterwards succeeded - we don't really know why the receipt failed so just return the wrapped receipt
-        Err(TransactionError::Rpc(eyre::eyre!(
-            "cannot finish transaction for unknown reason: {receipt:?}"
-        )))
     }
-}
 
-fn handle_success_receipt<R: ReceiptResponse>(receipt: &R) {
-    tracing::trace!(
-        "transaction with hash: {} confirmed",
-        receipt.transaction_hash()
-    );
-    let gas_used = receipt
-        .gas_used()
-        .to_string()
-        .parse::<f64>()
-        .unwrap_or(f64::NAN);
-    let cost_eth = alloy::primitives::utils::format_ether(receipt.cost());
-    // we do this to_string -> parse hop to have easy way to call to NAN if too large
-    let gas_price_wei = receipt
-        .effective_gas_price()
-        .to_string()
-        .parse::<f64>()
-        .unwrap_or(f64::NAN);
-    let gas_price_eth = alloy::primitives::utils::format_ether(receipt.effective_gas_price());
-    tracing::debug!(
-        "gas used: {gas_used}; transaction cost: {cost_eth} ETH; transaction gas price: {gas_price_eth} ETH"
-    );
-    metrics::gauge!(METRICS_ID_GAS_PRICE).set(gas_price_wei);
+    #[instrument(level = "info", skip_all, fields(tx_hash = tracing::field::Empty))]
+    async fn submit<D>(
+        &self,
+        transaction: CallBuilder<&DynProvider, D>,
+    ) -> Result<(), KeyRegistryEventError>
+    where
+        D: CallDecoder + Unpin + Clone,
+    {
+        // first we simulate the transaction
+        self.simulate_transaction(transaction.clone()).await?;
+        let receipt = self.send_transaction(transaction).await?;
+        receipt.ensure_success()?;
+        self.record_metrics(receipt).await
+    }
+
+    pub(crate) async fn add_round1_keygen_contribution(
+        &self,
+        oprf_key_id: OprfKeyId,
+        contribution: Round1Contribution,
+    ) -> Result<(), KeyRegistryEventError> {
+        let transaction = self
+            .contract
+            .addRound1KeyGenContribution(oprf_key_id.into_inner(), contribution);
+        self.submit(transaction).await
+    }
+
+    pub(crate) async fn add_round1_reshare_contribution(
+        &self,
+        oprf_key_id: OprfKeyId,
+        contribution: Round1Contribution,
+    ) -> Result<(), KeyRegistryEventError> {
+        let transaction = self
+            .contract
+            .addRound1ReshareContribution(oprf_key_id.into_inner(), contribution);
+        self.submit(transaction).await
+    }
+
+    pub(crate) async fn add_round2_contribution(
+        &self,
+        oprf_key_id: OprfKeyId,
+        contribution: Round2Contribution,
+    ) -> Result<(), KeyRegistryEventError> {
+        let transaction = self
+            .contract
+            .addRound2Contribution(oprf_key_id.into_inner(), contribution);
+        self.submit(transaction).await
+    }
+
+    pub(crate) async fn add_round3_contribution(
+        &self,
+        oprf_key_id: OprfKeyId,
+    ) -> Result<(), KeyRegistryEventError> {
+        let transaction = self
+            .contract
+            .addRound3Contribution(oprf_key_id.into_inner());
+        self.submit(transaction).await
+    }
 }

--- a/oprf-key-gen/src/services/transaction_handler.rs
+++ b/oprf-key-gen/src/services/transaction_handler.rs
@@ -3,7 +3,7 @@ use std::{f64, time::Duration};
 use alloy::{
     contract::{CallBuilder, CallDecoder},
     network::ReceiptResponse,
-    primitives::Address,
+    primitives::{Address, TxHash},
     providers::{DynProvider, Provider},
     rpc::types::TransactionReceipt,
     transports::TransportError,
@@ -28,9 +28,11 @@ use crate::{
 
 /// Service that handles transaction submission and receipt confirmation.
 ///
-/// Submits transactions to the blockchain via the configured RPC provider, waits for the
-/// required number of confirmations up to `max_wait_time`, and handles failure cases by
-/// performing a static call to extract revert data for diagnostics.
+/// Simulates each call first (`eth_call` pre-flight via [`submit`](TransactionHandler::submit)),
+/// then broadcasts the transaction and polls for receipts, retrying on `NullResp` responses up
+/// to `max_tries_fetching_receipt` times.  On receipt, [`ReceiptResponse::ensure_success`] is
+/// called to surface reverts.  Gas price and wallet balance are recorded as metrics after every
+/// confirmed transaction.
 #[derive(Clone)]
 pub(crate) struct TransactionHandler {
     max_wait_time_watch_transaction: Duration,
@@ -43,14 +45,25 @@ pub(crate) struct TransactionHandler {
     contract: OprfKeyRegistryInstance<DynProvider>,
 }
 
+/// Construction arguments for [`TransactionHandler`].
 pub(crate) struct TransactionHandlerArgs {
+    /// Maximum time to wait for enough block confirmations before treating the transaction as
+    /// timed out.
     pub(crate) max_wait_time_watch_transaction: Duration,
+    /// Number of block confirmations required before a receipt is considered final.
     pub(crate) confirmations_for_transaction: u64,
+    /// Delay between each manual `eth_getTransactionReceipt` retry after an initial
+    /// `NullResp`.
     pub(crate) sleep_between_get_receipt: Duration,
+    /// Maximum number of `eth_getTransactionReceipt` retries when receiving `NullResp`.
     pub(crate) max_tries_fetching_receipt: usize,
+    /// Gas limit applied to every call and send, in gas units.
     pub(crate) max_gas_per_transaction: u64,
+    /// HTTP provider used for transaction submission, balance queries, and receipt polling.
     pub(crate) rpc_provider: web3::HttpRpcProvider,
+    /// Wallet address used to query the on-chain balance after each confirmed transaction.
     pub(crate) wallet_address: Address,
+    /// Address of the `OprfKeyRegistry` contract.
     pub(crate) contract_address: Address,
 }
 
@@ -80,6 +93,7 @@ impl From<TransactionHandlerArgs> for TransactionHandler {
 }
 
 impl TransactionHandler {
+    /// Construct a [`TransactionHandler`] from its arguments.
     pub(crate) fn new(args: TransactionHandlerArgs) -> Self {
         Self::from(args)
     }
@@ -148,7 +162,7 @@ impl TransactionHandler {
 
     async fn record_metrics(
         &self,
-        receipt: TransactionReceipt,
+        receipt: &TransactionReceipt,
     ) -> Result<(), KeyRegistryEventError> {
         tracing::trace!(
             "transaction with hash: {} confirmed",
@@ -183,11 +197,20 @@ impl TransactionHandler {
         Ok(())
     }
 
-    #[instrument(level = "info", skip_all, fields(tx_hash = tracing::field::Empty))]
+    /// Full transaction lifecycle: simulate → send → confirm → ensure success → record metrics.
+    ///
+    /// Runs a pre-flight `eth_call` via [`simulate_transaction`](Self::simulate_transaction) to
+    /// surface reverts before spending gas, then broadcasts via
+    /// [`send_transaction`](Self::send_transaction), calls
+    /// [`ReceiptResponse::ensure_success`] to assert the receipt status, and
+    /// emits gas/balance metrics via [`record_metrics`](Self::record_metrics).
+    ///
+    /// Returns the `TxHash` of the confirmed transaction.
+    #[instrument(level = "info", skip_all)]
     async fn submit<D>(
         &self,
         transaction: CallBuilder<&DynProvider, D>,
-    ) -> Result<(), KeyRegistryEventError>
+    ) -> Result<TxHash, KeyRegistryEventError>
     where
         D: CallDecoder + Unpin + Clone,
     {
@@ -195,46 +218,75 @@ impl TransactionHandler {
         self.simulate_transaction(transaction.clone()).await?;
         let receipt = self.send_transaction(transaction).await?;
         receipt.ensure_success()?;
-        self.record_metrics(receipt).await
+        self.record_metrics(&receipt).await?;
+        Ok(receipt.transaction_hash)
     }
 
+    /// Submits a round-1 key-gen contribution to `OprfKeyRegistry::addRound1KeyGenContribution`.
+    ///
+    /// Returns the `TxHash` of the confirmed transaction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KeyRegistryEventError`] on revert, RPC failure, or receipt timeout.
     pub(crate) async fn add_round1_keygen_contribution(
         &self,
         oprf_key_id: OprfKeyId,
         contribution: Round1Contribution,
-    ) -> Result<(), KeyRegistryEventError> {
+    ) -> Result<TxHash, KeyRegistryEventError> {
         let transaction = self
             .contract
             .addRound1KeyGenContribution(oprf_key_id.into_inner(), contribution);
         self.submit(transaction).await
     }
 
+    /// Submits a round-1 reshare contribution to `OprfKeyRegistry::addRound1ReshareContribution`.
+    ///
+    /// Returns the `TxHash` of the confirmed transaction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KeyRegistryEventError`] on revert, RPC failure, or receipt timeout.
     pub(crate) async fn add_round1_reshare_contribution(
         &self,
         oprf_key_id: OprfKeyId,
         contribution: Round1Contribution,
-    ) -> Result<(), KeyRegistryEventError> {
+    ) -> Result<TxHash, KeyRegistryEventError> {
         let transaction = self
             .contract
             .addRound1ReshareContribution(oprf_key_id.into_inner(), contribution);
         self.submit(transaction).await
     }
 
+    /// Submits a round-2 contribution to `OprfKeyRegistry::addRound2Contribution`.
+    ///
+    /// Returns the `TxHash` of the confirmed transaction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KeyRegistryEventError`] on revert, RPC failure, or receipt timeout.
     pub(crate) async fn add_round2_contribution(
         &self,
         oprf_key_id: OprfKeyId,
         contribution: Round2Contribution,
-    ) -> Result<(), KeyRegistryEventError> {
+    ) -> Result<TxHash, KeyRegistryEventError> {
         let transaction = self
             .contract
             .addRound2Contribution(oprf_key_id.into_inner(), contribution);
         self.submit(transaction).await
     }
 
+    /// Submits a round-3 contribution to `OprfKeyRegistry::addRound3Contribution`.
+    ///
+    /// Returns the `TxHash` of the confirmed transaction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KeyRegistryEventError`] on revert, RPC failure, or receipt timeout.
     pub(crate) async fn add_round3_contribution(
         &self,
         oprf_key_id: OprfKeyId,
-    ) -> Result<(), KeyRegistryEventError> {
+    ) -> Result<TxHash, KeyRegistryEventError> {
         let transaction = self
             .contract
             .addRound3Contribution(oprf_key_id.into_inner());

--- a/oprf-key-gen/src/services/transaction_handler.rs
+++ b/oprf-key-gen/src/services/transaction_handler.rs
@@ -155,10 +155,7 @@ impl TransactionHandler {
         }
     }
 
-    async fn record_metrics(
-        &self,
-        receipt: &TransactionReceipt,
-    ) -> Result<(), KeyRegistryEventError> {
+    async fn record_metrics(&self, receipt: &TransactionReceipt) {
         tracing::trace!(
             "transaction with hash: {} confirmed",
             receipt.transaction_hash()
@@ -167,7 +164,7 @@ impl TransactionHandler {
         if let Ok(balance) = self.rpc_provider.get_balance(self.wallet_address).await {
             let balance_eth = alloy::primitives::utils::format_ether(balance);
             tracing::trace!("current wallet balance: {balance_eth} ETH",);
-            metrics::wallet::set_wallet_ballance(&balance_eth);
+            metrics::wallet::set_wallet_balance(&balance_eth);
         } else {
             tracing::warn!("could not fetch current wallet balance");
         }
@@ -183,7 +180,6 @@ impl TransactionHandler {
             "gas used: {gas_used}; transaction cost: {cost_eth} ETH; transaction gas price: {gas_price_eth} ETH"
         );
         metrics::wallet::set_gas_price_from_wei(receipt.effective_gas_price());
-        Ok(())
     }
 
     /// Full transaction lifecycle: simulate → send → confirm → ensure success → record metrics.
@@ -206,8 +202,8 @@ impl TransactionHandler {
         // first we simulate the transaction
         self.simulate_transaction(transaction.clone()).await?;
         let receipt = self.send_transaction(transaction).await?;
+        self.record_metrics(&receipt).await;
         receipt.ensure_success()?;
-        self.record_metrics(&receipt).await?;
         Ok(receipt.transaction_hash)
     }
 

--- a/oprf-key-gen/src/tests/keygen_test_secret_manager.rs
+++ b/oprf-key-gen/src/tests/keygen_test_secret_manager.rs
@@ -224,13 +224,13 @@ impl SecretManager for TestKeyGenSecretManager {
         &self,
         oprf_key_id: OprfKeyId,
         pending_epoch: ShareEpoch,
-    ) -> Result<Option<KeyGenIntermediateValues>, SecretManagerError> {
+    ) -> Result<KeyGenIntermediateValues, SecretManagerError> {
         let state = self.0.lock();
         state
             .keygen_intermediates
             .get(&(oprf_key_id, pending_epoch))
             .map(|bytes| Self::deserialize_intermediates(bytes))
-            .transpose()
+            .ok_or_else(|| SecretManagerError::MissingIntermediates(oprf_key_id, pending_epoch))?
     }
 
     async fn store_pending_dlog_share(

--- a/oprf-key-gen/src/tests/mod.rs
+++ b/oprf-key-gen/src/tests/mod.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::large_futures, reason = "doesnt matter for tests")]
 use std::fmt;
-use std::num::NonZeroUsize;
+use std::num::{NonZeroU16, NonZeroUsize};
 use std::time::Duration;
 
 use alloy::{primitives::U160, sol_types::SolEvent};
@@ -138,8 +138,8 @@ impl TestKeyGen {
                 wallet_private_key: private_key.into(),
                 zkey_path: setup.key_gen_path(),
                 witness_graph_path: setup.witness_path(),
-                expected_threshold: expected_threshold.try_into().expect("Is non-zero"),
-                expected_num_peers: expected_num_peers.try_into().expect("Is non-zero"),
+                expected_threshold: NonZeroU16::new(expected_threshold).expect("Is non-zero"),
+                expected_num_peers: NonZeroU16::new(expected_num_peers).expect("Is non-zero"),
                 rpc_provider_config: HttpRpcProviderConfig::with_default_values(vec![
                     anvil.endpoint_url(),
                 ]),
@@ -150,7 +150,7 @@ impl TestKeyGen {
         config.rpc_provider_config.chain_id = Some(31_337);
         config.event_stream_config.skip_backfill = skip_backfill;
         config.event_stream_config.confirmations_after_sync_block =
-            NonZeroUsize::try_from(2).expect("2 is non-zero");
+            NonZeroUsize::new(2).expect("2 is non-zero");
         if let Some(interval) = cursor_checkpoint_interval {
             config.cursor_checkpoint_interval = interval;
         }


### PR DESCRIPTION
- **feat(key-gen): add cursor checkpoint task**
- **test(key-gen): add test for cursor checkpoint**
- **chore: move trap in run-setup before docker-compose**
- **docs(key-gen): fixed broken docs**
- **wip**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches on-chain event processing and transaction submission/confirmation logic; cursor advancement semantics and new soft-error handling could impact missed/duplicate event handling if incorrect, but changes are largely refactoring plus added observability.
> 
> **Overview**
> Adds a periodic **chain cursor checkpoint** background task (configurable via `cursor_checkpoint_interval`) to persist the current block height during idle periods and reduce backfill on restart.
> 
> Refactors the key-registry event watcher into decoding (`events.rs`) and handling (`handler.rs`), changes cursor advancement to occur **only after successful handling or explicit soft-error downgrade**, and expands the soft-error policy (e.g., `WrongRound`, `DeletedId`, `AlreadySubmitted`, missing intermediates, rollback refusal).
> 
> Reworks metrics into `metrics::{health,wallet,chain_events}` and updates instrumentation: wallet balance/gas price are now recorded via helpers, and per-event/role counters plus a “current block” gauge are emitted.
> 
> Strengthens secret-manager semantics by making `fetch_keygen_intermediates` return an error instead of `None`, propagates this through `DLogSecretGenService` (new `SecretGenError`) and tests, and updates `TransactionHandler` to encapsulate contract calls, add pre-flight simulation, return confirmed `TxHash`, and record receipt/balance metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8f4f67a1f7d6293c6aac378a5ccdd7ad3c39377. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->