### PR TITLE
themis/remove iamalive

### DIFF
--- a/oprf-key-gen/src/lib.rs
+++ b/oprf-key-gen/src/lib.rs
@@ -68,7 +68,6 @@ pub use services::secret_manager;
 /// The tasks spawned by the key-gen library. Should call [`KeyGenTasks::join`] when shutting down for graceful shutdown.
 pub struct KeyGenTasks {
     key_event_watcher: tokio::task::JoinHandle<eyre::Result<()>>,
-    i_am_alive_task: tokio::task::JoinHandle<()>,
     cursor_checkpoint_task: tokio::task::JoinHandle<()>,
 
     // keep the providers alive as long as the tasks are
@@ -83,7 +82,6 @@ impl KeyGenTasks {
     /// Returns the error from the inner tasks or an error if the task panicked.
     pub async fn join(self) -> eyre::Result<()> {
         self.key_event_watcher.await??;
-        self.i_am_alive_task.await?;
         self.cursor_checkpoint_task.await?;
         Ok(())
     }
@@ -314,12 +312,6 @@ pub async fn start(
 
     let key_gen_router = api::routes(address, started_services.clone());
 
-    let i_am_alive_task = tokio::task::spawn(start_i_am_alive_task(
-        started_services,
-        config.i_am_alive_interval,
-        cancellation_token.clone(),
-    ));
-
     let cursor_checkpoint_task = tokio::task::spawn(start_cursor_checkpoint_task(
         config.cursor_checkpoint_interval,
         http_rpc_provider.clone(),
@@ -331,7 +323,6 @@ pub async fn start(
         key_gen_router,
         KeyGenTasks {
             key_event_watcher,
-            i_am_alive_task,
             cursor_checkpoint_task,
             _http_rpc_provider: http_rpc_provider,
             _ws_rpc_provider: ws_rpc_provider,
@@ -380,26 +371,4 @@ async fn start_cursor_checkpoint_task(
         }
     }
     tracing::info!("shutting down cursor checkpoint task");
-}
-
-async fn start_i_am_alive_task(
-    started_services: StartedServices,
-    i_am_alive_interval: Duration,
-    cancellation_token: CancellationToken,
-) {
-    let mut interval = tokio::time::interval(i_am_alive_interval);
-    tracing::info!("starting i am alive task");
-    loop {
-        tokio::select! {
-           _ = interval.tick() => {
-                if started_services.all_started() {
-                    metrics::health::inc_i_am_alive();
-                }
-           },
-           () = cancellation_token.cancelled() => {
-               break;
-           }
-        }
-    }
-    tracing::info!("shutting down i am alive task");
 }

--- a/oprf-key-gen/src/metrics.rs
+++ b/oprf-key-gen/src/metrics.rs
@@ -8,26 +8,8 @@
 ///
 /// This calls the `describe_*` functions from the `metrics` crate to set metadata on the different metrics.
 pub fn describe_metrics() {
-    health::describe_metrics();
     wallet::describe_metrics();
     chain_events::describe_metrics();
-}
-
-pub(crate) mod health {
-
-    const METRICS_ID_I_AM_ALIVE: &str = "taceo.oprf.key_gen.i.am.alive";
-
-    pub(super) fn describe_metrics() {
-        metrics::describe_counter!(
-            METRICS_ID_I_AM_ALIVE,
-            metrics::Unit::Count,
-            "I am alive metric. Used to measure liveness in datadog"
-        );
-    }
-
-    pub(crate) fn inc_i_am_alive() {
-        metrics::counter!(METRICS_ID_I_AM_ALIVE).increment(1);
-    }
 }
 
 pub(crate) mod wallet {

--- a/oprf-service/examples/taceo-oprf-service-example.rs
+++ b/oprf-service/examples/taceo-oprf-service-example.rs
@@ -118,7 +118,6 @@ pub async fn start_service(
         secret_manager,
         StartedServices::default(),
         &node_information,
-        cancellation_token.clone(),
     )
     .module("/example", Arc::new(ExampleOprfRequestAuthenticator))
     .build();

--- a/oprf-service/src/lib.rs
+++ b/oprf-service/src/lib.rs
@@ -60,7 +60,6 @@ use oprf_types::api::OprfRequestAuthService;
 use oprf_types::crypto::PartyId;
 use oprf_types::service::NodeInformation;
 use serde::Deserialize;
-use tokio_util::sync::CancellationToken;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::{MakeSpan, TraceLayer};
@@ -110,7 +109,6 @@ impl OprfServiceBuilder {
         secret_manager: SecretManagerService,
         started_services: StartedServices,
         node_information: &NodeInformation,
-        cancellation_token: CancellationToken,
     ) -> Self {
         tracing::info!("init OPRF material-store..");
         let oprf_key_material_store = OprfKeyMaterialStore::new(
@@ -125,33 +123,13 @@ impl OprfServiceBuilder {
         let version_str = nodes_common::version_info!();
         let info_route = Router::new()
             .merge(nodes_common::api::routes_with_services(
-                started_services.clone(),
+                started_services,
                 version_str,
             ))
             .merge(api::info::routes(
                 oprf_key_material_store.clone(),
                 node_information.address().to_owned(),
             ));
-
-        tokio::task::spawn({
-            let mut interval = tokio::time::interval(config.i_am_alive_interval);
-            async move {
-                tracing::info!("starting i am alive task");
-                loop {
-                    tokio::select! {
-                       _ = interval.tick() => {
-                            if started_services.all_started() {
-                                metrics::health::inc_i_am_alive();
-                            }
-                       },
-                       () = cancellation_token.cancelled() => {
-                           break;
-                       }
-                    }
-                }
-                tracing::info!("shutting down i am alive task");
-            }
-        });
 
         Self {
             open_sessions: OpenSessions::new(),

--- a/oprf-service/src/metrics.rs
+++ b/oprf-service/src/metrics.rs
@@ -9,7 +9,6 @@
 /// This calls the `describe_*` functions from the `metrics` crate to set metadata on the different metrics.
 pub fn describe_metrics() {
     request::describe_metrics();
-    health::describe_metrics();
     sessions::describe_metrics();
     secrets::describe_metrics();
 }
@@ -137,23 +136,6 @@ pub(crate) mod request {
         pub(crate) fn inc_client_version_in_query() {
             metrics::counter!(METRICS_ID_NODE_CLIENT_VERSION_QUERY).increment(1);
         }
-    }
-}
-
-pub(crate) mod health {
-
-    const METRICS_ID_I_AM_ALIVE: &str = "taceo.oprf.node.i.am.alive";
-
-    pub(super) fn describe_metrics() {
-        metrics::describe_counter!(
-            METRICS_ID_I_AM_ALIVE,
-            metrics::Unit::Count,
-            "I am alive metric. Used to measure liveness in datadog"
-        );
-    }
-
-    pub(crate) fn inc_i_am_alive() {
-        metrics::counter!(METRICS_ID_I_AM_ALIVE).increment(1);
     }
 }
 

--- a/oprf-service/src/tests/mod.rs
+++ b/oprf-service/src/tests/mod.rs
@@ -10,6 +10,7 @@ use oprf_types::{
     OprfKeyId, ShareEpoch,
     api::{OprfResponse, oprf_error_codes},
 };
+use ruint::aliases::U160;
 use serde::{Deserialize, Serialize};
 use tungstenite::protocol::{CloseFrame, frame::coding::CloseCode};
 use uuid::Uuid;
@@ -32,7 +33,7 @@ struct BadRequest {
 async fn test_can_fetch_new_key() -> eyre::Result<()> {
     let setup = TestSetup::new(DeploySetup::TwoThree).await?;
     let node = TestNode::start(0, &setup).await?;
-    let new_oprf_key_id = OprfKeyId::new(rand::random());
+    let new_oprf_key_id = OprfKeyId::new(U160::random());
     node.doesnt_have_key(new_oprf_key_id).await?;
     let epoch = ShareEpoch::new(rand::random());
     node.add_random_key_material_with_id_epoch(new_oprf_key_id, epoch, &mut rand::thread_rng())

--- a/oprf-service/src/tests/setup.rs
+++ b/oprf-service/src/tests/setup.rs
@@ -108,11 +108,6 @@ impl TestNode {
         pool: PgPool,
         secret_manager: PostgresSecretManager,
     ) -> Self {
-        let TestSetup {
-            provider: _,
-            cancellation_token,
-            ..
-        } = setup;
         assert!(party_id < 5, "can only spawn 5 nodes");
 
         let mut config = OprfNodeServiceConfig::with_default_values(
@@ -120,8 +115,6 @@ impl TestNode {
             "1.0.0".parse().expect("Valid VersionReq"),
         );
         config.session_lifetime = Duration::from_secs(10);
-
-        let child_token = cancellation_token.child_token();
 
         let started_services = StartedServices::new();
         let secret_manager = Arc::new(secret_manager);
@@ -134,7 +127,6 @@ impl TestNode {
                 OPRF_PEER_ADDRESS_0.to_string(),
                 setup.setup.threshold(),
             ),
-            child_token.clone(),
         )
         .module("/test", Arc::new(ConfigurableTestAuthenticator))
         .build();


### PR DESCRIPTION
- **refactor(node)!: remove i_am_alive task**
- **refactor(key-gen)!: remove i_am_alive task**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API on `OprfServiceBuilder::init` and `NodeInformation`, plus removal of Datadog liveness counters; address handling is looser without alloy parse errors on DB read.
> 
> **Overview**
> Removes the periodic **i am alive** background tasks and `taceo.oprf.*.i.am.alive` metrics from **oprf-key-gen** and **oprf-service**, including `KeyGenTasks` wiring and graceful-shutdown joins for that task.
> 
> **`NodeInformation`** now stores the operator EVM address as a **`String`** (no longer `alloy::Address`): construction, Postgres bind/load, `/wallet`, and tests are updated accordingly, and DB load no longer validates/parses checksummed addresses (the corrupt-address postgres test is removed).
> 
> **`OprfServiceBuilder::init`** takes **`&NodeInformation`** instead of an owned value and drops the **`CancellationToken`** parameter; callers (example binary, tests) are adjusted. **oprf-service** drops direct **`alloy`** / **`nodes-common` `web3`** usage and no longer re-exports **`web3`**.
> 
> **oprf-types** default features are empty; **`service`** no longer enables **`alloy`**. The **`taceo-oprf`** umbrella forwards **`postgres`** and **`chain`** sub-crate features with **`default-features = false`** on optional deps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7483f799827b3ff6949c3542e5e8639e05a43cca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->