### PR TITLE
chore(deps): bump taceo-nodes-common to 0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6177,9 +6177,9 @@ dependencies = [
 
 [[package]]
 name = "taceo-nodes-common"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dea5505990bca89790cece6b15dc7b317963d9725a722186a8756cd568b50b5"
+checksum = "f588f7f9a52606e62ec32f75d8a01f8e43b85eca0e1744303503a9dbd21e4969"
 dependencies = [
  "alloy",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ itertools = "0.14"
 k256 = "0.13"
 metrics = "0.24"
 moka = { version = "0.12", features = ["future"] }
-nodes-common = { package = "taceo-nodes-common", version = "0.7.2", default-features = false }
+nodes-common = { package = "taceo-nodes-common", version = "0.7.3", default-features = false }
 num-bigint = "0.4"
 parking_lot = "0.12"
 poseidon2 = { package = "taceo-poseidon2", version = "0.2", default-features = false }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only dependency bump with no local code changes; risk depends on upstream 0.7.3 changes in the external crate.
> 
> **Overview**
> Bumps the workspace dependency **`taceo-nodes-common`** from **0.7.2** to **0.7.3** in `Cargo.toml` and refreshes the corresponding **`Cargo.lock`** entry (version and checksum). No application source changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfc91407c796b30ac1e90d90a79589009b76e472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->