### PR TITLE
chore: unify error logs in repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,6 +1831,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cadence"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca08f6db9f0c963249cf23a27820f9d973d2acaad4d6bfaeb858b58ebd58a6a"
+dependencies = [
+ "crossbeam-channel",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3968,6 +3977,17 @@ checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
 dependencies = [
  "portable-atomic",
  "rapidhash",
+]
+
+[[package]]
+name = "metrics-exporter-statsd"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57971e32cdee88619fb6c673fd89cfd37c12f2dd7c187fb400b7aae0ede0ed9e"
+dependencies = [
+ "cadence",
+ "metrics",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6371,6 +6391,7 @@ dependencies = [
  "eyre",
  "http",
  "metrics",
+ "metrics-exporter-statsd",
  "opentelemetry",
  "opentelemetry-datadog",
  "opentelemetry-http",

--- a/justfile
+++ b/justfile
@@ -35,6 +35,14 @@ generate-contract-kats:
 run-setup:
     @bash scripts/run-setup.sh sleep
 
+[group('local-setup')]
+run-setup-dd:
+    @DATADOG_ENABLE=1 bash scripts/run-setup.sh sleep
+
+[group('local-setup')]
+backfill-monkey-test-dd:
+    @DATADOG_ENABLE=1 bash scripts/run-backfill-monkey-test.sh
+
 [group('ci')]
 check-pr: lint all-tests
 

--- a/oprf-client/src/sessions.rs
+++ b/oprf-client/src/sessions.rs
@@ -198,7 +198,8 @@ pub async fn init_sessions<OprfRequestAuth: Clone + Serialize + 'static>(
             Err((service, err)) => {
                 // we very much expect certain services to return an error therefore we do not log at warn/error level.
                 tracing::debug!(
-                    "Got error response from {:?}: {err:?}",
+                    %err,
+                    "got error response from {:?}",
                     service
                         .authority()
                         .map_or_else(|| "unknown service".to_owned(), ToString::to_string)

--- a/oprf-dev-client/src/lib.rs
+++ b/oprf-dev-client/src/lib.rs
@@ -153,7 +153,7 @@ pub async fn send_init_requests<OprfRequestAuth: Clone + Serialize + Send + 'sta
                 finish_requests.insert(id, finish_request);
                 durations.push(duration);
             }
-            Err(err) => tracing::error!("got an error during init: {err:?}"),
+            Err(err) => tracing::error!(?err, "got an error during init"),
         }
     }
 
@@ -206,7 +206,7 @@ pub async fn send_finish_requests(
                 responses.insert(id, res);
                 durations.push(duration);
             }
-            Err(err) => tracing::error!("Got an error during finish: {err:?}"),
+            Err(err) => tracing::error!(?err, "Got an error during finish"),
         }
     }
 

--- a/oprf-key-gen/Cargo.toml
+++ b/oprf-key-gen/Cargo.toml
@@ -58,7 +58,7 @@ sqlx = { workspace = true, features = [
   "runtime-tokio",
   "tls-rustls-aws-lc-rs",
 ] }
