### PR TITLE
themis/switch in client to query

### DIFF
--- a/oprf-client/src/lib.rs
+++ b/oprf-client/src/lib.rs
@@ -451,7 +451,7 @@ where
     };
 
     tracing::debug!("initializing sessions at {} services", services.len());
-    let sessions = sessions::init_sessions(services, threshold, oprf_req, connector)
+    let sessions = sessions::init_sessions(request_id, services, threshold, oprf_req, connector)
         .await
         .map_err(|errors| aggregate_error(threshold, errors))?;
 

--- a/oprf-client/src/sessions.rs
+++ b/oprf-client/src/sessions.rs
@@ -19,6 +19,7 @@ use oprf_types::{
 };
 use serde::Serialize;
 use tracing::instrument;
+use uuid::Uuid;
 
 use crate::Connector;
 
@@ -99,10 +100,11 @@ impl OprfSessions {
 #[instrument(level = "trace", skip(req, connector))]
 async fn init_session<Auth: Serialize>(
     service: Uri,
+    request_id: Uuid,
     req: OprfRequest<Auth>,
     connector: Connector,
 ) -> Result<(WebSocketSession, OprfResponse), NodeError> {
-    let mut session = WebSocketSession::new(service, connector).await?;
+    let mut session = WebSocketSession::new(service, request_id, connector).await?;
     session.send(req).await?;
     let response = session.read::<OprfResponse>().await?;
     Ok((session, response))
@@ -151,6 +153,7 @@ pub async fn finish_sessions(
 /// Returns a [`OprfSessions`] ready to be finalized with [`finish_sessions`].
 #[instrument(level = "debug", skip_all)]
 pub async fn init_sessions<OprfRequestAuth: Clone + Serialize + 'static>(
+    request_id: Uuid,
     oprf_services: &[Uri],
     threshold: usize,
     req: OprfRequest<OprfRequestAuth>,
@@ -163,7 +166,7 @@ pub async fn init_sessions<OprfRequestAuth: Clone + Serialize + 'static>(
             let req = req.clone();
             let service = service.to_owned();
             async move {
-                init_session(service.clone(), req, connector)
+                init_session(service.clone(), request_id, req, connector)
                     .await
                     .map_err(|err| (service, err))
             }
@@ -245,6 +248,7 @@ mod tests {
         api::{OprfPublicKeyWithEpoch, OprfResponse},
         crypto::{OprfPublicKey, PartyId},
     };
+    use uuid::Uuid;
 
     use crate::{OprfSessions, ws::WebSocketSession};
 
@@ -314,15 +318,21 @@ mod tests {
     async fn test_reject_duplicate_party_id() {
         let (_test_server, should_address) = mock_server(panic_on_message);
 
-        let websocket_session0 =
-            WebSocketSession::new(should_address.clone(), tokio_tungstenite::Connector::Plain)
-                .await
-                .expect("Can open websocket-session");
+        let websocket_session0 = WebSocketSession::new(
+            should_address.clone(),
+            Uuid::new_v4(),
+            tokio_tungstenite::Connector::Plain,
+        )
+        .await
+        .expect("Can open websocket-session");
 
-        let websocket_session1 =
-            WebSocketSession::new(should_address.clone(), tokio_tungstenite::Connector::Plain)
-                .await
-                .expect("Can open websocket-session");
+        let websocket_session1 = WebSocketSession::new(
+            should_address.clone(),
+            Uuid::new_v4(),
+            tokio_tungstenite::Connector::Plain,
+        )
+        .await
+        .expect("Can open websocket-session");
 
         let mut oprf_sessions = OprfSessions::with_capacity(ShareEpoch::default(), 2);
 

--- a/oprf-client/src/ws/mod.rs
+++ b/oprf-client/src/ws/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(not(target_arch = "wasm32"))]
 mod native;
+use http::Uri;
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) use native::WebSocketSession;
 
@@ -7,3 +8,14 @@ pub(crate) use native::WebSocketSession;
 mod wasm;
 #[cfg(target_arch = "wasm32")]
 pub(crate) use wasm::WebSocketSession;
+
+pub(crate) fn append_client_version_to_query(endpoint: &Uri) -> String {
+    let version = env!("CARGO_PKG_VERSION");
+    let has_query = endpoint.query().is_some();
+    let mut endpoint = endpoint.to_string();
+
+    endpoint.push(if has_query { '&' } else { '?' });
+    endpoint.push_str("version=");
+    endpoint.push_str(version);
+    endpoint
+}

--- a/oprf-client/src/ws/mod.rs
+++ b/oprf-client/src/ws/mod.rs
@@ -6,10 +6,11 @@ pub(crate) use native::WebSocketSession;
 
 #[cfg(target_arch = "wasm32")]
 mod wasm;
+use uuid::Uuid;
 #[cfg(target_arch = "wasm32")]
 pub(crate) use wasm::WebSocketSession;
 
-pub(crate) fn append_client_version_to_query(endpoint: &Uri) -> String {
+pub(crate) fn append_client_version_to_query(endpoint: &Uri, request_id: Uuid) -> String {
     let version = env!("CARGO_PKG_VERSION");
     let has_query = endpoint.query().is_some();
     let mut endpoint = endpoint.to_string();
@@ -17,5 +18,7 @@ pub(crate) fn append_client_version_to_query(endpoint: &Uri) -> String {
     endpoint.push(if has_query { '&' } else { '?' });
     endpoint.push_str("version=");
     endpoint.push_str(version);
+    endpoint.push_str("&request_id=");
+    endpoint.push_str(&request_id.to_string());
     endpoint
 }

--- a/oprf-client/src/ws/native.rs
+++ b/oprf-client/src/ws/native.rs
@@ -16,6 +16,7 @@ use tokio_tungstenite::{
         protocol::{CloseFrame, frame::coding::CloseCode},
     },
 };
+use uuid::Uuid;
 
 impl From<tungstenite::Error> for NodeError {
     fn from(value: tungstenite::Error) -> Self {
@@ -63,13 +64,17 @@ impl WebSocketSession {
         NodeError::UnexpectedMessage { reason }
     }
     /// Creates a new session at the provided endpoint.
-    pub(crate) async fn new(endpoint: Uri, connector: Connector) -> Result<Self, NodeError> {
+    pub(crate) async fn new(
+        endpoint: Uri,
+        request_id: Uuid,
+        connector: Connector,
+    ) -> Result<Self, NodeError> {
         let service = endpoint
             .authority()
             .map_or_else(|| "unknown authority".to_string(), ToString::to_string);
         tracing::trace!("> sending request to {service}..");
         let (ws, _) = tokio_tungstenite::connect_async_tls_with_config(
-            super::append_client_version_to_query(&endpoint),
+            super::append_client_version_to_query(&endpoint, request_id),
             None,
             false,
             Some(connector),

--- a/oprf-client/src/ws/native.rs
+++ b/oprf-client/src/ws/native.rs
@@ -7,13 +7,12 @@
 use crate::{NodeError, ServiceError};
 use futures::{SinkExt, StreamExt};
 use http::Uri;
-use oprf_types::api::OPRF_PROTOCOL_VERSION_HEADER;
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpStream;
 use tokio_tungstenite::{
     Connector, MaybeTlsStream, WebSocketStream,
     tungstenite::{
-        self, ClientRequestBuilder,
+        self,
         protocol::{CloseFrame, frame::coding::CloseCode},
     },
 };
@@ -65,17 +64,17 @@ impl WebSocketSession {
     }
     /// Creates a new session at the provided endpoint.
     pub(crate) async fn new(endpoint: Uri, connector: Connector) -> Result<Self, NodeError> {
-        let version = env!("CARGO_PKG_VERSION");
         let service = endpoint
             .authority()
             .map_or_else(|| "unknown authority".to_string(), ToString::to_string);
         tracing::trace!("> sending request to {service}..");
-        let request = ClientRequestBuilder::new(endpoint)
-            .with_header(OPRF_PROTOCOL_VERSION_HEADER.as_str(), version);
-
-        let (ws, _) =
-            tokio_tungstenite::connect_async_tls_with_config(request, None, false, Some(connector))
-                .await?;
+        let (ws, _) = tokio_tungstenite::connect_async_tls_with_config(
+            super::append_client_version_to_query(&endpoint),
+            None,
+            false,
+            Some(connector),
+        )
+        .await?;
         Ok(Self { service, inner: ws })
     }
 

--- a/oprf-client/src/ws/wasm.rs
+++ b/oprf-client/src/ws/wasm.rs
@@ -18,6 +18,7 @@ use futures::{SinkExt, StreamExt};
 use gloo_net::websocket::{Message, WebSocketError, futures::WebSocket};
 use http::Uri;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 const CLOSE_CODE_NORMAL: u16 = 1000;
 
@@ -48,11 +49,18 @@ impl WebSocketSession {
         clippy::unused_async,
         reason = "Want to have async to have equivalent signature with native"
     )]
-    pub(crate) async fn new(endpoint: Uri, _connector: Connector) -> Result<Self, NodeError> {
-        let service = super::append_client_version_to_query(&endpoint);
+    pub(crate) async fn new(
+        endpoint: Uri,
+        request_id: Uuid,
+        _connector: Connector,
+    ) -> Result<Self, NodeError> {
+        let service = endpoint
+            .authority()
+            .map_or_else(|| "unknown authority".to_string(), ToString::to_string);
         tracing::trace!("> sending request to {service}..");
 
-        let ws = WebSocket::open(&service).map_err(|e| {
+        let endpoint = super::append_client_version_to_query(&endpoint, request_id);
+        let ws = WebSocket::open(&endpoint).map_err(|e| {
             NodeError::WsError(Box::new(std::io::Error::other(format!(
                 "failed to open {endpoint}: {e:?}"
             ))))

--- a/oprf-client/src/ws/wasm.rs
+++ b/oprf-client/src/ws/wasm.rs
@@ -49,18 +49,10 @@ impl WebSocketSession {
         reason = "Want to have async to have equivalent signature with native"
     )]
     pub(crate) async fn new(endpoint: Uri, _connector: Connector) -> Result<Self, NodeError> {
-        let version = env!("CARGO_PKG_VERSION");
-        let has_query = endpoint.query().is_some();
-        let mut endpoint = endpoint.to_string();
-
-        endpoint.push(if has_query { '&' } else { '?' });
-        endpoint.push_str("version=");
-        endpoint.push_str(version);
-
-        let service = endpoint.clone();
+        let service = super::append_client_version_to_query(&endpoint);
         tracing::trace!("> sending request to {service}..");
 
-        let ws = WebSocket::open(&endpoint).map_err(|e| {
+        let ws = WebSocket::open(&service).map_err(|e| {
             NodeError::WsError(Box::new(std::io::Error::other(format!(
                 "failed to open {endpoint}: {e:?}"
             ))))

--- a/oprf-dev-client/src/lib.rs
+++ b/oprf-dev-client/src/lib.rs
@@ -127,9 +127,10 @@ pub async fn send_init_requests<OprfRequestAuth: Clone + Serialize + Send + 'sta
             let nodes = oprf_client::to_oprf_uri_many(nodes, module)
                 .context("while producing OPRF uris")?;
             let init_start = Instant::now();
-            let sessions = oprf_client::init_sessions(&nodes, threshold, req, connector)
-                .await
-                .map_err(|_| eyre::eyre!("Error during init-sessions for session-id: {id}"))?;
+            let sessions =
+                oprf_client::init_sessions(req.request_id, &nodes, threshold, req, connector)
+                    .await
+                    .map_err(|_| eyre::eyre!("Error during init-sessions for session-id: {id}"))?;
             let init_duration = init_start.elapsed();
             eyre::Ok((id, sessions, init_duration))
         });


### PR DESCRIPTION
- **chore: unify error logs in repo**
- **fix(key-gen): include metrics-statsd feature for telemetry-batteries**
- **refactor(service): swapped client version predecence + added anchor logs for user errors**
- **chore(key-gen): removed unused TraceLayer::new_for_http**
- **refactor(client): use query param over header for client version reporting**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the WebSocket connection handshake (moving client version from a header to query params and adding `request_id`), which can break compatibility with servers/proxies expecting the old header behavior.
> 
> **Overview**
> **WebSocket session initialization now appends client metadata as URL query params.** The native client drops the `OPRF_PROTOCOL_VERSION_HEADER` upgrade header and, like WASM, connects using `?version=<pkg>&request_id=<uuid>`.
> 
> To support this, `WebSocketSession::new` and `init_sessions`/`init_session` now take a `request_id` and thread it through from `distributed_oprf` (and `oprf-dev-client`), with tests updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d24c435e7623f96f4d61e7cf05defdd0404a6c41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->