### PR TITLE
refactor: replace nodes-observability with telemetry-batteries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,28 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -1486,6 +1502,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1701,6 +1732,31 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "time",
+]
+
+[[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+dependencies = [
+ "darling 0.23.0",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1943,6 +1999,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,6 +2219,15 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -2404,6 +2496,27 @@ dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
  "crypto-common 0.2.1",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2925,6 +3038,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git-version"
@@ -3841,12 +3960,12 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.3"
+version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
 dependencies = [
- "ahash",
  "portable-atomic",
+ "rapidhash",
 ]
 
 [[package]]
@@ -3856,6 +3975,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3863,6 +3991,15 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -4008,6 +4145,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4030,6 +4176,89 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-datadog"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a6b2d4db32343691eb945e6153e5a4bd494dbf9d931d5bf7d1d7f59bee156d0"
+dependencies = [
+ "ahash",
+ "http",
+ "indexmap 2.12.1",
+ "itoa",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "reqwest 0.12.28",
+ "rmp",
+ "ryu",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest 0.12.28",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "page_size"
@@ -4577,6 +4806,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4603,6 +4841,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4773,6 +5022,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4840,6 +5098,12 @@ dependencies = [
  "rand 0.9.4",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
@@ -5657,6 +5921,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5836,18 +6106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "taceo-nodes-observability"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7a5d1aebf2040316548b47bd3d7e2855a975702637fd9019f3148b1ee5b40de"
-dependencies = [
- "eyre",
- "metrics",
- "tracing",
- "tracing-subscriber 0.3.22",
-]
-
-[[package]]
 name = "taceo-oprf"
 version = "0.13.0"
 dependencies = [
@@ -5925,10 +6183,10 @@ dependencies = [
  "secrecy",
  "serde",
  "taceo-ark-babyjubjub",
- "taceo-nodes-observability",
  "taceo-oprf-client",
  "taceo-oprf-core",
  "taceo-oprf-types",
+ "telemetry-batteries",
  "tokio",
  "tracing",
  "uuid",
@@ -5967,10 +6225,10 @@ dependencies = [
  "taceo-ark-babyjubjub",
  "taceo-groth16-material",
  "taceo-nodes-common",
- "taceo-nodes-observability",
  "taceo-oprf-core",
  "taceo-oprf-test-utils",
  "taceo-oprf-types",
+ "telemetry-batteries",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -6010,11 +6268,11 @@ dependencies = [
  "sqlx",
  "taceo-ark-babyjubjub",
  "taceo-nodes-common",
- "taceo-nodes-observability",
  "taceo-oprf-client",
  "taceo-oprf-core",
  "taceo-oprf-test-utils",
  "taceo-oprf-types",
+ "telemetry-batteries",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -6049,7 +6307,6 @@ dependencies = [
  "taceo-groth16-material",
  "taceo-groth16-sol",
  "taceo-nodes-common",
- "taceo-nodes-observability",
  "taceo-oprf-core",
  "taceo-oprf-types",
  "testcontainers-modules",
@@ -6096,6 +6353,40 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "telemetry-batteries"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389eb13150fdfb5c2a79f333a8d71808cd024e1335d73d184590e2a02e0dd53a"
+dependencies = [
+ "backtrace",
+ "bon",
+ "chrono",
+ "color-eyre",
+ "dirs",
+ "eyre",
+ "http",
+ "metrics",
+ "opentelemetry",
+ "opentelemetry-datadog",
+ "opentelemetry-http",
+ "opentelemetry_sdk",
+ "pin-project",
+ "rand 0.9.4",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tracing",
+ "tracing-appender",
+ "tracing-error",
+ "tracing-opentelemetry",
+ "tracing-serde 0.1.3",
+ "tracing-subscriber 0.3.23",
+]
 
 [[package]]
 name = "tempfile"
@@ -6504,6 +6795,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6525,6 +6829,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber 0.3.23",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6535,17 +6896,23 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
+ "tracing-serde 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ itertools = "0.14"
 k256 = "0.13"
 metrics = "0.24"
 nodes-common = { package = "taceo-nodes-common", version = "0.5.2", default-features = false }
-nodes-observability = { package = "taceo-nodes-observability", version = "0.1.2", default-features = false }
 num-bigint = "0.4"
 parking_lot = "0.12"
 poseidon2 = { package = "taceo-poseidon2", version = "0.2", default-features = false }
@@ -68,6 +67,7 @@ semver = "1"
 serde = { version = "1" }
 serde_json = { version = "1" }
 sqlx = "0.8"
+telemetry-batteries = { version = "0.2.1", default-features = false }
 testcontainers-modules = { version = "0.15" }
 thiserror = { version = "2" }
 tokio = { version = "1" }

--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@ default:
     @just --justfile {{ justfile() }} --list --list-heading $'Project commands:\n'
 
 [private]
-[working-directory('logs')]
+[working-directory('logs/setup')]
 load-key-registry:
     grep -oP 'OprfKeyRegistry proxy deployed to: \K0x[a-fA-F0-9]+' deploy_oprf_key_registry.log
 
@@ -49,4 +49,4 @@ lint:
 
 [group('dev-client')]
 run-dev-client *args:
-    OPRF_DEV_CLIENT_OPRF_KEY_REGISTRY_CONTRACT=$(just load-key-registry) cargo run --release --example dev-client-example {{ args }}
+    RUST_LOG="taceo=trace,dev_client_example=trace,warn" OPRF_DEV_CLIENT_OPRF_KEY_REGISTRY_CONTRACT=$(just load-key-registry) cargo run --release --example dev-client-example {{ args }}

--- a/oprf-dev-client/Cargo.toml
+++ b/oprf-dev-client/Cargo.toml
@@ -49,8 +49,8 @@ ark-babyjubjub = { workspace = true }
 ark-ec.workspace = true
 ark-ff = { workspace = true }
 humantime.workspace = true
-nodes-observability = { workspace = true }
 rand_chacha = { workspace = true }
 rustls = { workspace = true }
 secrecy = { workspace = true }
+telemetry-batteries.workspace = true
 webpki-roots = { workspace = true }

--- a/oprf-dev-client/examples/dev-client-example.rs
+++ b/oprf-dev-client/examples/dev-client-example.rs
@@ -37,9 +37,7 @@ struct ExampleDevClientSetup {
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    nodes_observability::install_tracing(
-        "taceo_oprf_dev_client=trace,dev_client_example=trace,warn",
-    );
+    let _guard = telemetry_batteries::init().expect("Can initialize tracing");
     rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
         .expect("can install");

--- a/oprf-key-gen/Cargo.toml
+++ b/oprf-key-gen/Cargo.toml
@@ -44,7 +44,6 @@ nodes-common = { workspace = true, features = [
   "serde",
   "web3"
 ] }
-nodes-observability = { workspace = true }
 oprf-core = { package = "taceo-oprf-core", path = "../oprf-core", version = "0.5" }
 oprf-types = { package = "taceo-oprf-types", path = "../oprf-types", version = "0.13" }
 rand.workspace = true
@@ -59,6 +58,7 @@ sqlx = { workspace = true, features = [
   "runtime-tokio",
   "tls-rustls-aws-lc-rs"
 ] }
+telemetry-batteries.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = [
   "net",

--- a/oprf-key-gen/src/api.rs
+++ b/oprf-key-gen/src/api.rs
@@ -7,7 +7,6 @@
 use alloy::primitives::Address;
 use axum::Router;
 use nodes_common::StartedServices;
-use tower_http::trace::TraceLayer;
 
 pub(crate) mod info;
 
@@ -16,16 +15,12 @@ pub(crate) mod info;
 /// This function sets up:
 ///
 /// - General info about the deployment from [`info`].
-/// - An HTTP trace layer via [`TraceLayer`].
+/// - Call to `nodes_common::api::routes_with_services`.
 ///
-/// The returned [`Router`] can be incorporated into another router or be served directly by axum. Implementations don't need to configure anything in their `State`, the service is inlined as [`Extension`](https://docs.rs/axum/latest/axum/struct.Extension.html).
+/// The returned [`Router`] can be incorporated into another router or be served directly by axum.
 pub fn routes(wallet_address: Address, started_services: StartedServices) -> Router {
     let version_str = nodes_common::version_info!();
-    Router::new()
-        .merge(info::routes(wallet_address))
-        .merge(nodes_common::api::routes_with_services(
-            started_services,
-            version_str,
-        ))
-        .layer(TraceLayer::new_for_http())
+    Router::new().merge(info::routes(wallet_address)).merge(
+        nodes_common::api::routes_with_services(started_services, version_str),
+    )
 }

--- a/oprf-key-gen/src/lib.rs
+++ b/oprf-key-gen/src/lib.rs
@@ -62,6 +62,7 @@ pub use nodes_common::Environment;
 pub use nodes_common::StartedServices;
 pub use services::event_cursor_store;
 pub use services::secret_manager;
+use tower_http::trace::TraceLayer;
 
 /// The tasks spawned by the key-gen library. Should call [`KeyGenTasks::join`] when shutting down for graceful shutdown.
 pub struct KeyGenTasks {
@@ -280,7 +281,7 @@ pub async fn start(
     ));
 
     Ok((
-        key_gen_router,
+        key_gen_router.layer(TraceLayer::new_for_http()),
         KeyGenTasks {
             key_event_watcher,
             i_am_alive_task,

--- a/oprf-key-gen/src/main.rs
+++ b/oprf-key-gen/src/main.rs
@@ -165,11 +165,7 @@ fn main() -> ExitCode {
         .build()
         .expect("Can build Tokio runtime");
     runtime.block_on(async {
-        // nodes_observability already needs a tokio reactor to set up the logs/metrics exporter
-        let tracing_config =
-            nodes_observability::TracingConfig::try_from_env().expect("Can create TracingConfig");
-        let _tracing_handle = nodes_observability::initialize_tracing(&tracing_config)
-            .expect("Can get tracing handle");
+        let _guard = telemetry_batteries::init().expect("Can initialize tracing");
 
         // load the config
         let config = match maybe_config {

--- a/oprf-service/Cargo.toml
+++ b/oprf-service/Cargo.toml
@@ -73,13 +73,13 @@ ark-ff = { workspace = true }
 axum-test = { workspace = true, features = ["ws"] }
 config = { workspace = true }
 itertools = { workspace = true }
-nodes-observability = { workspace = true }
 oprf-client = { package = "taceo-oprf-client", path = "../oprf-client", version = "0.9" }
 oprf-test-utils = { package = "taceo-oprf-test-utils", path = "../oprf-test-utils", version = "0.11", default-features = false, features = [
   "deploy-anvil",
   "postgres-test-container"
 ] }
 rustls = { workspace = true }
+telemetry-batteries.workspace = true
 
 [features]
 default = ["postgres"]

--- a/oprf-service/examples/taceo-oprf-service-example.rs
+++ b/oprf-service/examples/taceo-oprf-service-example.rs
@@ -77,7 +77,8 @@ async fn main() -> eyre::Result<ExitCode> {
     rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
         .expect("can install");
-    nodes_observability::install_tracing("oprf_service_example=trace, info");
+    let _guard = telemetry_batteries::init()?;
+
     tracing::info!("{}", nodes_common::version_info!());
 
     let config = load_example_config()?;

--- a/oprf-service/src/api/oprf.rs
+++ b/oprf-service/src/api/oprf.rs
@@ -1,12 +1,6 @@
 use crate::api::errors::Error;
 use crate::api::version_header::{ProtocolVersion, ProtocolVersionQuery};
-use crate::metrics::{
-    METRICS_CLIENT_VERSION_MISMATCH, METRICS_ID_NODE_OPRF_SUCCESS, METRICS_ID_NODE_PART_1_DURATION,
-    METRICS_ID_NODE_PART_1_FINISH, METRICS_ID_NODE_PART_1_START, METRICS_ID_NODE_PART_2_DURATION,
-    METRICS_ID_NODE_PART_2_FINISH, METRICS_ID_NODE_PART_2_START,
-    METRICS_ID_NODE_REQUEST_AUTH_START, METRICS_ID_NODE_REQUEST_AUTH_VERIFIED,
-    METRICS_ID_NODE_REQUEST_VERIFY_DURATION, METRICS_ID_NODE_SESSIONS_TIMEOUT,
-};
+use crate::metrics;
 use crate::oprf_key_material_store::OprfSession;
 use crate::services::open_sessions::OpenSessions;
 use crate::services::oprf_key_material_store::OprfKeyMaterialStore;
@@ -107,7 +101,7 @@ enum HumanReadable {
 /// ## Session Flow
 ///
 /// See [`partial_oprf`] for the flow of the web-socket connection. If the session finishes successfully, encounters an error, the user closes the connection, or we run into a timeout, the implementation will try to initiate a graceful shutdown of the web-socket connection (closing handshake). We do this on a best-effort basis but are very restrictive on what we expect. We close any session that sends invalid requests/authentication. If sending the `Close` frame fails, we simply ignore the error and destruct everything associated with the session.
-#[instrument(level = "debug", skip_all,name="request", fields(client_version=tracing::field::Empty))]
+#[instrument(level = "debug", skip_all, name="request", fields(client_version=tracing::field::Empty,request_id=tracing::field::Empty, oprf_key_id=tracing::field::Empty))]
 async fn oprf_ws_handler<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
     State(state): State<OprfModuleState<ReqAuth>>,
     websocket_upgrade: WebSocketUpgrade,
@@ -123,7 +117,7 @@ async fn oprf_ws_handler<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
         websocket_upgrade
             .max_message_size(state.max_message_size)
             .on_failed_upgrade(|err| {
-                tracing::warn!("could not establish websocket connection: {err:?}");
+                tracing::warn!(%err, "could not establish websocket connection");
             })
             .on_upgrade(move |mut ws| {
                 async move {
@@ -142,7 +136,7 @@ async fn oprf_ws_handler<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
                     {
                         Ok(Ok(session_id)) => {
                             tracing::debug!("successfully created nullifier for {session_id}");
-                            ::metrics::counter!(METRICS_ID_NODE_OPRF_SUCCESS).increment(1);
+                            metrics::request::inc_success();
                             Some(CloseFrame {
                                 code: close_code::NORMAL,
                                 reason: "success".into(),
@@ -150,8 +144,7 @@ async fn oprf_ws_handler<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
                         }
                         Ok(Err(err)) => err.into_close_frame(),
                         Err(_) => {
-                            tracing::trace!("session ran into timeout"); 
-                            ::metrics::counter!(METRICS_ID_NODE_SESSIONS_TIMEOUT).increment(1);
+                            tracing::debug!("session ran into timeout"); 
                             Some(CloseFrame {
                                 code: oprf_error_codes::TIMEOUT,
                                 reason: "timeout".into(),
@@ -159,7 +152,7 @@ async fn oprf_ws_handler<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
                         }
                     };
                     if let Some(close_frame) = close_frame {
-                        tracing::trace!(" < sending close frame");
+                        tracing::trace!("sending close frame");
                         // In their example, axum just sends the frame and ignores the error afterwards and also don't wait for the peers close frame. Therefore we do the same,
                         #[allow(clippy::let_underscore_must_use, reason="we don't care about this error as we close the connection anyways and only send close frame on best effort")]
                         let _ = ws.send(ws::Message::Close(Some(close_frame))).await;
@@ -172,8 +165,8 @@ async fn oprf_ws_handler<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
             "invalid version, expected: {} got: {client_version}",
             state.version_req
         );
-        tracing::trace!("{msg}");
-        ::metrics::counter!(METRICS_CLIENT_VERSION_MISMATCH).increment(1);
+        tracing::debug!("{msg}");
+        metrics::request::inc_client_version_mismatch();
         (StatusCode::BAD_REQUEST, msg).into_response()
     }
 }
@@ -188,7 +181,6 @@ async fn oprf_ws_handler<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
 /// 6) Finalizes the proof share for the session and sends it back to the user (same serialization as the initial request of the user).
 ///
 /// Clients may and will close the connection at any point because they only need `threshold` amount of sessions, therefore it is very much expected that sane clients send a `Close` frame at any point (or simply drop the connection). This method handles this gracefully at any point.
-#[instrument(level="debug", skip_all, fields(request_id=tracing::field::Empty, oprf_key_id=tracing::field::Empty))]
 async fn partial_oprf<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
     socket: &mut WebSocket,
     party_id: PartyId,
@@ -197,11 +189,8 @@ async fn partial_oprf<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
     oprf_material_store: OprfKeyMaterialStore,
     req_auth_service: OprfRequestAuthService<ReqAuth>,
 ) -> Result<Uuid, Error> {
-    tracing::trace!("> new oprf session - reading request...");
-    ::metrics::counter!(METRICS_ID_NODE_PART_1_START).increment(1);
-    let (init_request, human_readable) = read_request::<OprfRequest<ReqAuth>>(socket)
-        .instrument(tracing::debug_span!("read_init_request"))
-        .await?;
+    tracing::trace!("new oprf session - reading request...");
+    let (init_request, human_readable) = read_request::<OprfRequest<ReqAuth>>(socket).await?;
 
     // Some setup before we start processing - setup span and reserve the session ID
     let request_id = init_request.request_id;
@@ -222,28 +211,20 @@ async fn partial_oprf<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
     // record the key-id for the span
     oprf_span.record("oprf_key_id", session.key_id().to_string());
 
-    write_response(response, human_readable, socket)
-        .instrument(tracing::debug_span!("write_init_response"))
-        .await?;
-    ::metrics::counter!(METRICS_ID_NODE_PART_1_FINISH).increment(1);
+    write_response(response, human_readable, socket).await?;
 
-    let (challenge_request, still_human_readable) = read_request::<DLogCommitmentsShamir>(socket)
-        .instrument(tracing::debug_span!("read_challenge_request"))
-        .await?;
+    let (challenge_request, still_human_readable) =
+        read_request::<DLogCommitmentsShamir>(socket).await?;
     if still_human_readable != human_readable {
         tracing::trace!("user switched encoding between round 1 and round 2. Will reject");
         return Err(Error::UnexpectedMessage);
     }
-    ::metrics::counter!(METRICS_ID_NODE_PART_2_START).increment(1);
 
     let proof_share =
         challenge(challenge_request, request_id, party_id, threshold, session).await?;
 
     tracing::trace!("sending challenge response to client...");
-    write_response(proof_share, human_readable, socket)
-        .instrument(tracing::debug_span!("write_challenge_response"))
-        .await?;
-    ::metrics::counter!(METRICS_ID_NODE_PART_2_FINISH).increment(1);
+    write_response(proof_share, human_readable, socket).await?;
     Ok(request_id)
 }
 
@@ -262,13 +243,9 @@ async fn init_session<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
     }
 
     tracing::trace!("verifying request with auth service...");
-    ::metrics::counter!(METRICS_ID_NODE_REQUEST_AUTH_START).increment(1);
     let start_verify = Instant::now();
     let oprf_key_id = req_auth_service.authenticate(&init_request).await?;
-    let duration_verify = start_verify.elapsed();
-    ::metrics::counter!(METRICS_ID_NODE_REQUEST_AUTH_VERIFIED).increment(1);
-    ::metrics::histogram!(METRICS_ID_NODE_REQUEST_VERIFY_DURATION)
-        .record(duration_verify.as_millis() as f64);
+    metrics::request::record_verify_duration(start_verify.elapsed());
 
     tracing::trace!("initiating session with key id {oprf_key_id:?}...");
     let (session, commitments) = oprf_material_store
@@ -280,9 +257,7 @@ async fn init_session<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
         party_id,
         oprf_pub_key_with_epoch: session.public_key_with_epoch(),
     };
-    let duration_part_one = start_part_one.elapsed();
-    ::metrics::histogram!(METRICS_ID_NODE_PART_1_DURATION)
-        .record(duration_part_one.as_millis() as f64);
+    metrics::request::record_part1_duration(start_part_one.elapsed());
     Ok((session, response))
 }
 
@@ -318,10 +293,7 @@ async fn challenge(
 
     tracing::trace!("finalizing session...");
     let proof_share = OprfKeyMaterialStore::challenge(request_id, party_id, session, challenge);
-
-    let duration_part_two = start_part_two.elapsed();
-    ::metrics::histogram!(METRICS_ID_NODE_PART_2_DURATION)
-        .record(duration_part_two.as_millis() as f64);
+    metrics::request::record_part2_duration(start_part_two.elapsed());
     Ok(proof_share)
 }
 
@@ -329,10 +301,11 @@ async fn challenge(
 ///
 /// # Errors
 /// Returns the corresponding error if either the peer closes the connection (gracefully with a `Close` frame or not) or if the `Msg` cannot be serialized with the corresponding format.
+#[instrument(level = "debug", skip_all)]
 async fn read_request<Msg: for<'de> Deserialize<'de>>(
     socket: &mut WebSocket,
 ) -> Result<(Msg, HumanReadable), Error> {
-    tracing::trace!(" > read request");
+    tracing::trace!("read request..");
     let res = match socket.recv().await.ok_or(Error::ConnectionClosed)?? {
         ws::Message::Text(json) => (
             serde_json::from_slice::<Msg>(json.as_bytes())?,
@@ -346,12 +319,13 @@ async fn read_request<Msg: for<'de> Deserialize<'de>>(
 }
 
 /// Attempts to write a `Msg` to the web-socket. Depending on `human_readable` either sends a `Text` (`json`) frame or `Binary` (`cbor`) frame.
+#[instrument(level = "debug", skip_all)]
 async fn write_response<Msg: Serialize>(
     response: Msg,
     human_readable: HumanReadable,
     socket: &mut WebSocket,
 ) -> Result<(), Error> {
-    tracing::trace!(" > write response");
+    tracing::trace!("write response..");
     let msg = match human_readable {
         HumanReadable::Yes => {
             let msg = serde_json::to_string(&response).expect("Can serialize response");

--- a/oprf-service/src/lib.rs
+++ b/oprf-service/src/lib.rs
@@ -50,7 +50,6 @@
 //! If you want to enable HTTP/2.0, you either have to do it by hand or by calling `axum::serve`, which enabled HTTP/2.0 by default. Have a look at [Axum's HTTP2.0 example](https://github.com/tokio-rs/axum/blob/aeff16e91af6fa76efffdee8f3e5f464b458785b/examples/websockets-http2/src/main.rs#L57).
 
 use crate::api::oprf::OprfModuleState;
-use crate::metrics::{METRICS_ID_I_AM_ALIVE, METRICS_ID_NODE_SESSIONS_OPEN};
 use crate::services::key_event_watcher::KeyEventWatcherTaskArgs;
 use crate::services::open_sessions::OpenSessions;
 use crate::services::oprf_key_material_store::OprfKeyMaterialStore;
@@ -121,8 +120,6 @@ impl OprfServiceBuilder {
         started_services: StartedServices,
         cancellation_token: CancellationToken,
     ) -> eyre::Result<Self> {
-        ::metrics::gauge!(METRICS_ID_NODE_SESSIONS_OPEN).set(0);
-
         tracing::info!("loading address from secret-manager..");
         let address = secret_manager
             .load_address()
@@ -201,7 +198,7 @@ impl OprfServiceBuilder {
                     tokio::select! {
                        _ = interval.tick() => {
                             if started_services.all_started() {
-                                ::metrics::counter!(METRICS_ID_I_AM_ALIVE).increment(1);
+                                metrics::health::inc_i_am_alive();
                             }
                        },
                        () = cancellation_token.cancelled() => {
@@ -215,7 +212,7 @@ impl OprfServiceBuilder {
 
         Ok(Self {
             config,
-            open_sessions: OpenSessions::default(),
+            open_sessions: OpenSessions::new(),
             root,
             api: Router::new(),
             key_event_watcher,

--- a/oprf-service/src/metrics.rs
+++ b/oprf-service/src/metrics.rs
@@ -4,138 +4,150 @@
 //! provides a helper [`describe_metrics`] to set metadata for
 //! each metric using the `metrics` crate.
 
-/// Event signaling that the node is alive
-pub const METRICS_ID_I_AM_ALIVE: &str = "taceo.oprf.node.i.am.alive";
-
-/// Observed event for start of `OprfRequest` authentication.
-pub const METRICS_ID_NODE_REQUEST_AUTH_START: &str = "taceo.oprf.node.request_auth.start";
-/// Observed event for successful verification of `OprfRequest` authentication.
-pub const METRICS_ID_NODE_REQUEST_AUTH_VERIFIED: &str = "taceo.oprf.node.request_auth.verified";
-/// Metrics key for counting successful OPRF evaluations
-pub const METRICS_ID_NODE_OPRF_SUCCESS: &str = "taceo.oprf.node.success";
-/// Metrics key for counting currently running sessions.
-pub const METRICS_ID_NODE_SESSIONS_OPEN: &str = "taceo.oprf.node.sessions.open";
-/// Metrics key for deleted sessions.
-pub const METRICS_ID_NODE_SESSIONS_TIMEOUT: &str = "taceo.oprf.node.sessions.timeout";
-/// Metrics key for registered `DLogSecrets`.
-pub const METRICS_ID_NODE_OPRF_SECRETS: &str = "taceo.oprf.node.secrets";
-/// Metrics key for how often we reject clients due to version mismatch.
-pub const METRICS_CLIENT_VERSION_MISMATCH: &str = "taceo.oprf.node.client.invalid_version";
-
-/// Metrics key for the duration of successful `OprfRequestAuth` verification
-pub const METRICS_ID_NODE_REQUEST_VERIFY_DURATION: &str = "taceo.oprf.node.request_verify.duration";
-/// Metrics key for the duration of part one of the OPRF computation
-pub const METRICS_ID_NODE_PART_1_DURATION: &str = "taceo.oprf.node.part_1.duration";
-/// Metrics key for the duration of part two of the OPRF computation
-pub const METRICS_ID_NODE_PART_2_DURATION: &str = "taceo.oprf.node.part_2.duration";
-/// Metrics key for number of requests for part one of the OPRF computation
-pub const METRICS_ID_NODE_PART_1_START: &str = "taceo.oprf.node.part_1.start";
-/// Metrics key for number of finishing handling a request for part one of the OPRF computation
-pub const METRICS_ID_NODE_PART_1_FINISH: &str = "taceo.oprf.node.part_1.finish";
-/// Metrics key for number of requests for part two of the OPRF computation
-pub const METRICS_ID_NODE_PART_2_START: &str = "taceo.oprf.node.part_2.start";
-/// Metrics key for number of finishing handling a request for part two of the OPRF computation
-pub const METRICS_ID_NODE_PART_2_FINISH: &str = "taceo.oprf.node.part_2.finish";
-
-/// Metrics key for times the node could not fetch key-material after finalize event.
-pub const METRICS_ID_NODE_CANNOT_FETCH_KEY_MATERIAL: &str = "taceo.oprf.node.fetch.error";
-
 /// Describe all metrics used by the service.
 ///
 /// This calls the `describe_*` functions from the `metrics` crate to set metadata on the different metrics.
 pub fn describe_metrics() {
-    metrics::describe_counter!(
-        METRICS_ID_I_AM_ALIVE,
-        metrics::Unit::Count,
-        "I am alive metric. Used to measure liveness in datadog"
-    );
-    metrics::describe_counter!(
-        METRICS_ID_NODE_REQUEST_AUTH_START,
-        metrics::Unit::Count,
-        "Number of OPRF request authentication attempts started."
-    );
+    request::describe_metrics();
+    health::describe_metrics();
+    sessions::describe_metrics();
+    secrets::describe_metrics();
+}
 
-    metrics::describe_counter!(
-        METRICS_ID_NODE_REQUEST_AUTH_VERIFIED,
-        metrics::Unit::Count,
-        "Number of OPRF request authentications successfully verified."
-    );
+pub(crate) mod request {
+    use std::time::Duration;
 
-    metrics::describe_counter!(
-        METRICS_ID_NODE_OPRF_SUCCESS,
-        metrics::Unit::Count,
-        "Number of successful OPRF evaluations"
-    );
+    /// Metrics key for counting successful OPRF evaluations
+    const METRICS_ID_NODE_OPRF_SUCCESS: &str = "taceo.oprf.node.request.success";
 
-    metrics::describe_gauge!(
-        METRICS_ID_NODE_SESSIONS_OPEN,
-        metrics::Unit::Count,
-        "Number of open sessions the node has stored"
-    );
+    /// Metrics key for the duration of successful `OprfRequestAuth` verification
+    const METRICS_ID_NODE_REQUEST_VERIFY_DURATION: &str = "taceo.oprf.node.request.verify.duration";
+    /// Metrics key for the duration of part one of the OPRF computation
+    const METRICS_ID_NODE_PART_1_DURATION: &str = "taceo.oprf.node.request.part1.duration";
+    /// Metrics key for the duration of part two of the OPRF computation
+    const METRICS_ID_NODE_PART_2_DURATION: &str = "taceo.oprf.node.request.part2.duration";
 
-    metrics::describe_counter!(
-        METRICS_ID_NODE_SESSIONS_TIMEOUT,
-        metrics::Unit::Count,
-        "Number of sessions that were removed because they exceeded the deadline"
-    );
+    /// Metrics key for how often we reject clients due to version mismatch.
+    const METRICS_CLIENT_VERSION_MISMATCH: &str = "taceo.oprf.node.client.invalid_version";
 
-    metrics::describe_gauge!(
-        METRICS_ID_NODE_OPRF_SECRETS,
-        metrics::Unit::Count,
-        "Number of secrets stored"
-    );
+    pub(super) fn describe_metrics() {
+        metrics::describe_counter!(
+            METRICS_ID_NODE_OPRF_SUCCESS,
+            metrics::Unit::Count,
+            "Number of successful OPRF evaluations"
+        );
 
-    metrics::describe_histogram!(
-        METRICS_ID_NODE_REQUEST_VERIFY_DURATION,
-        metrics::Unit::Milliseconds,
-        "Duration of successful OprfRequestAuth verification"
-    );
+        metrics::describe_histogram!(
+            METRICS_ID_NODE_REQUEST_VERIFY_DURATION,
+            metrics::Unit::Milliseconds,
+            "Duration of successful OprfRequestAuth verification"
+        );
 
-    metrics::describe_histogram!(
-        METRICS_ID_NODE_PART_1_DURATION,
-        metrics::Unit::Milliseconds,
-        "Duration of the OPRF computation part one"
-    );
+        metrics::describe_histogram!(
+            METRICS_ID_NODE_PART_1_DURATION,
+            metrics::Unit::Milliseconds,
+            "Duration of the OPRF computation part one"
+        );
 
-    metrics::describe_histogram!(
-        METRICS_ID_NODE_PART_2_DURATION,
-        metrics::Unit::Milliseconds,
-        "Duration of the OPRF computation part two"
-    );
+        metrics::describe_histogram!(
+            METRICS_ID_NODE_PART_2_DURATION,
+            metrics::Unit::Milliseconds,
+            "Duration of the OPRF computation part two"
+        );
 
-    metrics::describe_counter!(
-        METRICS_ID_NODE_PART_1_START,
-        metrics::Unit::Count,
-        "Number of requests to compute part one of OPRF"
-    );
+        metrics::describe_counter!(
+            METRICS_CLIENT_VERSION_MISMATCH,
+            metrics::Unit::Count,
+            "How often we rejected clients due to version mismatch"
+        );
+    }
 
-    metrics::describe_counter!(
-        METRICS_ID_NODE_PART_1_FINISH,
-        metrics::Unit::Count,
-        "Number of finished computations for part one of OPRF"
-    );
+    pub(crate) fn inc_client_version_mismatch() {
+        metrics::counter!(METRICS_CLIENT_VERSION_MISMATCH).increment(1);
+    }
 
-    metrics::describe_counter!(
-        METRICS_ID_NODE_PART_2_START,
-        metrics::Unit::Count,
-        "Number of requests to compute part two of OPRF"
-    );
+    pub(crate) fn inc_success() {
+        metrics::counter!(METRICS_ID_NODE_OPRF_SUCCESS).increment(1);
+    }
 
-    metrics::describe_counter!(
-        METRICS_ID_NODE_PART_2_FINISH,
-        metrics::Unit::Count,
-        "Number of finished computations for part two of OPRF"
-    );
+    pub(crate) fn record_verify_duration(duration: Duration) {
+        metrics::histogram!(METRICS_ID_NODE_REQUEST_VERIFY_DURATION)
+            .record(duration.as_millis() as f64);
+    }
 
-    metrics::describe_counter!(
-        METRICS_ID_NODE_CANNOT_FETCH_KEY_MATERIAL,
-        metrics::Unit::Count,
-        "Number of times we could not fetch key-material from secret-manager"
-    );
+    pub(crate) fn record_part1_duration(duration: Duration) {
+        metrics::histogram!(METRICS_ID_NODE_PART_1_DURATION).record(duration.as_millis() as f64);
+    }
 
-    metrics::describe_counter!(
-        METRICS_CLIENT_VERSION_MISMATCH,
-        metrics::Unit::Count,
-        "How often we rejected clients due to version mismatch"
-    );
+    pub(crate) fn record_part2_duration(duration: Duration) {
+        metrics::histogram!(METRICS_ID_NODE_PART_2_DURATION).record(duration.as_millis() as f64);
+    }
+}
+
+pub(crate) mod health {
+
+    const METRICS_ID_I_AM_ALIVE: &str = "taceo.oprf.node.i.am.alive";
+
+    pub(super) fn describe_metrics() {
+        metrics::describe_counter!(
+            METRICS_ID_I_AM_ALIVE,
+            metrics::Unit::Count,
+            "I am alive metric. Used to measure liveness in datadog"
+        );
+    }
+
+    pub(crate) fn inc_i_am_alive() {
+        metrics::counter!(METRICS_ID_I_AM_ALIVE).increment(1);
+    }
+}
+
+pub(crate) mod sessions {
+    /// Metrics key for counting currently running sessions.
+    const METRICS_ID_NODE_SESSIONS_OPEN: &str = "taceo.oprf.node.sessions.open";
+
+    pub(super) fn describe_metrics() {
+        metrics::describe_gauge!(
+            METRICS_ID_NODE_SESSIONS_OPEN,
+            metrics::Unit::Count,
+            "Number of open sessions the node has stored"
+        );
+    }
+
+    pub(crate) fn reset() {
+        ::metrics::gauge!(METRICS_ID_NODE_SESSIONS_OPEN).set(0);
+    }
+
+    pub(crate) fn inc() {
+        ::metrics::gauge!(METRICS_ID_NODE_SESSIONS_OPEN).increment(1);
+    }
+
+    pub(crate) fn dec() {
+        ::metrics::gauge!(METRICS_ID_NODE_SESSIONS_OPEN).decrement(1);
+    }
+}
+
+pub(crate) mod secrets {
+
+    /// Metrics key for registered `DLogSecrets`.
+    const METRICS_ID_NODE_OPRF_SECRETS: &str = "taceo.oprf.node.secrets";
+
+    pub(super) fn describe_metrics() {
+        metrics::describe_gauge!(
+            METRICS_ID_NODE_OPRF_SECRETS,
+            metrics::Unit::Count,
+            "Number of secrets stored"
+        );
+    }
+
+    pub(crate) fn set(x: usize) {
+        ::metrics::gauge!(METRICS_ID_NODE_OPRF_SECRETS).set(x as f64);
+    }
+
+    pub(crate) fn inc() {
+        ::metrics::gauge!(METRICS_ID_NODE_OPRF_SECRETS).increment(1);
+    }
+
+    pub(crate) fn dec() {
+        ::metrics::gauge!(METRICS_ID_NODE_OPRF_SECRETS).decrement(1);
+    }
 }

--- a/oprf-service/src/services/key_event_watcher.rs
+++ b/oprf-service/src/services/key_event_watcher.rs
@@ -27,11 +27,8 @@ use oprf_types::{OprfKeyId, ShareEpoch, chain::OprfKeyRegistry};
 use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, instrument};
 
-use crate::{
-    metrics::METRICS_ID_NODE_CANNOT_FETCH_KEY_MATERIAL,
-    services::{
-        oprf_key_material_store::OprfKeyMaterialStore, secret_manager::SecretManagerService,
-    },
+use crate::services::{
+    oprf_key_material_store::OprfKeyMaterialStore, secret_manager::SecretManagerService,
 };
 
 /// Represents errors returned when fetching OPRF key material from the [`SecretManagerService`].
@@ -259,14 +256,12 @@ async fn fetch_oprf_key_material_from_secret_manager(
             oprf_key_material_store.insert(oprf_key_id, key_material);
         }
         Err(FetchOprfKeyMaterialError::NotFound) => {
-            tracing::warn!(
+            tracing::error!(
                 "Could not fetch oprf-key-id {oprf_key_id} and epoch {epoch} after {get_oprf_key_material_timeout:?}. Will continue anyways."
             );
-            ::metrics::counter!(METRICS_ID_NODE_CANNOT_FETCH_KEY_MATERIAL).increment(1);
         }
         Err(err) => {
             tracing::error!("Could not fetch key-material: {err:?}");
-            ::metrics::counter!(METRICS_ID_NODE_CANNOT_FETCH_KEY_MATERIAL).increment(1);
         }
     }
 }

--- a/oprf-service/src/services/open_sessions.rs
+++ b/oprf-service/src/services/open_sessions.rs
@@ -8,10 +8,10 @@ use parking_lot::Mutex;
 use uuid::Uuid;
 
 use crate::api::errors::Error;
-use crate::metrics::METRICS_ID_NODE_SESSIONS_OPEN;
+use crate::metrics;
 
 /// Keeps track of all currently opened sessions.
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub(crate) struct OpenSessions(Arc<Mutex<HashSet<Uuid>>>);
 
 /// A guard for an open session.
@@ -30,6 +30,11 @@ impl Drop for SessionDropGuard {
 }
 
 impl OpenSessions {
+    pub(crate) fn new() -> Self {
+        metrics::sessions::reset();
+        Self(Arc::default())
+    }
+
     /// Inserts a new session into the service.
     ///
     /// If there is already a session with this id, will return an [`Error::SessionReuse`].
@@ -37,7 +42,7 @@ impl OpenSessions {
     /// On success, returns a [`SessionDropGuard`] that marks the session as reserved.
     pub(crate) fn insert_new_session(&self, session: Uuid) -> Result<SessionDropGuard, Error> {
         if self.0.lock().insert(session) {
-            ::metrics::gauge!(METRICS_ID_NODE_SESSIONS_OPEN).increment(1);
+            metrics::sessions::inc();
             Ok(SessionDropGuard {
                 session,
                 open_sessions: self.clone(),
@@ -52,6 +57,6 @@ impl OpenSessions {
     /// Is private so only the `Drop` implementation can call this.
     fn remove_session(&self, session: Uuid) {
         self.0.lock().remove(&session);
-        ::metrics::gauge!(METRICS_ID_NODE_SESSIONS_OPEN).decrement(1);
+        metrics::sessions::dec();
     }
 }

--- a/oprf-service/src/services/oprf_key_material_store.rs
+++ b/oprf-service/src/services/oprf_key_material_store.rs
@@ -20,7 +20,7 @@ use parking_lot::RwLock;
 use std::{collections::HashMap, sync::Arc};
 use uuid::Uuid;
 
-use crate::metrics::METRICS_ID_NODE_OPRF_SECRETS;
+use crate::metrics;
 
 /// Storage for [`OprfKeyMaterial`]s.
 #[derive(Default, Clone)]
@@ -49,7 +49,7 @@ impl OprfKeyMaterialStore {
     /// Creates a new storage instance with the provided initial shares.
     #[must_use]
     pub fn new(inner: HashMap<OprfKeyId, OprfKeyMaterial>) -> Self {
-        ::metrics::gauge!(METRICS_ID_NODE_OPRF_SECRETS).set(inner.len() as f64);
+        metrics::secrets::set(inner.len());
         Self(Arc::new(RwLock::new(inner)))
     }
 
@@ -169,7 +169,7 @@ impl OprfKeyMaterialStore {
             }
         })
         .or_insert_with(|| {
-            ::metrics::gauge!(METRICS_ID_NODE_OPRF_SECRETS).increment(1);
+            metrics::secrets::inc();
             tracing::info!(
                 "added {oprf_key_id:?} material to OprfKeyMaterialStore"
             );
@@ -182,7 +182,7 @@ impl OprfKeyMaterialStore {
     /// If the id is not registered, doesn't do anything.
     pub(super) fn remove(&self, oprf_key_id: OprfKeyId) {
         if self.0.write().remove(&oprf_key_id).is_some() {
-            ::metrics::gauge!(METRICS_ID_NODE_OPRF_SECRETS).decrement(1);
+            metrics::secrets::dec();
             tracing::info!("removed {oprf_key_id:?} material from OprfKeyMaterialStore");
         }
     }

--- a/oprf-test-utils/Cargo.toml
+++ b/oprf-test-utils/Cargo.toml
@@ -39,7 +39,6 @@ groth16-material = { workspace = true, optional = true }
 groth16-sol = { workspace = true, optional = true }
 itertools.workspace = true
 nodes-common = { workspace = true, features = ["postgres"], optional = true }
-nodes-observability = { workspace = true, optional = true }
 oprf-core = { package = "taceo-oprf-core", path = "../oprf-core", version = "0.5" }
 oprf-types = { package = "taceo-oprf-types", path = "../oprf-types", version = "0.13" }
 parking_lot = { workspace = true }
@@ -72,8 +71,11 @@ generate-test-transcript = [
   "dep:askama",
   "dep:clap",
   "dep:groth16-material",
-  "groth16-material/circom",
   "dep:groth16-sol",
-  "dep:nodes-observability"
+  "groth16-material/circom"
 ]
-postgres-test-container = ["dep:sqlx", "dep:testcontainers-modules", "dep:nodes-common"]
+postgres-test-container = [
+  "dep:nodes-common",
+  "dep:sqlx",
+  "dep:testcontainers-modules"
+]

--- a/oprf-test-utils/src/bin/generate-test-transcript.rs
+++ b/oprf-test-utils/src/bin/generate-test-transcript.rs
@@ -213,7 +213,7 @@ fn producer_contributions<R: Rng + CryptoRng>(
         poly.coeffs().to_vec().iter().map(|x| x.into()).collect(),
     );
     input.insert("nonces", nonces.iter().map(|n| n.into()).collect_vec());
-    tracing::debug!("computing proof for {function_name}");
+    println!("computing proof for {function_name}");
     let (proof, public) = compute_key_gen_proof(input, key_gen_material, rng)?;
 
     let round1 = SolidityRound1Call::new(
@@ -488,9 +488,8 @@ fn check_reshare(
 }
 
 fn main() -> eyre::Result<ExitCode> {
-    nodes_observability::install_tracing("debug");
     let config = TestTranscriptConfig::parse();
-    tracing::info!("starting with config: {config:#?}");
+    println!("starting with config: {config:#?}");
 
     let mut rng = ChaCha20Rng::seed_from_u64(config.seed);
     let key_gen_material = CircomGroth16MaterialBuilder::new()
@@ -529,7 +528,7 @@ fn main() -> eyre::Result<ExitCode> {
     )
     .context("while doing key-gen contributions")?;
 
-    tracing::info!("doing first reshare proofs");
+    println!("doing first reshare proofs");
 
     let alice_reshare_poly = KeyGenPoly::reshare(&mut rng, alice_keygen_share, DEGREE);
     let bob_reshare_poly = KeyGenPoly::reshare(&mut rng, bob_keygen_share, DEGREE);
@@ -553,7 +552,7 @@ fn main() -> eyre::Result<ExitCode> {
     )
     .context("while doing reshare 1 contributions")?;
 
-    tracing::info!("doing second reshare proofs");
+    println!("doing second reshare proofs");
 
     let bob_reshare_poly = KeyGenPoly::reshare(&mut rng, bob_reshare1_share, DEGREE);
     let carol_reshare_poly = KeyGenPoly::reshare(&mut rng, carol_reshare1_share, DEGREE);

--- a/scripts/run-setup.sh
+++ b/scripts/run-setup.sh
@@ -40,14 +40,12 @@ main() {
 
     if [[ "$RUN_MODE" == "e2e-test" ]]; then
         log "Running dev-client tests"
-        OPRF_DEV_CLIENT_OPRF_KEY_REGISTRY_CONTRACT=$DEPLOYED_ADDRESS \
-            ./target/release/examples/dev-client-example reshare-test
-        OPRF_DEV_CLIENT_OPRF_KEY_REGISTRY_CONTRACT=$DEPLOYED_ADDRESS \
-            ./target/release/examples/dev-client-example stress-test-oprf
-        OPRF_DEV_CLIENT_OPRF_KEY_REGISTRY_CONTRACT=$DEPLOYED_ADDRESS \
-            ./target/release/examples/dev-client-example stress-test-key-gen
-        OPRF_DEV_CLIENT_OPRF_KEY_REGISTRY_CONTRACT=$DEPLOYED_ADDRESS \
-            ./target/release/examples/dev-client-example delete-test
+        export OPRF_DEV_CLIENT_OPRF_KEY_REGISTRY_CONTRACT=$DEPLOYED_ADDRESS
+        export RUST_LOG="taceo=trace,dev_client_example=trace,warn"
+        ./target/release/examples/dev-client-example reshare-test
+        ./target/release/examples/dev-client-example stress-test-oprf
+        ./target/release/examples/dev-client-example stress-test-key-gen
+        ./target/release/examples/dev-client-example delete-test
         log "Dev-client tests completed successfully"
     else
         log "No dev-client tests requested, entering sleep mode. Press Ctrl+C to stop"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Switches tracing/metrics initialization and related dependencies across binaries/services, which can affect logging, exporters, and operational visibility at runtime. Also touches request/session metrics instrumentation paths and Axum `TraceLayer` placement, so regressions would be primarily in observability rather than protocol behavior.
> 
> **Overview**
> **Replaces observability plumbing across the workspace** by dropping `taceo-nodes-observability` and adopting `telemetry-batteries` (new workspace dep, updated lockfile with OpenTelemetry/Datadog-related crates).
> 
> Updates the dev client, key-gen binary, and service example to initialize tracing via `telemetry_batteries::init()` and adjusts local/e2e tooling (`justfile`, `scripts/run-setup.sh`) to set `RUST_LOG` and use a new `logs/setup` working directory.
> 
> Refactors OPRF service metrics usage by namespacing metric helpers (`metrics::{request,health,sessions,secrets}`), wiring session/secret gauges through these helpers, and adding richer request span fields (`request_id`, `oprf_key_id`) plus some log-level/message tweaks; also moves HTTP tracing middleware so key-gen applies `TraceLayer` at the router returned by `start()` rather than inside `api::routes()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d140f7878898ef95fc3bad7252fa4ba38d5c55c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->