### PR TITLE
build(deps): bump nodes-common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6177,9 +6177,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-nodes-common"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb26c280819a49d38da5e896faad160b7341ae1614654d0dd0859395cfae24c"
+checksum = "f12f985493849cff13ca33db08f95429565387da7892ab70bcb8571a9d3a66f5"
 dependencies = [
  "alloy",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,11 @@ ark-bn254 = { version = "0.5" }
 ark-ec = "0.5"
 ark-ff = "0.5"
 ark-groth16 = "0.5"
-ark-serde-compat = { package = "taceo-ark-serde-compat", version = "0.5", default-features = false }
+ark-serde-compat = {
+  package = "taceo-ark-serde-compat",
+  version = "0.5",
+  default-features = false
+}
 ark-serialize = "0.5"
 async-trait = "0.1"
 axum = "0.8"
@@ -36,14 +40,26 @@ axum-test = "18"
 backon = { version = "1.6", default-features = false }
 blake3 = "1"
 ciborium = "0.2"
-circom-types = { package = "taceo-circom-types", version = "0.2.2", default-features = false }
+circom-types = {
+  package = "taceo-circom-types",
+  version = "0.2.2",
+  default-features = false
+}
 clap = "4"
 config = { version = "0.15", default-features = false }
 criterion = "0.8"
 eyre = { version = "0.6" }
 futures = "0.3"
-groth16-material = { package = "taceo-groth16-material", version = "0.3", default-features = false }
-groth16-sol = { package = "taceo-groth16-sol", version = "0.3", default-features = false }
+groth16-material = {
+  package = "taceo-groth16-material",
+  version = "0.3",
+  default-features = false
+}
+groth16-sol = {
+  package = "taceo-groth16-sol",
+  version = "0.3",
+  default-features = false
+}
 http = "1"
 humantime = "2"
 humantime-serde = "1.1.1"
@@ -51,16 +67,28 @@ itertools = "0.14"
 k256 = "0.13"
 metrics = "0.24"
 moka = { version = "0.12", features = ["future"] }
-nodes-common = { package = "taceo-nodes-common", version = "0.7", default-features = false }
+nodes-common = {
+  package = "taceo-nodes-common",
+  version = "0.7.1",
+  default-features = false
+}
 num-bigint = "0.4"
 parking_lot = "0.12"
-poseidon2 = { package = "taceo-poseidon2", version = "0.2", default-features = false }
+poseidon2 = {
+  package = "taceo-poseidon2",
+  version = "0.2",
+  default-features = false
+}
 rand = { version = "0.8" }
 rand_chacha = { version = "0.3" }
-reqwest = { version = "0.12", default-features = false, features = [
-  "json",
-  "rustls-tls",
-] }
+reqwest = {
+  version = "0.12",
+  default-features = false,
+  features = [
+    "json",
+    "rustls-tls",
+  ]
+}
 ruint = { version = "1", features = ["serde"] }
 rustls = "0.23"
 secrecy = "0.10"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Patch-level external dependency bump with no application source changes; typical supply-chain review applies to the upstream crate release.
> 
> **Overview**
> Bumps the shared **`taceo-nodes-common`** workspace dependency from **0.7.0** to **0.7.1** and refreshes **`Cargo.lock`** (version + checksum). Several **`[workspace.dependencies]`** entries in **`Cargo.toml`** are reformatted to multiline tables; dependency versions for other crates are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2ebdaca826a2c4a82f4a248202f4a8684bc9047. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->