### PR TITLE
fix(key-gen): redacts ws urls

### DIFF
--- a/oprf-key-gen/src/config.rs
+++ b/oprf-key-gen/src/config.rs
@@ -36,7 +36,6 @@ use nodes_common::{
     Environment,
     web3::{self},
 };
-use reqwest::Url;
 use secrecy::SecretString;
 use serde::Deserialize;
 
@@ -70,7 +69,7 @@ pub struct OprfKeyGenServiceConfig {
     pub rpc_provider_config: web3::HttpRpcProviderConfig,
 
     /// The websocket RPC url used for `eth_subscribe`.
-    pub ws_rpc_url: Url,
+    pub ws_rpc_url: SecretString,
 
     /// Max time we wait for a submitted transaction receipt to reach the required
     /// number of confirmations before treating it as failed.
@@ -175,7 +174,7 @@ pub struct OprfKeyGenServiceConfigMandatoryValues {
     pub rpc_provider_config: HttpRpcProviderConfig,
 
     /// The websocket RPC url used for `eth_subscribe`.
-    pub ws_rpc_url: Url,
+    pub ws_rpc_url: SecretString,
 }
 
 impl OprfKeyGenServiceConfig {

--- a/oprf-key-gen/src/lib.rs
+++ b/oprf-key-gen/src/lib.rs
@@ -244,7 +244,9 @@ pub async fn start(
     // down, the event stream ends, and the supervisor can restart the process to backfill
     // missed events from the persisted ChainCursor. See `NoReconnect` for the full rationale.
     let ws_rpc_provider = ProviderBuilder::new()
-        .connect_pubsub_with(NoReconnect(WsConnect::new(config.ws_rpc_url.clone())))
+        .connect_pubsub_with(NoReconnect(WsConnect::new(
+            config.ws_rpc_url.expose_secret(),
+        )))
         .await
         .context("while connecting ws provider")?
         .erased();

--- a/oprf-key-gen/src/tests/mod.rs
+++ b/oprf-key-gen/src/tests/mod.rs
@@ -145,7 +145,7 @@ impl TestKeyGen {
                     anvil.endpoint_url()
                 ])
                 .expect("Can build provider"),
-                ws_rpc_url: anvil.ws_endpoint_url(),
+                ws_rpc_url: anvil.ws_endpoint().into(),
             });
 
         config.confirmations_for_transaction = 0;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Narrow config/typing change for credential handling; connection behavior is unchanged aside from explicit secret exposure at connect time.
> 
> **Overview**
> Treats the WebSocket RPC URL as a secret in key-gen configuration, matching how `wallet_private_key` is already handled.
> 
> `ws_rpc_url` on `OprfKeyGenServiceConfig` and `OprfKeyGenServiceConfigMandatoryValues` changes from `reqwest::Url` to `secrecy::SecretString`. Startup passes `config.ws_rpc_url.expose_secret()` into `WsConnect` instead of cloning a URL type. Tests build the field via `anvil.ws_endpoint().into()` rather than `ws_endpoint_url()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d037b1cdf3222736df59864d116eae111c2696b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->