### PR TITLE
chore(key-gen): not an error log anymore if WS connection closes

### DIFF
--- a/oprf-client/Cargo.toml
+++ b/oprf-client/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["cryptography", "mpc", "oprf"]
-publish = false
+publish = true
 
 [dependencies]
 ark-babyjubjub = { workspace = true }

--- a/oprf-core/Cargo.toml
+++ b/oprf-core/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["cryptography", "mpc", "oprf"]
-publish = false
+publish = true
 
 [[bench]]
 harness = false

--- a/oprf-dev-client/Cargo.toml
+++ b/oprf-dev-client/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["client", "development", "mpc", "oprf"]
-publish = false
+publish = true
 
 [dependencies]
 alloy = { workspace = true, features = [

--- a/oprf-key-gen/src/services/key_event_watcher.rs
+++ b/oprf-key-gen/src/services/key_event_watcher.rs
@@ -203,8 +203,11 @@ pub(crate) async fn key_event_watcher_task(args: KeyEventWatcherTaskConfig) -> e
     loop {
         tokio::select! {
             log = event_stream.next() => {
-                let log = log.ok_or_else(||eyre::eyre!("logs subscribe stream was closed"))?.context("while fetching event from event_stream")?;
-
+                let Some(log) = log else {
+                    tracing::info!("event-stream closed - initiate shutdown");
+                    return Ok(());
+                };
+                let log = log.context("while fetching event from event_stream")?;
                 key_gen_event(log, &event_handler, &chain_cursor_service).await?;
             }
             () = cancellation_token.cancelled() => {

--- a/oprf-types/Cargo.toml
+++ b/oprf-types/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["cryptography", "mpc", "oprf"]
-publish = false
+publish = true
 
 [dependencies]
 alloy = { workspace = true, features = ["contract"], optional = true }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Watcher change only alters shutdown semantics on stream end; publish flags are release configuration with no runtime behavior change in services.
> 
> **Overview**
> **Key-gen watcher:** When the blockchain event subscription stream ends (`None` from `next()`), the watcher now logs at info and exits with `Ok(())` instead of failing with *"logs subscribe stream was closed"*. That matches an expected WebSocket close during shutdown rather than a fault.
> 
> **Crates:** `publish` is set to `true` in `oprf-client`, `oprf-core`, `oprf-dev-client`, and `oprf-types` so those workspace crates can be published to crates.io.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f8f6320afc7ca159ccf983b6e8926c863381bb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->