### PR TITLE
chore: prepare test-utils release

### DIFF
--- a/oprf-service/Cargo.toml
+++ b/oprf-service/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["cryptography", "mpc", "oprf"]
-publish = true
+publish = false
 
 [package.metadata.cargo-machete]
 ignored = ["humantime-serde"]

--- a/oprf-test-utils/Cargo.toml
+++ b/oprf-test-utils/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["oprf", "tests"]
-publish = false
+publish = true
 
 [[bin]]
 name = "generate-test-transcript"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Manifest-only `publish` flag changes with no runtime or API code modifications.
> 
> **Overview**
> Prepares a **test-utils** release by adjusting which workspace crates are eligible for `cargo publish`.
> 
> **`taceo-oprf-service`** (`publish` **true → false**): the main OPRF node service crate will no longer be published to crates.io.
> 
> **`taceo-oprf-test-utils`** (`publish` **false → true**): the testing utilities crate is marked publishable for the upcoming release (still at version `0.13.0` in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eec8786b7e64dc7f5927d0a558f7949ee3f3b30b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->