### PR TITLE
fix/key gen.12 rc.2

### DIFF
--- a/build/Dockerfile.oprf-key-gen
+++ b/build/Dockerfile.oprf-key-gen
@@ -21,6 +21,7 @@ COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
+ARG GIT_HASH
 COPY --from=planner /app/recipe.json recipe.json
 # Build dependencies - this is the caching Docker layer!
 RUN cargo chef cook --release --recipe-path recipe.json
@@ -51,5 +52,6 @@ COPY ./artifacts/OPRFKeyGenGraph.13.bin /app/OPRFKeyGenGraph.13.bin
 COPY ./artifacts/OPRFKeyGen.25.arks.zkey /app/OPRFKeyGen.25.arks.zkey
 COPY ./artifacts/OPRFKeyGenGraph.25.bin /app/OPRFKeyGenGraph.25.bin
 COPY --from=builder /app/target/release/taceo-oprf-key-gen /app/taceo-oprf-key-gen
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 ENTRYPOINT [ "/app/taceo-oprf-key-gen" ]

--- a/oprf-key-gen/src/main.rs
+++ b/oprf-key-gen/src/main.rs
@@ -50,7 +50,9 @@ fn default_max_wait_shutdown() -> Duration {
     Duration::from_secs(10)
 }
 
-fn load_key_gen_config() -> eyre::Result<OprfKeyGenConfig> {
+// we are not allowed to build an eyre::Report yet because telemetry-batteries expects to install
+// the color-eyre hook
+fn load_key_gen_config() -> Result<OprfKeyGenConfig, config::ConfigError> {
     let cfg = Config::builder().add_source(
         config::Environment::with_prefix("TACEO_OPRF_KEY_GEN")
             .separator("__")
@@ -59,11 +61,7 @@ fn load_key_gen_config() -> eyre::Result<OprfKeyGenConfig> {
             .try_parsing(true),
     );
 
-    let key_gen_config = cfg
-        .build()
-        .context("while building from config")?
-        .try_deserialize()
-        .context("while parsing config")?;
+    let key_gen_config = cfg.build()?.try_deserialize()?;
 
     // Unset all env vars with our prefix to prevent leakage to subprocesses.
     // Safety: this is called before any threads are spawned.
@@ -178,7 +176,7 @@ fn main() -> ExitCode {
         let config = match maybe_config {
             Ok(config) => config,
             Err(err) => {
-                tracing::error!("failed to load config: {err:?}");
+                tracing::error!("failed to load config: {err}");
                 return ExitCode::FAILURE;
             }
         };


### PR DESCRIPTION
- **fix(key-gen): dont use eyre::Report for maybe config**
- **fix(build): added pki certs to scratch build**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes startup/config error handling and the container runtime filesystem (CA bundle), which could affect boot failures and TLS connectivity in production.
> 
> **Overview**
> Avoids constructing an `eyre::Report` during initial config parsing by returning `config::ConfigError` from `load_key_gen_config`, and tweaks logging to print the raw config error before telemetry is installed.
> 
> Updates `Dockerfile.oprf-key-gen` scratch runtime to include `ca-certificates.crt` (and adds a `GIT_HASH` build arg in the builder stage), enabling TLS validation from within the container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9618297feeb66882ca0faa7a1e3a4999d725bf4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->