### PR TITLE
refactor(node)!: builder for oprf-service not fallible anymore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6200,7 +6200,7 @@ dependencies = [
 
 [[package]]
 name = "taceo-oprf"
-version = "0.15.3"
+version = "0.16.0"
 dependencies = [
  "taceo-oprf-client",
  "taceo-oprf-core",

--- a/oprf-service/examples/taceo-oprf-service-example.rs
+++ b/oprf-service/examples/taceo-oprf-service-example.rs
@@ -119,7 +119,7 @@ pub async fn start_service(
         StartedServices::default(),
         node_information,
         cancellation_token.clone(),
-    )?
+    )
     .module("/example", Arc::new(ExampleOprfRequestAuthenticator))
     .build();
 

--- a/oprf-service/src/lib.rs
+++ b/oprf-service/src/lib.rs
@@ -105,16 +105,13 @@ impl OprfServiceBuilder {
     /// - Loads node information (party ID, address) from the secret manager.
     /// - Initializes the cache-backed OPRF key material store.
     /// - Initializes the Axum router exposing the node API.
-    ///
-    /// # Errors
-    /// Returns an error if loading node information from the secret manager fails.
     pub fn init(
         config: OprfNodeServiceConfig,
         secret_manager: SecretManagerService,
         started_services: StartedServices,
         node_information: NodeInformation,
         cancellation_token: CancellationToken,
-    ) -> eyre::Result<Self> {
+    ) -> Self {
         tracing::info!("init OPRF material-store..");
         let oprf_key_material_store = OprfKeyMaterialStore::new(
             secret_manager,
@@ -156,7 +153,7 @@ impl OprfServiceBuilder {
             }
         });
 
-        Ok(Self {
+        Self {
             open_sessions: OpenSessions::new(),
             info_routes: info_route,
             api: Router::new(),
@@ -164,7 +161,7 @@ impl OprfServiceBuilder {
             party_id: node_information.party_id(),
             threshold: node_information.threshold(),
             config,
-        })
+        }
     }
 
     /// Adds a CORS layer for the `info` routes.

--- a/oprf-service/src/tests/setup.rs
+++ b/oprf-service/src/tests/setup.rs
@@ -107,7 +107,7 @@ impl TestNode {
         setup: &TestSetup,
         pool: PgPool,
         secret_manager: PostgresSecretManager,
-    ) -> eyre::Result<Self> {
+    ) -> Self {
         let TestSetup {
             provider: _,
             cancellation_token,
@@ -135,20 +135,20 @@ impl TestNode {
                 setup.setup.threshold(),
             ),
             child_token.clone(),
-        )?
+        )
         .module("/test", Arc::new(ConfigurableTestAuthenticator))
         .build();
         let server = TestServer::builder()
             .http_transport()
             .build(service)
             .expect("Can build test-server");
-        Ok(TestNode {
+        TestNode {
             secret_manager,
             started_services,
             server: Arc::new(server),
             party_id,
             pool,
-        })
+        }
     }
 
     pub async fn start(party_id: usize, setup: &TestSetup) -> eyre::Result<Self> {
@@ -171,7 +171,7 @@ impl TestNode {
         let pool = nodes_common::postgres::pg_pool_with_schema(&postgres_config, CreateSchema::Yes)
             .await?;
         MIGRATOR.run(&pool).await?;
-        let test_node = Self::start_with_secret_manager(party_id, setup, pool, secret_manager)?;
+        let test_node = Self::start_with_secret_manager(party_id, setup, pool, secret_manager);
         let key_id = OprfKeyId::from(oprf_key_id);
         test_node
             .add_random_key_material_with_id(key_id, &mut rand::thread_rng())


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Public builder API break requires downstream upgrades; behavior change is limited to error propagation at init time since init paths were previously always succeeding in practice.
> 
> **Overview**
> **Breaking change:** `OprfServiceBuilder::init` no longer returns `eyre::Result<Self>`; it always returns `Self`. The documented `# Errors` section is removed because initialization no longer reports fallible setup through this API.
> 
> Call sites drop `?` / `Ok(...)` wrapping—the example binary and test `start_with_secret_manager` chain `.module(...).build()` directly. The workspace `taceo-oprf` crate version moves **0.15.3 → 0.16.0** in `Cargo.lock` to reflect the API break.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 830f0e54e72821ab1de66d43fe39ec119b1fd4cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->