-telemetry-batteries.workspace = true
+telemetry-batteries = { workspace = true, features = ["metrics-statsd"] }
 thiserror.workspace = true
 tokio = { workspace = true, features = [
   "net",
@@ -73,11 +73,11 @@ tower-http = { workspace = true, features = ["set-header", "trace"] }
 tracing.workspace = true
 zeroize = { workspace = true, features = ["derive"] }
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { workspace = true }
-
 [dev-dependencies]
 alloy = { workspace = true, features = ["node-bindings"] }
 axum-test = { workspace = true, features = ["ws"] }
 oprf-test-utils = { package = "taceo-oprf-test-utils", path = "../oprf-test-utils", version = "0.12" }
 parking_lot = { workspace = true }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { workspace = true }

--- a/oprf-key-gen/src/lib.rs
+++ b/oprf-key-gen/src/lib.rs
@@ -307,7 +307,7 @@ async fn start_cursor_checkpoint_task(
             Ok(checkpoint) => Some(ChainCursor::new(checkpoint, 0)),
             Err(err) => {
                 tracing::warn!(%err, "cannot fetch checkpoint for cursor");
-                tracing::warn!("tying again in {checkpoint_interval:?}");
+                tracing::warn!("trying again in {checkpoint_interval:?}");
                 None
             }
         };
@@ -325,7 +325,7 @@ async fn start_cursor_checkpoint_task(
                     tracing::info!("successfully called store_chain_cursor");
                 }
                 Err(err) => {
-                    tracing::warn!(%err, "cannot persist checkpoint to DB");
+                    tracing::warn!(?err, "cannot persist checkpoint to DB");
                     tracing::warn!("tying again in {checkpoint_interval:?}");
                 }
             }

--- a/oprf-key-gen/src/lib.rs
+++ b/oprf-key-gen/src/lib.rs
@@ -62,7 +62,6 @@ pub use nodes_common::Environment;
 pub use nodes_common::StartedServices;
 pub use services::event_cursor_store;
 pub use services::secret_manager;
-use tower_http::trace::TraceLayer;
 
 /// The tasks spawned by the key-gen library. Should call [`KeyGenTasks::join`] when shutting down for graceful shutdown.
 pub struct KeyGenTasks {
@@ -281,7 +280,7 @@ pub async fn start(
     ));
 
     Ok((
-        key_gen_router.layer(TraceLayer::new_for_http()),
+        key_gen_router,
         KeyGenTasks {
             key_event_watcher,
             i_am_alive_task,

--- a/oprf-key-gen/src/lib.rs
+++ b/oprf-key-gen/src/lib.rs
@@ -305,8 +305,7 @@ async fn start_cursor_checkpoint_task(
         let checkpoint = match rpc_provider.get_block_number().await {
             Ok(checkpoint) => Some(ChainCursor::new(checkpoint, 0)),
             Err(err) => {
-                tracing::warn!(%err, "cannot fetch checkpoint for cursor");
-                tracing::warn!("trying again in {checkpoint_interval:?}");
+                tracing::warn!(%err, "cannot fetch checkpoint for cursor - trying again in {checkpoint_interval:?}");
                 None
             }
         };
@@ -324,8 +323,10 @@ async fn start_cursor_checkpoint_task(
                     tracing::info!("successfully called store_chain_cursor");
                 }
                 Err(err) => {
-                    tracing::warn!(?err, "cannot persist checkpoint to DB");
-                    tracing::warn!("tying again in {checkpoint_interval:?}");
+                    tracing::warn!(
+                        ?err,
+                        "cannot persist checkpoint to DB - trying again in {checkpoint_interval:?}"
+                    );
                 }
             }
         }

--- a/oprf-key-gen/src/main.rs
+++ b/oprf-key-gen/src/main.rs
@@ -176,7 +176,7 @@ fn main() -> ExitCode {
         let config = match maybe_config {
             Ok(config) => config,
             Err(err) => {
-                tracing::error!("failed to load config: {err}");
+                tracing::error!(%err, "failed to load config");
                 return ExitCode::FAILURE;
             }
         };
@@ -187,7 +187,7 @@ fn main() -> ExitCode {
                 ExitCode::SUCCESS
             }
             Err(err) => {
-                tracing::error!("key-gen did shutdown: {err:?}");
+                tracing::error!(?err, "key-gen did shutdown");
                 tracing::error!("good night anyways");
                 ExitCode::FAILURE
             }

--- a/oprf-key-gen/src/postgres.rs
+++ b/oprf-key-gen/src/postgres.rs
@@ -57,7 +57,7 @@ enum PostgresDbError {
     RefusingToRollbackEpoch,
     #[error(transparent)]
     DbError(#[from] sqlx::Error),
-    #[error(transparent)]
+    #[error("internal error: {0:?}")]
     Internal(#[from] eyre::Report),
 }
 
@@ -102,8 +102,8 @@ impl PostgresDb {
         f.retry(self.backoff_strategy())
             .sleep(tokio::time::sleep)
             .when(is_retryable_error)
-            .notify(|e, duration| {
-                tracing::warn!("Retrying {op_name} in db: {e} after {duration:?}");
+            .notify(|err, duration| {
+                tracing::warn!(%err, "Retrying {op_name} in db after {duration:?}");
             })
             .await
     }

--- a/oprf-key-gen/src/postgres.rs
+++ b/oprf-key-gen/src/postgres.rs
@@ -12,32 +12,26 @@
 //! The schema is managed by the embedded migrations in `./migrations`, applied automatically
 //! during [`PostgresDb::init`].
 
-use std::num::NonZeroUsize;
-use std::time::Duration;
+use std::{num::NonZeroUsize, time::Duration};
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use async_trait::async_trait;
-use nodes_common::web3::event_stream::ChainCursor;
+use backon::{BackoffBuilder, ConstantBackoff, ConstantBuilder, Retryable};
+use eyre::Context;
+use nodes_common::{
+    postgres::{CreateSchema, PostgresConfig},
+    web3::event_stream::ChainCursor,
+};
 use oprf_core::ddlog_equality::shamir::DLogShareShamir;
-use oprf_types::crypto::OprfPublicKey;
-use sqlx::Acquire;
-use sqlx::PgExecutor;
-use sqlx::Row as _;
+use oprf_types::{OprfKeyId, ShareEpoch, crypto::OprfPublicKey};
+use sqlx::{Acquire, PgExecutor, PgPool, Row as _};
 use tracing::instrument;
 
-use crate::secret_manager;
-use crate::secret_manager::KeyGenIntermediateValues;
-use crate::secret_manager::SecretManager;
-use crate::secret_manager::SecretManagerError;
-use crate::services::event_cursor_store::ChainCursorStorage;
-use backon::BackoffBuilder;
-use backon::ConstantBackoff;
-use backon::ConstantBuilder;
-use backon::Retryable;
-use eyre::Context;
-use nodes_common::postgres::{CreateSchema, PostgresConfig};
-use oprf_types::{OprfKeyId, ShareEpoch};
-use sqlx::PgPool;
+use crate::{
+    metrics,
+    secret_manager::{self, KeyGenIntermediateValues, SecretManager, SecretManagerError},
+    services::event_cursor_store::ChainCursorStorage,
+};
 
 type Result<T> = std::result::Result<T, PostgresDbError>;
 
@@ -140,7 +134,7 @@ impl ChainCursorStorage for PostgresDb {
     #[instrument(level = "debug", skip_all, fields(chain_cursor=%chain_cursor))]
     #[allow(
         clippy::cast_possible_wrap,
-        reason = "We want to wrap the value because sqlx can only store i64, but we have u64"
+        reason = "We serialize the u64 as i64 because of sqlx limitations."
     )]
     async fn store_chain_cursor(&self, chain_cursor: ChainCursor) -> eyre::Result<()> {
         tracing::trace!("trying to store chain cursor...");
@@ -164,6 +158,8 @@ impl ChainCursorStorage for PostgresDb {
             .await?;
         if rows_affected == 0 {
             tracing::info!("did not update chain-event cursor - refusing to rollback");
+        } else {
+            metrics::chain_events::record_current_block(chain_cursor);
         }
         Ok(())
     }

--- a/oprf-key-gen/src/services/key_event_watcher.rs
+++ b/oprf-key-gen/src/services/key_event_watcher.rs
@@ -83,7 +83,7 @@ pub(crate) enum KeyRegistryEventError {
     TransactionFailedError(#[from] TransactionFailedError),
     #[error("Cannot handle event due to secret-manager error: {0}")]
     SecretManagerError(#[source] SecretManagerError),
-    #[error(transparent)]
+    #[error("internal error: {0:?}")]
     Internal(#[from] eyre::Report),
 }
 
@@ -238,7 +238,7 @@ async fn key_gen_event(
     log: Log<LogData>,
     event_handler: &KeyRegistryEventHandler,
     chain_cursor_service: &ChainCursorService,
-) -> Result<()> {
+) -> eyre::Result<()> {
     tracing::trace!("parsing event...");
     let event = KeyRegistryEvent::try_decode_log(&log).context("while decoding chain event")?;
     event.record_span_fields(&tracing::Span::current());
@@ -247,7 +247,7 @@ async fn key_gen_event(
     let result = event_handler.handle(event, &tracing::Span::current()).await;
 
     tracing::trace!("process result...");
-    handle_soft_errors(result)?;
+    handle_soft_errors(result).context("while handling key-gen event")?;
 
     tracing::trace!("store chain cursor...");
     let block_number = log
@@ -259,7 +259,8 @@ async fn key_gen_event(
     let chain_cursor = ChainCursor::new(block_number, index);
     chain_cursor_service
         .store_chain_cursor(chain_cursor)
-        .await?;
+        .await
+        .context("while storing chain cursor")?;
     metrics::chain_events::record_current_block(chain_cursor);
     Ok(())
 }
@@ -280,7 +281,7 @@ async fn key_gen_event(
 ///   as a warning and skipped.
 ///
 /// All other errors are returned as-is and will abort the watcher task.
-fn handle_soft_errors(result: Result<()>) -> Result<()> {
+fn handle_soft_errors(result: Result<()>) -> eyre::Result<()> {
     match result {
         Ok(()) => Ok(()),
         Err(KeyRegistryEventError::Revert(RevertError::OprfKeyRegistry(
@@ -325,6 +326,10 @@ fn handle_soft_errors(result: Result<()>) -> Result<()> {
             );
             Ok(())
         }
-        Err(err) => Err(err),
+        Err(
+            KeyRegistryEventError::SecretManagerError(SecretManagerError::Internal(report))
+            | KeyRegistryEventError::Internal(report),
+        ) => Err(report),
+        Err(err) => Err(eyre::Report::from(err)),
     }
 }

--- a/oprf-key-gen/src/services/key_event_watcher.rs
+++ b/oprf-key-gen/src/services/key_event_watcher.rs
@@ -30,7 +30,6 @@ use std::{
 
 use crate::{
     event_cursor_store::ChainCursorService,
-    metrics,
     secret_manager::SecretManagerError,
     services::{
         key_event_watcher::{events::KeyRegistryEvent, handler::KeyRegistryEventHandler},
@@ -261,7 +260,6 @@ async fn key_gen_event(
         .store_chain_cursor(chain_cursor)
         .await
         .context("while storing chain cursor")?;
-    metrics::chain_events::record_current_block(chain_cursor);
     Ok(())
 }
 

--- a/oprf-key-gen/src/services/secret_gen.rs
+++ b/oprf-key-gen/src/services/secret_gen.rs
@@ -51,7 +51,7 @@ mod tests;
 pub(crate) enum SecretGenError {
     #[error(transparent)]
     SecretManagerError(#[from] SecretManagerError),
-    #[error(transparent)]
+    #[error("internal error: {0:?}")]
     Internal(#[from] eyre::Report),
 }
 

--- a/oprf-key-gen/src/services/secret_manager.rs
+++ b/oprf-key-gen/src/services/secret_manager.rs
@@ -41,7 +41,7 @@ pub enum SecretManagerError {
     #[error("Refusing to overwrite newer share")]
     RefusingToRollbackEpoch,
     /// Implementation specific error.
-    #[error(transparent)]
+    #[error("internal error: {0:?}")]
     Internal(#[from] eyre::Report),
 }
 

--- a/oprf-service/Cargo.toml
+++ b/oprf-service/Cargo.toml
@@ -79,7 +79,7 @@ oprf-test-utils = { package = "taceo-oprf-test-utils", path = "../oprf-test-util
   "postgres-test-container"
 ] }
 rustls = { workspace = true }
-telemetry-batteries.workspace = true
+telemetry-batteries = { workspace = true, features = ["metrics-statsd"] }
 
 [features]
 default = ["postgres"]

--- a/oprf-service/examples/deploy/datadog/oprf-logs.yaml
+++ b/oprf-service/examples/deploy/datadog/oprf-logs.yaml
@@ -1,0 +1,42 @@
+logs:
+  - type: file
+    path: /var/log/oprf-logs/*/key-gen0.log
+    service: taceo-oprf-key-gen-0
+    source: oprf-key-gen
+    tags:
+      - peer:0
+
+  - type: file
+    path: /var/log/oprf-logs/*/key-gen1.log
+    service: taceo-oprf-key-gen-1
+    source: oprf-key-gen
+    tags:
+      - peer:1
+
+  - type: file
+    path: /var/log/oprf-logs/*/key-gen2.log
+    service: taceo-oprf-key-gen-2
+    source: oprf-key-gen
+    tags:
+      - peer:2
+
+  - type: file
+    path: /var/log/oprf-logs/*/node0.log
+    service: taceo-oprf-service-0
+    source: oprf-service
+    tags:
+      - peer:0
+
+  - type: file
+    path: /var/log/oprf-logs/*/node1.log
+    service: taceo-oprf-service-1
+    source: oprf-service
+    tags:
+      - peer:1
+
+  - type: file
+    path: /var/log/oprf-logs/*/node2.log
+    service: taceo-oprf-service-2
+    source: oprf-service
+    tags:
+      - peer:2

--- a/oprf-service/examples/deploy/docker-compose.yml
+++ b/oprf-service/examples/deploy/docker-compose.yml
@@ -19,3 +19,24 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: postgres
+
+  datadog:
+    image: gcr.io/datadoghq/agent:7
+    container_name: datadog-agent
+    profiles: ["datadog"]
+    ports:
+      - "8125:8125/udp"
+      - "8126:8126/tcp"
+    environment:
+      DD_API_KEY: ${DD_API_KEY:?DD_API_KEY required when DATADOG_ENABLE=1}
+      DD_SITE: datadoghq.eu
+      DD_HOSTNAME: oprf-dev-local
+      DD_TAGS: "env:dev"
+      DD_DOGSTATSD_NON_LOCAL_TRAFFIC: "true"
+      DD_APM_ENABLED: "true"
+      DD_APM_NON_LOCAL_TRAFFIC: "true"
+      DD_LOGS_ENABLED: "true"
+      DD_PROCESS_AGENT_ENABLED: "false"
+    volumes:
+      - ./datadog/oprf-logs.yaml:/etc/datadog-agent/conf.d/oprf.d/conf.yaml:ro
+      - ../../../logs:/var/log/oprf-logs:ro

--- a/oprf-service/examples/deploy/docker-compose.yml
+++ b/oprf-service/examples/deploy/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - "8125:8125/udp"
       - "8126:8126/tcp"
     environment:
-      DD_API_KEY: ${DD_API_KEY:?DD_API_KEY required when DATADOG_ENABLE=1}
+      DD_API_KEY: ${DD_API_KEY:-}
       DD_SITE: datadoghq.eu
       DD_HOSTNAME: oprf-dev-local
       DD_TAGS: "env:dev"

--- a/oprf-service/examples/taceo-oprf-service-example.rs
+++ b/oprf-service/examples/taceo-oprf-service-example.rs
@@ -1,9 +1,4 @@
-use std::{
-    net::SocketAddr,
-    process::ExitCode,
-    sync::{Arc, atomic::Ordering},
-    time::Duration,
-};
+use std::{net::SocketAddr, process::ExitCode, sync::Arc, time::Duration};
 
 use config::{Config, Environment};
 use eyre::Context;
@@ -111,7 +106,7 @@ async fn main() -> eyre::Result<ExitCode> {
         }
         Err(err) => {
             // we don't want to double print the error therefore we just return FAILURE
-            tracing::error!("{err:?}");
+            tracing::error!(?err, "oprf-service exited with error");
             Ok(ExitCode::FAILURE)
         }
     }
@@ -123,8 +118,7 @@ pub async fn start_service(
     secret_manager: SecretManagerService,
     shutdown_signal: impl std::future::Future<Output = ()> + Send + 'static,
 ) -> eyre::Result<()> {
-    let (cancellation_token, is_graceful_shutdown) =
-        nodes_common::spawn_shutdown_task(shutdown_signal);
+    let (cancellation_token, _) = nodes_common::spawn_shutdown_task(shutdown_signal);
 
     tracing::info!("init oprf service..");
     let (oprf_service_router, key_event_watcher) = OprfServiceBuilder::init(
@@ -154,7 +148,7 @@ pub async fn start_service(
             .await;
         tracing::info!("axum server shutdown");
         if let Err(err) = axum_result {
-            tracing::error!("got error from axum: {err:?}");
+            tracing::error!(%err, "got error from axum");
         }
         // we cancel the token in case axum encountered an error to shutdown the service
         axum_cancel_token.cancel();
@@ -168,16 +162,17 @@ pub async fn start_service(
         config.max_wait_time_shutdown
     );
     match tokio::time::timeout(config.max_wait_time_shutdown, async move {
-        tokio::join!(server, key_event_watcher)
+        key_event_watcher.await??;
+        server.await?;
+        eyre::Ok(())
     })
     .await
     {
-        Ok(_) => tracing::info!("successfully finished shutdown in time"),
-        Err(_) => tracing::warn!("could not finish shutdown in time"),
-    }
-    if is_graceful_shutdown.load(Ordering::Relaxed) {
-        Ok(())
-    } else {
-        eyre::bail!("Unexpected shutdown - check error logs")
+        Ok(Ok(())) => {
+            tracing::info!("successfully finished shutdown in time");
+            Ok(())
+        }
+        Ok(Err(err)) => Err(err),
+        Err(_) => eyre::bail!("could not finish shutdown in time"),
     }
 }

--- a/oprf-service/src/api/errors.rs
+++ b/oprf-service/src/api/errors.rs
@@ -7,7 +7,6 @@ use oprf_types::{
     OprfKeyId,
     api::{OprfRequestAuthenticatorError, oprf_error_codes},
 };
-use tracing::instrument;
 use tungstenite::error::ProtocolError;
 use uuid::Uuid;
 
@@ -50,11 +49,9 @@ pub(crate) enum Error {
 
 impl Error {
     /// Transforms the error into a [`CloseFrame`](https://docs.rs/axum/latest/axum/extract/ws/struct.CloseFrame.html) if necessary.
-    #[instrument(level = "debug", skip_all)]
     pub(crate) fn into_close_frame(self) -> Option<CloseFrame> {
         // Prepare the error log line as we need to consume self.
-        // We log both, Display and Debug to not miss any context
-        let maybe_log_line = format!("{self}; {self:?}");
+        let maybe_log_line = format!("{self}");
         let close_frame = match self {
             // for Axum and auth error we short circuit and don't print the log line
             // * handle axum error log in the dedicated method
@@ -69,7 +66,8 @@ impl Error {
             // For all other errors, we print it before returning the CloseFrame.
             Error::ConnectionClosed => {
                 // nothing to do here
-                None
+                tracing::debug!("nothing to do client closed session");
+                return None;
             }
             Error::BlindedQueryIsIdentity => Some(CloseFrame {
                 code: oprf_error_codes::BLINDED_QUERY_IS_IDENTITY,
@@ -119,13 +117,12 @@ impl Error {
                 ),
             }),
         };
-        tracing::debug!("{maybe_log_line}");
+        tracing::warn!(user_error = true, "{maybe_log_line}");
         close_frame
     }
 }
 
 fn handle_axum_error(err: axum::Error) -> Option<CloseFrame> {
-    let maybe_log_line = format!("{err}; {err:?}");
     let inner = err.into_inner();
     if let Some(err) = inner.downcast_ref::<tungstenite::Error>() {
         match err {
@@ -138,7 +135,7 @@ fn handle_axum_error(err: axum::Error) -> Option<CloseFrame> {
                 return None;
             }
             tungstenite::Error::Capacity(_) => {
-                tracing::debug!("{maybe_log_line}");
+                tracing::warn!(user_error=true, %err, "websocket message too large");
                 return Some(CloseFrame {
                     code: close_code::SIZE,
                     reason: to_close_frame_bytes!("size exceeds max frame length"),
@@ -147,8 +144,8 @@ fn handle_axum_error(err: axum::Error) -> Option<CloseFrame> {
             _ => {}
         }
     }
-    // There was an unknown Axum error - log as warning maybe we need to update match block
-    tracing::warn!("{maybe_log_line}");
+    // There was an unknown Axum error
+    tracing::error!(err = %inner, "unknown axum error");
     Some(CloseFrame {
         code: close_code::ERROR,
         reason: to_close_frame_bytes!("unexpected error"),

--- a/oprf-service/src/api/oprf.rs
+++ b/oprf-service/src/api/oprf.rs
@@ -101,7 +101,6 @@ enum HumanReadable {
 /// ## Session Flow
 ///
 /// See [`partial_oprf`] for the flow of the web-socket connection. If the session finishes successfully, encounters an error, the user closes the connection, or we run into a timeout, the implementation will try to initiate a graceful shutdown of the web-socket connection (closing handshake). We do this on a best-effort basis but are very restrictive on what we expect. We close any session that sends invalid requests/authentication. If sending the `Close` frame fails, we simply ignore the error and destruct everything associated with the session.
-#[instrument(level = "debug", skip_all, name="request", fields(client_version=tracing::field::Empty,request_id=tracing::field::Empty, oprf_key_id=tracing::field::Empty))]
 async fn oprf_ws_handler<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
     State(state): State<OprfModuleState<ReqAuth>>,
     websocket_upgrade: WebSocketUpgrade,
@@ -109,15 +108,16 @@ async fn oprf_ws_handler<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
     query_version: Query<ProtocolVersionQuery>,
 ) -> axum::response::Response {
     let Some(client_version) = parse_client_header(header_version, query_version) else {
+        tracing::warn!(user_error = true, "missing client version");
         return (StatusCode::BAD_REQUEST, "missing client version").into_response();
     };
     let parent_span = tracing::Span::current();
-    parent_span.record("client_version", format!("{client_version}"));
+    parent_span.record("client_version", client_version.to_string());
     if state.version_req.matches(&client_version) {
         websocket_upgrade
             .max_message_size(state.max_message_size)
             .on_failed_upgrade(|err| {
-                tracing::warn!(%err, "could not establish websocket connection");
+                tracing::warn!(user_error=true, %err, "could not establish websocket connection");
             })
             .on_upgrade(move |mut ws| {
                 async move {
@@ -144,7 +144,8 @@ async fn oprf_ws_handler<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
                         }
                         Ok(Err(err)) => err.into_close_frame(),
                         Err(_) => {
-                            tracing::debug!("session ran into timeout"); 
+                            tracing::warn!(user_error=true, "session ran into timeout");
+                            metrics::request::inc_client_timeout();
                             Some(CloseFrame {
                                 code: oprf_error_codes::TIMEOUT,
                                 reason: "timeout".into(),
@@ -165,7 +166,7 @@ async fn oprf_ws_handler<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
             "invalid version, expected: {} got: {client_version}",
             state.version_req
         );
-        tracing::debug!("{msg}");
+        tracing::warn!(user_error = true, "{msg}");
         metrics::request::inc_client_version_mismatch();
         (StatusCode::BAD_REQUEST, msg).into_response()
     }
@@ -341,17 +342,19 @@ async fn write_response<Msg: Serialize>(
     Ok(())
 }
 
-/// Tries to determine the client version of the request by checking the http header and query parameters. At least one of those must be present. The header takes precedence.
+/// Tries to determine the client version of the request by checking the http header and query parameters. At least one of those must be present. The query takes precedence.
 ///
 /// Returns `None` if none of those are present.
 fn parse_client_header(
     header_version: Option<TypedHeader<ProtocolVersion>>,
     Query(query_version): Query<ProtocolVersionQuery>,
 ) -> Option<semver::Version> {
-    // http header has precedence
-    if let Some(TypedHeader(ProtocolVersion(client_version))) = header_version {
+    // query has precedence
+    if let Some(ProtocolVersion(client_version)) = query_version.version {
+        metrics::request::params::inc_client_version_in_query();
         Some(client_version)
-    } else if let Some(ProtocolVersion(client_version)) = query_version.version {
+    } else if let Some(TypedHeader(ProtocolVersion(client_version))) = header_version {
+        metrics::request::params::inc_client_version_in_header();
         Some(client_version)
     } else {
         None

--- a/oprf-service/src/api/version_header.rs
+++ b/oprf-service/src/api/version_header.rs
@@ -34,7 +34,7 @@ impl de::Visitor<'_> for ProtocolVersionHeaderVisitor {
         E: de::Error,
     {
         let version = semver::Version::parse(v).map_err(|err| {
-            tracing::trace!("could not parse header version: {err:?}");
+            tracing::trace!(%err, "could not parse header version");
             de::Error::custom("expected semver version")
         })?;
         Ok(ProtocolVersion(version))
@@ -56,15 +56,14 @@ impl Header for ProtocolVersion {
             .ok_or_else(headers::Error::invalid)?
             .to_str()
             .map_err(|err| {
-                tracing::trace!("could not convert header to string: {err:?}");
-
+                tracing::trace!(%err, "could not convert header to string");
                 headers::Error::invalid()
             })?;
         if values.next().is_some() {
             Err(headers::Error::invalid())
         } else {
             let version = semver::Version::parse(version_req).map_err(|err| {
-                tracing::trace!("could not parse header version: {err:?}");
+                tracing::trace!(%err, "could not parse header version");
                 headers::Error::invalid()
             })?;
             Ok(ProtocolVersion(version))

--- a/oprf-service/src/lib.rs
+++ b/oprf-service/src/lib.rs
@@ -49,6 +49,8 @@
 //!
 //! If you want to enable HTTP/2.0, you either have to do it by hand or by calling `axum::serve`, which enabled HTTP/2.0 by default. Have a look at [Axum's HTTP2.0 example](https://github.com/tokio-rs/axum/blob/aeff16e91af6fa76efffdee8f3e5f464b458785b/examples/websockets-http2/src/main.rs#L57).
 
+use std::fmt;
+
 use crate::api::oprf::OprfModuleState;
 use crate::services::key_event_watcher::KeyEventWatcherTaskArgs;
 use crate::services::open_sessions::OpenSessions;
@@ -56,15 +58,16 @@ use crate::services::oprf_key_material_store::OprfKeyMaterialStore;
 use crate::{config::OprfNodeServiceConfig, services::secret_manager::SecretManagerService};
 use alloy::providers::{Provider as _, ProviderBuilder, WsConnect};
 use axum::Router;
-use eyre::Context as _;
-use http::StatusCode;
+use axum::extract::MatchedPath;
+use eyre::Context;
+use http::{HeaderMap, HeaderName, StatusCode};
 use oprf_types::api::OprfRequestAuthService;
 use oprf_types::chain::OprfKeyRegistry;
 use oprf_types::crypto::PartyId;
 use serde::Deserialize;
 use tokio_util::sync::CancellationToken;
 use tower_http::timeout::TimeoutLayer;
-use tower_http::trace::TraceLayer;
+use tower_http::trace::{MakeSpan, TraceLayer};
 
 pub(crate) mod api;
 pub mod config;
@@ -84,7 +87,7 @@ pub use services::secret_manager;
 /// [`OprfServiceBuilder`] to initialize a `OprfService` with multiple [`OprfRequestAuthService`]s.
 pub struct OprfServiceBuilder {
     config: OprfNodeServiceConfig,
-    root: Router,
+    info_routes: Router,
     api: Router,
     key_event_watcher: tokio::task::JoinHandle<Result<(), eyre::Error>>,
     open_sessions: OpenSessions,
@@ -181,8 +184,9 @@ impl OprfServiceBuilder {
         });
 
         tracing::info!("init oprf-service...");
+
         let version_str = nodes_common::version_info!();
-        let root = Router::new()
+        let info_route = Router::new()
             .merge(nodes_common::api::routes_with_services(
                 started_services.clone(),
                 version_str,
@@ -213,7 +217,7 @@ impl OprfServiceBuilder {
         Ok(Self {
             config,
             open_sessions: OpenSessions::new(),
-            root,
+            info_routes: info_route,
             api: Router::new(),
             key_event_watcher,
             oprf_key_material_store,
@@ -267,15 +271,61 @@ impl OprfServiceBuilder {
     /// - If no oprf modules were added
     pub fn build(self) -> (axum::Router, tokio::task::JoinHandle<eyre::Result<()>>) {
         assert!(self.api.has_routes(), "Needs at least 1 oprf-module");
+        // setup the dedicated HTTP trace layer for the auth modules
+        let auth_modules = self
+            .api
+            .layer(TraceLayer::new_for_http().make_span_with(OprfAuthModulesMakeSpan));
         (
-            self.root
-                .nest("/api", self.api)
+            Router::new()
+                .merge(self.info_routes)
+                .nest("/api", auth_modules)
                 .layer(TimeoutLayer::with_status_code(
                     StatusCode::REQUEST_TIMEOUT,
                     self.config.http_request_timeout,
-                ))
-                .layer(TraceLayer::new_for_http()),
+                )),
             self.key_event_watcher,
+        )
+    }
+}
+
+#[derive(Clone, Copy)]
+struct OprfAuthModulesMakeSpan;
+
+struct FilteredHeaders<'a>(&'a HeaderMap);
+
+const ALLOWED_HEADERS: &[HeaderName] = &[
+    http::header::HOST,
+    http::header::ORIGIN,
+    http::header::USER_AGENT,
+];
+
+impl fmt::Debug for FilteredHeaders<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut map = f.debug_map();
+        for (name, value) in self.0 {
+            if ALLOWED_HEADERS.contains(name) {
+                map.entry(&name, &value);
+            }
+        }
+        map.finish()
+    }
+}
+
+impl<B> MakeSpan<B> for OprfAuthModulesMakeSpan {
+    fn make_span(&mut self, request: &http::Request<B>) -> tracing::Span {
+        let matched_path = request
+            .extensions()
+            .get::<MatchedPath>()
+            .map_or_else(|| request.uri().path(), MatchedPath::as_str);
+        tracing::info_span!(
+            "oprf_request",
+            request_id = tracing::field::Empty,
+            oprf_key_id = tracing::field::Empty,
+            client_version = tracing::field::Empty,
+            method = %request.method(),
+            path = %matched_path,
+            version = ?request.version(),
+            headers = ?FilteredHeaders(request.headers()),
         )
     }
 }

--- a/oprf-service/src/metrics.rs
+++ b/oprf-service/src/metrics.rs
@@ -30,7 +30,11 @@ pub(crate) mod request {
     /// Metrics key for how often we reject clients due to version mismatch.
     const METRICS_CLIENT_VERSION_MISMATCH: &str = "taceo.oprf.node.client.invalid_version";
 
+    /// Metrics key for how often we terminated user connection due to timeout.
+    const METRICS_CLIENT_TIMEOUT: &str = "taceo.oprf.node.request.timeout";
+
     pub(super) fn describe_metrics() {
+        params::describe_metrics();
         metrics::describe_counter!(
             METRICS_ID_NODE_OPRF_SUCCESS,
             metrics::Unit::Count,
@@ -60,6 +64,12 @@ pub(crate) mod request {
             metrics::Unit::Count,
             "How often we rejected clients due to version mismatch"
         );
+
+        metrics::describe_counter!(
+            METRICS_CLIENT_TIMEOUT,
+            metrics::Unit::Count,
+            "How often we terminated user connection due to timeout"
+        );
     }
 
     pub(crate) fn inc_client_version_mismatch() {
@@ -68,6 +78,10 @@ pub(crate) mod request {
 
     pub(crate) fn inc_success() {
         metrics::counter!(METRICS_ID_NODE_OPRF_SUCCESS).increment(1);
+    }
+
+    pub(crate) fn inc_client_timeout() {
+        metrics::counter!(METRICS_CLIENT_TIMEOUT).increment(1);
     }
 
     pub(crate) fn record_verify_duration(duration: Duration) {
@@ -81,6 +95,35 @@ pub(crate) mod request {
 
     pub(crate) fn record_part2_duration(duration: Duration) {
         metrics::histogram!(METRICS_ID_NODE_PART_2_DURATION).record(duration.as_millis() as f64);
+    }
+
+    pub(crate) mod params {
+
+        const METRICS_ID_NODE_CLIENT_VERSION_HEADER: &str =
+            "taceo.oprf.node.request.params.version.header";
+        const METRICS_ID_NODE_CLIENT_VERSION_QUERY: &str =
+            "taceo.oprf.node.request.params.version.query";
+
+        pub(super) fn describe_metrics() {
+            metrics::describe_counter!(
+                METRICS_ID_NODE_CLIENT_VERSION_HEADER,
+                metrics::Unit::Count,
+                "How often clients reported their client version by HTTP header"
+            );
+            metrics::describe_counter!(
+                METRICS_ID_NODE_CLIENT_VERSION_QUERY,
+                metrics::Unit::Count,
+                "How often clients reported their client version by query parameter"
+            );
+        }
+
+        pub(crate) fn inc_client_version_in_header() {
+            metrics::counter!(METRICS_ID_NODE_CLIENT_VERSION_HEADER).increment(1);
+        }
+
+        pub(crate) fn inc_client_version_in_query() {
+            metrics::counter!(METRICS_ID_NODE_CLIENT_VERSION_QUERY).increment(1);
+        }
     }
 }
 

--- a/oprf-service/src/services/key_event_watcher.rs
+++ b/oprf-service/src/services/key_event_watcher.rs
@@ -47,7 +47,7 @@ enum FetchOprfKeyMaterialError {
     #[error("Cannot find requested material")]
     NotFound,
     /// Internal error from DB.
-    #[error(transparent)]
+    #[error("internal error: {0:?}")]
     Internal(#[from] eyre::Report),
 }
 
@@ -79,7 +79,7 @@ pub(crate) async fn key_event_watcher_task(
     let result = handle_events(key_event_watcher_task_args).await;
     match result.as_ref() {
         Ok(()) => tracing::info!("stopped key event watcher without error"),
-        Err(err) => tracing::warn!("key event watcher encountered an error: {err:?}"),
+        Err(err) => tracing::error!(?err, "key event watcher encountered an error"),
     }
     result
 }
@@ -261,7 +261,7 @@ async fn fetch_oprf_key_material_from_secret_manager(
             );
         }
         Err(err) => {
-            tracing::error!("Could not fetch key-material: {err:?}");
+            tracing::error!(%err, "could not fetch key-material");
         }
     }
 }

--- a/oprf-service/src/services/secret_manager/postgres.rs
+++ b/oprf-service/src/services/secret_manager/postgres.rs
@@ -81,7 +81,7 @@ impl SecretManager for PostgresSecretManager {
         .retry(self.backoff_strategy())
         .sleep(tokio::time::sleep)
         .when(is_retryable_error)
-        .notify(|e, duration| tracing::warn!("Retrying load address: {e:?} after {duration:?}"))
+        .notify(|err, duration| tracing::warn!(%err, "retrying load address after {duration:?}"))
         .await?
         .ok_or_else(|| eyre::eyre!("Cannot get address from DB, maybe key-gen needs to start"))?;
         Address::parse_checksummed(stored_address, None).context("invalid address stored in DB")
@@ -107,7 +107,7 @@ impl SecretManager for PostgresSecretManager {
         .retry(self.backoff_strategy())
         .sleep(tokio::time::sleep)
         .when(is_retryable_error)
-        .notify(|e, duration| tracing::warn!("Retrying load secrets: {e:?} after {duration:?}"))
+        .notify(|err, duration| tracing::warn!(%err, "retrying load secrets after {duration:?}"))
         .await
         .context("while fetching all OPRF keys")?;
         tracing::trace!("loaded {} rows. parsing..", rows.len());
@@ -144,10 +144,8 @@ impl SecretManager for PostgresSecretManager {
         .retry(self.backoff_strategy())
         .sleep(tokio::time::sleep)
         .when(is_retryable_error)
-        .notify(|e, duration| {
-            tracing::warn!(
-                "Retrying get_oprf_key_material for {oprf_key_id}: {e:?} after {duration:?}"
-            );
+        .notify(|err, duration| {
+            tracing::warn!(%err, "retrying get_oprf_key_material for {oprf_key_id} after {duration:?}");
         })
         .await
         .context("while fetching previous share")?;

--- a/oprf-service/src/tests/mod.rs
+++ b/oprf-service/src/tests/mod.rs
@@ -246,20 +246,20 @@ async fn init_with_version_query() -> eyre::Result<()> {
 }
 
 #[tokio::test]
-async fn client_version_header_precedence() -> eyre::Result<()> {
+async fn client_version_query_precedence() -> eyre::Result<()> {
     let setup = TestSetup::new(DeploySetup::TwoThree).await?;
     let node = TestNode::start(0, &setup).await?;
     let mut ws = node
         .server
-        .get_websocket("/api/test/oprf?version=2.0.0")
+        .get_websocket(&format!("/api/test/oprf?version={TEST_PROTOCOL_VERSION}"))
         .add_header(
             oprf_types::api::OPRF_PROTOCOL_VERSION_HEADER.as_str(),
-            TEST_PROTOCOL_VERSION,
+            "2.0.0",
         )
         .await
         .into_websocket()
         .await;
-    // check that the init request works even if query header is wrong
+    // check that the init request works even if HTTP header is wrong
     setup::ws_send(
         &mut ws,
         &setup::request(&mut rand::thread_rng()),

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -132,7 +132,12 @@ terminate_pid_gracefully() {
 compose_up_anvil_postgres() {
     log "Starting local dependencies"
     mkdir -p "$LOG_DIR"
-    docker compose -f "$COMPOSE_FILE" up -d anvil postgres >/dev/null
+    if [[ -n "${DATADOG_ENABLE:-}" ]]; then
+        [[ -n "${DD_API_KEY:-}" ]] || fail "DATADOG_ENABLE=1 requires DD_API_KEY to be exported"
+        docker compose -f "$COMPOSE_FILE" --profile datadog up -d anvil postgres datadog >/dev/null
+    else
+        docker compose -f "$COMPOSE_FILE" up -d anvil postgres >/dev/null
+    fi
     docker logs -f anvil >"$LOG_DIR/anvil.log" 2>&1 &
     ANVIL_LOG_PID=$!
     wait_for_anvil
@@ -297,8 +302,20 @@ start_keygen_node() {
     local i=$1
     local port=$((20000 + i))
     local schema="${schemas[$i]}"
+    local dd_env=()
     mkdir -p "$LOG_DIR"
 
+    if [[ -n "${DATADOG_ENABLE:-}" ]]; then
+        dd_env=(
+            TELEMETRY_PRESET=datadog
+            "TELEMETRY_SERVICE_NAME=taceo-oprf-key-gen-${i}"
+            TELEMETRY_METRICS_BACKEND=statsd
+            TELEMETRY_LOG_FORMAT=datadog_json
+            TELEMETRY_EYRE_MODE=json
+        )
+    fi
+
+    env \
     RUST_LOG="taceo=trace,warn" \
     TACEO_OPRF_KEY_GEN__BIND_ADDR="0.0.0.0:${port}" \
     TACEO_OPRF_KEY_GEN__SERVICE__WALLET_PRIVATE_KEY="${node_private_keys[$i]}" \
@@ -317,6 +334,7 @@ start_keygen_node() {
     TACEO_OPRF_KEY_GEN__SERVICE__BACKFILL__CHUNK_SIZE=2 \
     TACEO_OPRF_KEY_GEN__POSTGRES__CONNECTION_STRING="$POSTGRES_URL" \
     TACEO_OPRF_KEY_GEN__POSTGRES__SCHEMA="$schema" \
+    "${dd_env[@]+"${dd_env[@]}"}" \
     ./target/release/taceo-oprf-key-gen >>"$LOG_DIR/key-gen${i}.log" 2>&1 &
     keygen_pids[$i]="$!"
     log "started key-gen${i} with PID ${keygen_pids[$i]}"
@@ -353,7 +371,19 @@ start_oprf_service_nodes() {
     for i in $(peer_indices); do
         local port=$((10000 + i))
         local wallet="${participant_addresses[$i]}"
+        local dd_env=()
 
+        if [[ -n "${DATADOG_ENABLE:-}" ]]; then
+            dd_env=(
+                TELEMETRY_PRESET=datadog
+                "TELEMETRY_SERVICE_NAME=taceo-oprf-service-${i}"
+                TELEMETRY_METRICS_BACKEND=statsd
+                TELEMETRY_LOG_FORMAT=datadog_json
+                TELEMETRY_EYRE_MODE=json
+            )
+        fi
+
+        env \
         RUST_LOG="taceo=trace,warn" \
         TACEO_OPRF_NODE__POSTGRES__CONNECTION_STRING="$POSTGRES_URL" \
         TACEO_OPRF_NODE__POSTGRES__SCHEMA="${schemas[$i]}" \
@@ -364,6 +394,7 @@ start_oprf_service_nodes() {
         TACEO_OPRF_NODE__RPC__CHAIN_ID=31337 \
         TACEO_OPRF_NODE__SERVICE__VERSION_REQ=">=0.0.0" \
         TACEO_OPRF_NODE__BIND_ADDR="0.0.0.0:${port}" \
+        "${dd_env[@]+"${dd_env[@]}"}" \
         ./target/release/examples/taceo-oprf-service-example >"$LOG_DIR/node${i}.log" 2>&1 &
         nodes_pids[$i]="$!"
         log "started node${i} with PID ${nodes_pids[$i]} (wallet $wallet)"


### PR DESCRIPTION
NOTE: enforce convention:
eyre::Report -> Debug
all other errors -> Display

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: primarily logging/telemetry refactors, but it changes client protocol version precedence (query over header) and adjusts request tracing, which could affect client behavior and observability assumptions.
> 
> **Overview**
> Unifies error logging across clients/services by standardizing structured `tracing` usage and clarifying *internal* (`eyre::Report`) vs external error formatting, including updated soft-error handling/context in key-gen and more explicit websocket close/error logging.
> 
> Adds optional StatsD/Datadog support: enables `telemetry-batteries` `metrics-statsd` feature, introduces `metrics-exporter-statsd` in the lockfile, emits new request metrics (client timeout + version source), and provides local Datadog agent setup via `docker-compose` + log config, `just` commands, and `scripts` support gated by `DATADOG_ENABLE`/`DD_API_KEY`.
> 
> Updates OPRF websocket handling to prefer the `version` query parameter over the protocol version header (with corresponding metrics and test update), and refines HTTP tracing by applying a dedicated `TraceLayer`/span for auth modules with filtered request headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef2f4df172817f40e3855bcaa289fb8d0055b7f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->