### PR TITLE
themis/add cors layer for info routes

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -74,6 +74,7 @@ ignore = [
     { id = "RUSTSEC-2024-0388", reason = "derivative crate is unmaintained, but arkworks is still using it." },
     { id = "RUSTSEC-2025-0055", reason = "ark-relations is using v0.2 of tracing-subscriber still, we do not use this functionality so it is not exploitable." },
     { id = "RUSTSEC-2023-0089", reason = "need to wait until circom-witness-rs updates deps" },
+    { id = "RUSTSEC-2026-0173", reason = "need to wait until alloy removes. Not relevant as only error reporting" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/deny.toml
+++ b/deny.toml
@@ -73,8 +73,6 @@ ignore = [
     { id = "RUSTSEC-2024-0436", reason = "Paste crate is unmaintained, but arkworks is still using it." },
     { id = "RUSTSEC-2024-0388", reason = "derivative crate is unmaintained, but arkworks is still using it." },
     { id = "RUSTSEC-2025-0055", reason = "ark-relations is using v0.2 of tracing-subscriber still, we do not use this functionality so it is not exploitable." },
-    { id = "RUSTSEC-2026-0066", reason = "can't be upgraded with current version of testcontainers" },
-    { id = "RUSTSEC-2026-0097", reason = "can't upgrade due to transative deps. Doesn't affect us because we don't enable the log feature" },
     { id = "RUSTSEC-2023-0089", reason = "need to wait until circom-witness-rs updates deps" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.

--- a/justfile
+++ b/justfile
@@ -44,7 +44,11 @@ backfill-monkey-test-dd:
     @DATADOG_ENABLE=1 bash scripts/run-backfill-monkey-test.sh
 
 [group('ci')]
-check-pr: lint all-tests
+check-pr: lint cargo-deny all-tests
+
+[group('ci')]
+cargo-deny:
+    cargo deny check
 
 [group('ci')]
 lint:

--- a/oprf-service/Cargo.toml
+++ b/oprf-service/Cargo.toml
@@ -63,7 +63,7 @@ tokio = { workspace = true, features = [
   "tokio-macros",
 ] }
 tokio-util = { workspace = true }
-tower-http = { workspace = true, features = ["set-header", "timeout", "trace"] }
+tower-http = { workspace = true, features = ["set-header", "timeout", "trace", "cors"] }
 tracing.workspace = true
 tungstenite = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }

--- a/oprf-service/src/lib.rs
+++ b/oprf-service/src/lib.rs
@@ -56,11 +56,12 @@ use crate::{config::OprfNodeServiceConfig, services::secret_manager::SecretManag
 use axum::Router;
 use axum::extract::MatchedPath;
 use eyre::Context;
-use http::{HeaderMap, HeaderName, StatusCode};
+use http::{HeaderMap, HeaderName, Method, StatusCode};
 use oprf_types::api::OprfRequestAuthService;
 use oprf_types::crypto::PartyId;
 use serde::Deserialize;
 use tokio_util::sync::CancellationToken;
+use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::{MakeSpan, TraceLayer};
 
@@ -77,6 +78,16 @@ pub use semver::VersionReq;
 pub use services::secret_manager;
 
 /// [`OprfServiceBuilder`] to initialize a `OprfService` with multiple [`OprfRequestAuthService`]s.
+///
+/// Beyond the OPRF modules added via [`OprfServiceBuilder::module`], the builder always exposes a
+/// set of read-only info routes at the root (not under `/api`):
+/// - `GET /health`
+/// - `GET /version`
+/// - `GET /wallet`
+/// - `GET /oprf_pub/{id}`
+///
+/// CORS for those info routes is **opt-in**: call [`OprfServiceBuilder::cors_for_info`] before
+/// [`OprfServiceBuilder::build`] to allow cross-origin `GET` requests from any origin.
 pub struct OprfServiceBuilder {
     config: OprfNodeServiceConfig,
     info_routes: Router,
@@ -162,6 +173,21 @@ impl OprfServiceBuilder {
             threshold: node_information.threshold(),
             config,
         })
+    }
+
+    /// Adds a CORS layer for the `info` routes.
+    ///
+    /// This CORS layer uses the default values from [`CorsLayer`](https://docs.rs/tower-http/latest/tower_http/cors/struct.CorsLayer.html) and
+    /// explicitly sets allow-methods to `GET` and a wild-card for allowed origins.
+    ///
+    /// The layer is applied only to the info routes (served at the root, not under `/api`).
+    #[must_use]
+    pub fn cors_for_info(mut self) -> Self {
+        let cors = CorsLayer::new()
+            .allow_methods([Method::GET])
+            .allow_origin(AllowOrigin::any());
+        self.info_routes = self.info_routes.layer(cors);
+        self
     }
 
     /// Add a new `OprfRequestAuthService` module with the given `path`.


### PR DESCRIPTION
- **chore: remove RUSTSEC advisories that are no longer needed**
- **feat(node): add CORS layer for health and info routes**
- **ci: ignore RUSTSEC-2026-0173**
- **ci: add cargo deny check to check-pr just command**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wildcard CORS on public info endpoints is intentional but broad if enabled in production; otherwise changes are CI and dependency advisory housekeeping.
> 
> **Overview**
> Adds **opt-in CORS** on `OprfServiceBuilder` via `cors_for_info()`: a `tower-http` `CorsLayer` limited to **GET** and **any origin**, applied only to root info routes (`/health`, `/version`, `/wallet`, `/oprf_pub/{id}`)—not `/api` OPRF modules. `tower-http` gains the **`cors`** feature in `oprf-service`.
> 
> **CI / supply chain:** `just check-pr` now runs **`cargo deny check`**; `deny.toml` drops two stale advisory ignores and adds **`RUSTSEC-2026-0173`** (alloy transitive, deemed non-exploitable for this repo).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad418c50fc3d8120618b6974eabd04d57c5f98b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->