### PR TITLE
chore(node): session timeout put to trace

### DIFF
--- a/oprf-service/src/api/oprf.rs
+++ b/oprf-service/src/api/oprf.rs
@@ -148,7 +148,7 @@ async fn oprf_ws_handler<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
                         }
                         Ok(Err(err)) => err.into_close_frame(),
                         Err(_) => {
-                            tracing::warn!(user_error=true, "session ran into timeout");
+                            tracing::trace!("session ran into timeout");
                             metrics::request::inc_client_timeout();
                             Some(CloseFrame {
                                 code: oprf_error_codes::TIMEOUT,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Logging-only change; timeout metrics and WebSocket close behavior are unchanged.
> 
> **Overview**
> When an OPRF WebSocket session exceeds **`max_connection_lifetime`**, the log for that timeout is **downgraded from `warn` with `user_error=true` to `trace`**, with the same message text. **Timeout handling is unchanged**: `inc_client_timeout()` still runs and the connection still closes with the TIMEOUT close frame.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac83380c5901d63b27942c93c7176d61e4868149. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->