### PR TITLE
fix(key-gen): restart key-gen on ws-connect errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
 dependencies = [
  "filetime",
  "futures-core",
@@ -2689,7 +2689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5167,7 +5167,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5226,7 +5226,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6422,7 +6422,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/oprf-key-gen/src/lib.rs
+++ b/oprf-key-gen/src/lib.rs
@@ -202,8 +202,10 @@ pub async fn start(
             .build()
             .context("while init blockchain connection")?;
 
+    // We set retries to 0 so that on ws-connection errors we restart immediately and start backfill
+    let ws_connect = WsConnect::new(config.ws_rpc_url.clone()).with_max_retries(0);
     let ws_rpc_provider = ProviderBuilder::new()
-        .connect_ws(WsConnect::new(config.ws_rpc_url.clone()))
+        .connect_ws(ws_connect)
         .await
         .context("while connecting ws provider")?
         .erased();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small operational change to WS retry behavior; recovery path relies on existing cursor backfill and does not alter key-gen or on-chain logic.
> 
> **Overview**
> Configures the OPRF key-gen WebSocket RPC client to use **zero connection retries** via `WsConnect::with_max_retries(0)`, so transient WS failures surface quickly instead of hanging in the alloy client’s retry loop.
> 
> When the subscription drops, the **`key_event_watcher`** task can exit and the process can restart; startup already reloads the persisted chain cursor and **backfills** missed `OprfKeyRegistry` events from the last processed position.
> 
> `Cargo.lock` only reflects routine dependency bumps (e.g. `astral-tokio-tar`, `windows-sys` pins used by `errno` / `rustix` / related crates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1e8c7f12ed721e82ea07d07758e596994d0bde9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->