### PR TITLE
chore: set publish true again for umbrella + service

### DIFF
--- a/oprf-service/Cargo.toml
+++ b/oprf-service/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["cryptography", "mpc", "oprf"]
-publish = false
+publish = true
 
 [dependencies]
 alloy = { workspace = true, features = [

--- a/oprf/Cargo.toml
+++ b/oprf/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["cryptography", "mpc", "oprf"]
-publish = false
+publish = true
 
 [dependencies]
 oprf-client = { package = "taceo-oprf-client", path = "../oprf-client", version = "0.10.0", optional = true }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Manifest-only change affecting publish flags, with no application logic or security surface impact.
> 
> **Overview**
> Re-enables **crates.io publishing** for the umbrella crate `taceo-oprf` and the node service crate `taceo-oprf-service` by setting `publish = true` in each package’s `Cargo.toml` (overriding the workspace default of `publish = false`).
> 
> No runtime, API, or dependency changes—only release metadata so these two packages can be published again alongside the other already-publishable OPRF crates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cc57d4a0724b10116b1fc9bd87f4978479c8786. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->