### PR TITLE
refactor(node): update metrics for OPRF key cache

### DIFF
--- a/oprf-service/src/metrics.rs
+++ b/oprf-service/src/metrics.rs
@@ -184,8 +184,12 @@ pub(crate) mod sessions {
 
 pub(crate) mod secrets {
 
-    /// Metrics key for registered `DLogSecrets`.
+    /// Metrics key for stored `DLogSecrets` in cache.
     const METRICS_ID_NODE_OPRF_SECRETS: &str = "taceo.oprf.node.secrets";
+    /// Number of misses in the `DLogSecrets` cache.
+    const METRICS_ID_NODE_OPRF_SECRETS_MISSES: &str = "taceo.oprf.node.secrets.misses";
+    /// Number of hits in the `DLogSecrets` cache.
+    const METRICS_ID_NODE_OPRF_SECRETS_HITS: &str = "taceo.oprf.node.secrets.hits";
 
     pub(super) fn describe_metrics() {
         metrics::describe_gauge!(
@@ -193,17 +197,29 @@ pub(crate) mod secrets {
             metrics::Unit::Count,
             "Number of secrets stored"
         );
+
+        metrics::describe_counter!(
+            METRICS_ID_NODE_OPRF_SECRETS_MISSES,
+            metrics::Unit::Count,
+            "Number of misses in the oprf-secrets cache."
+        );
+
+        metrics::describe_counter!(
+            METRICS_ID_NODE_OPRF_SECRETS_HITS,
+            metrics::Unit::Count,
+            "Number of hits in the oprf-secrets cache."
+        );
     }
 
-    pub(crate) fn set(x: usize) {
+    pub(crate) fn set(x: u64) {
         ::metrics::gauge!(METRICS_ID_NODE_OPRF_SECRETS).set(x as f64);
     }
 
-    pub(crate) fn inc() {
-        ::metrics::gauge!(METRICS_ID_NODE_OPRF_SECRETS).increment(1);
+    pub(crate) fn hit() {
+        metrics::counter!(METRICS_ID_NODE_OPRF_SECRETS_HITS).increment(1);
     }
 
-    pub(crate) fn dec() {
-        ::metrics::gauge!(METRICS_ID_NODE_OPRF_SECRETS).decrement(1);
+    pub(crate) fn miss() {
+        metrics::counter!(METRICS_ID_NODE_OPRF_SECRETS_MISSES).increment(1);
     }
 }

--- a/oprf-service/src/services/oprf_key_material_store.rs
+++ b/oprf-service/src/services/oprf_key_material_store.rs
@@ -60,15 +60,12 @@ impl OprfKeyMaterialStore {
         time_to_live: Duration,
         time_to_idle: Duration,
     ) -> Self {
-        metrics::secrets::set(0);
-
         let store = Cache::builder()
             .max_capacity(max_capacity)
             .time_to_live(time_to_live)
             .time_to_idle(time_to_idle)
             .eviction_listener(move |k, _, cause| {
-                tracing::debug!("removing OprfKeyId {k} because: {cause:?}");
-                metrics::secrets::dec();
+                tracing::trace!("removing OprfKeyId {k} because: {cause:?}");
             })
             .build();
 
@@ -153,7 +150,11 @@ impl OprfKeyMaterialStore {
             .or_try_insert_with(self.secret_manager.get_oprf_key_material(oprf_key_id))
             .await?;
         if key_material.is_fresh() {
-            metrics::secrets::inc();
+            self.store.run_pending_tasks().await;
+            metrics::secrets::set(self.store.entry_count());
+            metrics::secrets::miss();
+        } else {
+            metrics::secrets::hit();
         }
         Ok(key_material.into_value())
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Observability-only changes to metrics; no change to OPRF key loading or caching behavior beyond calling `run_pending_tasks` before updating the gauge on misses.
> 
> **Overview**
> **OPRF key cache observability** now tracks **cache hits/misses** and sets the **secrets gauge** from the cache’s real `entry_count` on misses, instead of manually incrementing/decrementing on insert/eviction.
> 
> `metrics::secrets` drops `inc`/`dec`, adds `hit()`/`miss()` counters (`taceo.oprf.node.secrets.hits` / `.misses`), and `set` takes `u64`. `OprfKeyMaterialStore` no longer resets or bumps the gauge in `new` or the eviction listener; on a fresh `or_try_insert_with` it runs pending eviction tasks, updates the gauge, and records a miss—otherwise it records a hit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a38eac450be4fb14ed34a175ce88a87b2b9d7179. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->