### PR TITLE
chore: set service publish to true again

### DIFF
--- a/oprf-service/Cargo.toml
+++ b/oprf-service/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["cryptography", "mpc", "oprf"]
-publish = false
+publish = true
 
 [package.metadata.cargo-machete]
 ignored = ["humantime-serde"]

--- a/oprf-test-utils/Cargo.toml
+++ b/oprf-test-utils/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 repository.workspace = true
 license.workspace = true
 keywords = ["oprf", "tests"]
-publish = true
+publish = false
 
 [[bin]]
 name = "generate-test-transcript"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only Cargo.toml changes with no runtime or API impact.
> 
> **Overview**
> **Publishing flags** are flipped for two workspace crates: `taceo-oprf-service` is set to **`publish = true`** again so the main node service can be published to crates.io, and **`taceo-oprf-test-utils`** is set to **`publish = false`** so internal test helpers stay workspace-only (aligned with other non-published crates like `oprf-key-gen` and the workspace default).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e6d4847e1d5455bff111c9e2b06e122f25771f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->