### PR TITLE
build(key-gen): set max tracing level to info for key-gen release builds

### DIFF
--- a/oprf-key-gen/Cargo.toml
+++ b/oprf-key-gen/Cargo.toml
@@ -70,7 +70,7 @@ tokio = { workspace = true, features = [
 ] }
 tokio-util = { workspace = true }
 tower-http = { workspace = true, features = ["set-header", "trace"] }
-tracing.workspace = true
+tracing = { workspace = true, features = ["release_max_level_info"] }
 zeroize = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/oprf-key-gen/src/postgres.rs
+++ b/oprf-key-gen/src/postgres.rs
@@ -60,14 +60,14 @@ impl PostgresDb {
     ///
     /// # Errors
     /// Returns an error if creating the database pool fails, or if running the migrations fails.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(level = "info", skip_all)]
     pub async fn init(db_config: &PostgresConfig) -> eyre::Result<Self> {
-        tracing::debug!("init PgPool with schema: {}", db_config.schema);
+        tracing::info!("init PgPool with schema: {}", db_config.schema);
         let pool = nodes_common::postgres::pg_pool_with_schema(db_config, CreateSchema::Yes)
             .await
             .context("while creating pool")?;
         // We create the pool eagerly, so running migrations here should not hit pool-acquire retries.
-        tracing::debug!("potentially running migrations..");
+        tracing::trace!("potentially running migrations..");
         sqlx::migrate!("./migrations")
             .run(&pool)
             .await
@@ -106,7 +106,7 @@ impl PostgresDb {
 #[async_trait]
 impl ChainCursorStorage for PostgresDb {
     /// Loads the `ChainEventCursor` for backfill.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(level = "info", skip_all)]
     #[allow(
         clippy::cast_sign_loss,
         reason = "We serialize the u64 as i64 due sqlx limitations. We deserialize it then to u64 which is ok"
@@ -131,7 +131,7 @@ impl ChainCursorStorage for PostgresDb {
             .await?)
     }
 
-    #[instrument(level = "debug", skip_all, fields(chain_cursor=%chain_cursor))]
+    #[instrument(level = "info", skip_all, fields(chain_cursor=%chain_cursor))]
     #[allow(
         clippy::cast_possible_wrap,
         reason = "We serialize the u64 as i64 because of sqlx limitations."
@@ -208,11 +208,11 @@ impl SecretManager for PostgresDb {
         };
         self.with_retry("store-wallet-address", store_address)
             .await?;
-        tracing::trace!("successfully stored address");
+        tracing::debug!("successfully stored address");
         Ok(())
     }
 
-    #[instrument(level = "debug", skip(self))]
+    #[instrument(level = "info", skip(self))]
     async fn get_share_by_epoch(
         &self,
         oprf_key_id: OprfKeyId,
@@ -223,7 +223,7 @@ impl SecretManager for PostgresDb {
         Ok(self.with_retry("get-share-by-epoch", get_share).await?)
     }
 
-    #[instrument(level = "debug", skip(self))]
+    #[instrument(level = "info", skip(self))]
     async fn delete_oprf_key_material(&self, oprf_key_id: OprfKeyId) -> secret_manager::Result<()> {
         tracing::trace!("trying to delete key-material..");
 
@@ -251,7 +251,7 @@ impl SecretManager for PostgresDb {
             .await?)
     }
 
-    #[instrument(level = "debug", skip_all, fields(oprf_key_id=%oprf_key_id))]
+    #[instrument(level = "info", skip_all, fields(oprf_key_id=%oprf_key_id))]
     async fn try_store_keygen_intermediates(
         &self,
         oprf_key_id: OprfKeyId,
@@ -283,7 +283,7 @@ impl SecretManager for PostgresDb {
             .await?)
     }
 
-    #[instrument(level = "debug", skip_all, fields(oprf_key_id=%oprf_key_id))]
+    #[instrument(level = "info", skip_all, fields(oprf_key_id=%oprf_key_id))]
     async fn fetch_keygen_intermediates(
         &self,
         oprf_key_id: OprfKeyId,
@@ -315,18 +315,18 @@ impl SecretManager for PostgresDb {
             .ok_or_else(|| PostgresDbError::MissingIntermediates(oprf_key_id, pending_epoch))?)
     }
 
-    #[instrument(level = "debug", skip(self))]
+    #[instrument(level = "info", skip(self))]
     async fn abort_keygen(&self, oprf_key_id: OprfKeyId) -> secret_manager::Result<()> {
         tracing::trace!("trying to abort key-gen...");
 
         let abort_keygen = || Self::delete_intermediates_inner(oprf_key_id, &self.pool);
         let rows_deleted = self.with_retry("abort-keygen", abort_keygen).await?;
 
-        tracing::trace!("aborted {rows_deleted} key-gens from postgres");
+        tracing::debug!("aborted {rows_deleted} key-gens from postgres");
         Ok(())
     }
 
-    #[instrument(level = "debug", skip_all, fields(oprf_key_id=%oprf_key_id))]
+    #[instrument(level = "info", skip_all, fields(oprf_key_id=%oprf_key_id))]
     async fn store_pending_dlog_share(
         &self,
         oprf_key_id: OprfKeyId,
@@ -356,7 +356,7 @@ impl SecretManager for PostgresDb {
             .await?;
 
         if rows_affected == 1 {
-            tracing::trace!("successfully stored pending dlog share");
+            tracing::debug!("successfully stored pending dlog share");
             Ok(())
         } else {
             tracing::warn!("cannot store pending share because no matching intermediates exist");
@@ -367,7 +367,7 @@ impl SecretManager for PostgresDb {
         }
     }
 
-    #[instrument(level = "debug", skip_all, fields(oprf_key_id=%oprf_key_id, epoch=%epoch))]
+    #[instrument(level = "info", skip_all, fields(oprf_key_id=%oprf_key_id, epoch=%epoch))]
     async fn confirm_dlog_share(
         &self,
         oprf_key_id: OprfKeyId,
@@ -392,7 +392,7 @@ impl SecretManager for PostgresDb {
                 .await?
                 .is_some()
             {
-                tracing::debug!("already have this share stored - delete intermediates");
+                tracing::warn!("already have this share stored - delete intermediates");
                 Self::delete_intermediates_inner(oprf_key_id, &mut *conn).await?;
                 tx.commit().await?;
                 return Ok(());

--- a/oprf-key-gen/src/services/key_event_watcher.rs
+++ b/oprf-key-gen/src/services/key_event_watcher.rs
@@ -160,15 +160,14 @@ pub(crate) async fn key_event_watcher_task(args: KeyEventWatcherTaskConfig) -> e
         cancellation_token,
     } = args;
 
-    tracing::info!("loading chain-cursor");
     let chain_cursor = chain_cursor_service
         .load_chain_cursor()
         .await
         .context("while loading chain cursor")?;
+    tracing::info!("loaded chain cursor at: {chain_cursor}");
 
     let contract = OprfKeyRegistry::new(contract_address, http_rpc_provider.inner());
 
-    tracing::info!("chain cursor at: {chain_cursor}");
     let event_signatures = vec![
         OprfKeyRegistry::SecretGenRound1::SIGNATURE_HASH,
         OprfKeyRegistry::SecretGenRound2::SIGNATURE_HASH,

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -16,6 +16,14 @@ COMPOSE_FILE="${COMPOSE_FILE:-./oprf-service/examples/deploy/docker-compose.yml}
 LOG_TAG="${LOG_TAG:-[oprf]}"
 LOG_DIR="${LOG_DIR:-logs}"
 
+if [[ -n "${DEBUG_KEYGEN:-}" ]]; then
+    KEYGEN_CARGO_BUILD_ARGS=()
+    KEYGEN_BUILD_TARGET_DIR="debug"
+else
+    KEYGEN_CARGO_BUILD_ARGS=(--release)
+    KEYGEN_BUILD_TARGET_DIR="release"
+fi
+
 node_private_keys=(
     "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356"
     "0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97"
@@ -335,7 +343,7 @@ start_keygen_node() {
     TACEO_OPRF_KEY_GEN__POSTGRES__CONNECTION_STRING="$POSTGRES_URL" \
     TACEO_OPRF_KEY_GEN__POSTGRES__SCHEMA="$schema" \
     "${dd_env[@]+"${dd_env[@]}"}" \
-    ./target/release/taceo-oprf-key-gen >>"$LOG_DIR/key-gen${i}.log" 2>&1 &
+    ./target/${KEYGEN_BUILD_TARGET_DIR}/taceo-oprf-key-gen >>"$LOG_DIR/key-gen${i}.log" 2>&1 &
     keygen_pids[$i]="$!"
     log "started key-gen${i} with PID ${keygen_pids[$i]}"
 }
@@ -411,7 +419,7 @@ docker_psql() {
 
 build_keygen_binary() {
     log "Building taceo-oprf-key-gen"
-    cargo build --release --bin taceo-oprf-key-gen >"$LOG_DIR/build-keygen.log" 2>&1
+    cargo build "${KEYGEN_CARGO_BUILD_ARGS[@]+"${KEYGEN_CARGO_BUILD_ARGS[@]}"}" --bin taceo-oprf-key-gen >"$LOG_DIR/build-keygen.log" 2>&1
 }
 
 prepare_keygen_db() {

--- a/scripts/run-setup.sh
+++ b/scripts/run-setup.sh
@@ -16,7 +16,9 @@ run_deploy() {
     deploy_key_registry
 
     cargo clean --workspace
-    cargo build --workspace --release --examples --bins
+    cargo build --release --example taceo-oprf-service-example
+    cargo build --release --example dev-client-example
+    build_keygen_binary
 
     log "starting keygen"
     # need to start key-gen before nodes because they run DB migrations


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to logging verbosity/levels and local dev scripts; no protocol, DB schema, or business logic changes.
> 
> **Overview**
> **Reduces key-gen log verbosity in release builds** by enabling `tracing`’s `release_max_level_info` feature and bumping several `#[instrument]` spans from `debug` to `info` (with some messages shifted to `trace`/`debug`/`warn` for better signal).
> 
> Improves operator/dev ergonomics: the key event watcher now logs the loaded chain cursor once, and the `scripts/` tooling can build/run key-gen in either `debug` or `release` via `DEBUG_KEYGEN`, plus `run-setup.sh` builds only the needed examples/binary instead of the whole workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3222163c0286a43e2c55b648001290ab95cf864b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->