### PR TITLE
themis/ws restart for real

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6177,9 +6177,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-nodes-common"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12f985493849cff13ca33db08f95429565387da7892ab70bcb8571a9d3a66f5"
+checksum = "3dea5505990bca89790cece6b15dc7b317963d9725a722186a8756cd568b50b5"
 dependencies = [
  "alloy",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ itertools = "0.14"
 k256 = "0.13"
 metrics = "0.24"
 moka = { version = "0.12", features = ["future"] }
-nodes-common = { package = "taceo-nodes-common", version = "0.7.1", default-features = false }
+nodes-common = { package = "taceo-nodes-common", version = "0.7.2", default-features = false }
 num-bigint = "0.4"
 parking_lot = "0.12"
 poseidon2 = { package = "taceo-poseidon2", version = "0.2", default-features = false }

--- a/oprf-key-gen/src/lib.rs
+++ b/oprf-key-gen/src/lib.rs
@@ -40,7 +40,9 @@ use alloy::{
     network::EthereumWallet,
     primitives::Address,
     providers::{DynProvider, Provider as _, ProviderBuilder, WsConnect},
+    pubsub::{ConnectionHandle, PubSubConnect},
     signers::local::PrivateKeySigner,
+    transports::{TransportErrorKind, TransportResult},
 };
 use eyre::Context as _;
 use groth16_material::circom::CircomGroth16MaterialBuilder;
@@ -84,6 +86,42 @@ impl KeyGenTasks {
         self.i_am_alive_task.await?;
         self.cursor_checkpoint_task.await?;
         Ok(())
+    }
+}
+
+// Wraps WsConnect but refuses all reconnect attempts.
+//
+// When the WS connection drops, alloy's pubsub service calls `try_reconnect()` before
+// propagating the error. Returning a NonRetryable error here causes the service to shut
+// down immediately, which closes the subscription broadcast channel. The key-event-watcher
+// then sees `RecvError::Closed`, its event stream yields `None`, and the task returns
+// `Ok(())`. The cancellation-token drop-guard fires, the whole process exits cleanly, and
+// the supervisor (k8s) restarts it. On restart, `EventStreamBuilder` backfills missed events
+// from the persisted `ChainCursor`.
+//
+// Why not `WsConnect::with_max_retries(0)`?
+// alloy-pubsub v2 always makes ONE reconnect attempt before checking the counter, so
+// `max_retries = 0` still silently reconnects on transient errors and keeps the subscription
+// alive — missing the gap events entirely.
+struct NoReconnect(WsConnect);
+
+impl PubSubConnect for NoReconnect {
+    fn is_local(&self) -> bool {
+        self.0.is_local()
+    }
+
+    fn connect(
+        &self,
+    ) -> impl core::future::Future<Output = TransportResult<ConnectionHandle>> + Send {
+        self.0.connect()
+    }
+
+    fn try_reconnect(
+        &self,
+    ) -> impl core::future::Future<Output = TransportResult<ConnectionHandle>> + Send {
+        core::future::ready(Err(TransportErrorKind::non_retryable_str(
+            "WS connection lost - refusing to reconnect so the service restarts and backfills",
+        )))
     }
 }
 
@@ -202,10 +240,11 @@ pub async fn start(
             .build()
             .context("while init blockchain connection")?;
 
-    // We set retries to 0 so that on ws-connection errors we restart immediately and start backfill
-    let ws_connect = WsConnect::new(config.ws_rpc_url.clone()).with_max_retries(0);
+    // NoReconnect refuses reconnects so that on WS connection errors the pubsub service shuts
+    // down, the event stream ends, and the supervisor can restart the process to backfill
+    // missed events from the persisted ChainCursor. See `NoReconnect` for the full rationale.
     let ws_rpc_provider = ProviderBuilder::new()
-        .connect_ws(ws_connect)
+        .connect_pubsub_with(NoReconnect(WsConnect::new(config.ws_rpc_url.clone())))
         .await
         .context("while connecting ws provider")?
         .erased();


### PR DESCRIPTION
- **fix(key-gen): add a custom wrapper to prevent reconnects on ws-errors**
- **build(deps): bump nodes-common**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how key-gen handles WS outages and depends on supervisor restart plus persisted cursor backfill; incorrect behavior could miss or mishandle registry events until detected.
> 
> **Overview**
> **OPRF key-gen** no longer relies on `WsConnect::with_max_retries(0)` for WebSocket pubsub. That setting still allowed **one** alloy-pubsub reconnect, which could keep the subscription alive and **skip on-chain events** during a gap.
> 
> The PR adds a **`NoReconnect`** `PubSubConnect` wrapper around `WsConnect` that fails `try_reconnect` with a non-retryable error, wires it via **`connect_pubsub_with`**, and bumps **`taceo-nodes-common`** to **0.7.2** in workspace `Cargo.toml` / lockfile.
> 
> On disconnect, pubsub shuts down, the key event watcher’s stream ends, the process exits so the supervisor can restart, and startup **backfills** from the persisted **`ChainCursor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9dfb7740b0bcccebd003b207c0085a4328360ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->