### PR TITLE
themis/add transitive feature deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6342,7 +6342,6 @@ dependencies = [
 name = "taceo-oprf-service"
 version = "0.17.0"
 dependencies = [
- "alloy",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "async-trait",
@@ -6360,6 +6359,7 @@ dependencies = [
  "moka",
  "parking_lot",
  "rand 0.8.6",
+ "ruint",
  "rustls",
  "secrecy",
  "semver 1.0.28",

--- a/oprf-key-gen/src/lib.rs
+++ b/oprf-key-gen/src/lib.rs
@@ -166,7 +166,7 @@ async fn contract_sanity_checks(
     tracing::info!("we are party id: {party_id}. Threshold/NumPeers also match",);
     Ok(NodeInformation::new(
         party_id,
-        key_gen_wallet_address,
+        key_gen_wallet_address.to_string(),
         config.expected_threshold,
     ))
 }

--- a/oprf-key-gen/src/postgres.rs
+++ b/oprf-key-gen/src/postgres.rs
@@ -207,7 +207,7 @@ impl SecretManager for PostgresDb {
                     threshold = EXCLUDED.threshold
             ",
             )
-            .bind(node_information.address().to_string())
+            .bind(node_information.address())
             .bind(i32::from(node_information.party_id().into_inner()))
             .bind(i32::from(node_information.threshold().get()))
             .execute(&self.pool)

--- a/oprf-key-gen/src/postgres/tests.rs
+++ b/oprf-key-gen/src/postgres/tests.rs
@@ -53,9 +53,10 @@ async fn load_node_information_success() -> eyre::Result<()> {
     let address = key.address();
     let should_party_id = PartyId(42);
     let should_threshold = NonZeroU16::new(2).expect("2 is non-zero");
-    let should_node_information = NodeInformation::new(should_party_id, address, should_threshold);
+    let should_node_information =
+        NodeInformation::new(should_party_id, address.to_string(), should_threshold);
     secret_manager
-        .store_node_information(should_node_information)
+        .store_node_information(should_node_information.clone())
         .await?;
 
     // check that the address is stored in the DB

--- a/oprf-service/Cargo.toml
+++ b/oprf-service/Cargo.toml
@@ -15,14 +15,6 @@ publish = true
 ignored = ["humantime-serde"]
 
 [dependencies]
-alloy = { workspace = true, features = [
-  "contract",
-  "provider-http",
-  "provider-ws",
-  "reqwest-rustls-tls",
-  "rpc-types-eth",
-  "sol-types"
-] }
 ark-babyjubjub = { workspace = true }
 ark-serialize.workspace = true
 async-trait = { workspace = true }
@@ -38,8 +30,7 @@ moka.workspace = true
 nodes-common = { workspace = true, features = [
   "api",
   "postgres",
-  "serde",
-  "web3"
+  "serde"
 ] }
 oprf-core = { package = "taceo-oprf-core", path = "../oprf-core", version = "0.6" }
 oprf-types = { package = "taceo-oprf-types", path = "../oprf-types", version = "0.14", features = [
@@ -82,6 +73,7 @@ oprf-test-utils = { package = "taceo-oprf-test-utils", path = "../oprf-test-util
   "deploy-anvil",
   "postgres-test-container"
 ] }
+ruint.workspace = true
 rustls = { workspace = true }
 telemetry-batteries = { workspace = true, features = ["metrics-statsd"] }
 

--- a/oprf-service/examples/taceo-oprf-service-example.rs
+++ b/oprf-service/examples/taceo-oprf-service-example.rs
@@ -117,7 +117,7 @@ pub async fn start_service(
         config.node_config,
         secret_manager,
         StartedServices::default(),
-        node_information,
+        &node_information,
         cancellation_token.clone(),
     )
     .module("/example", Arc::new(ExampleOprfRequestAuthenticator))

--- a/oprf-service/src/api/info.rs
+++ b/oprf-service/src/api/info.rs
@@ -8,7 +8,6 @@
 //! The endpoints include a `Cache-Control: no-cache` header to prevent caching of responses.
 use crate::secret_manager::SecretManagerError;
 use crate::services::oprf_key_material_store::OprfKeyMaterialStore;
-use alloy::primitives::Address;
 use axum::{
     Json, Router,
     extract::{Path, State},
@@ -20,12 +19,12 @@ use oprf_types::OprfKeyId;
 
 #[derive(Clone)]
 struct InfoState {
-    wallet_address: Address,
+    wallet_address: String,
     oprf_material_store: OprfKeyMaterialStore,
 }
 
 /// Create a router containing the info endpoints.
-pub(crate) fn routes(oprf_material_store: OprfKeyMaterialStore, wallet_address: Address) -> Router {
+pub(crate) fn routes(oprf_material_store: OprfKeyMaterialStore, wallet_address: String) -> Router {
     Router::new()
         .route("/wallet", get(wallet))
         .route("/oprf_pub/{id}", get(oprf_key_available))
@@ -39,7 +38,7 @@ pub(crate) fn routes(oprf_material_store: OprfKeyMaterialStore, wallet_address: 
 ///
 /// Returns `200 OK` with a string response.
 async fn wallet(State(info_state): State<InfoState>) -> impl IntoResponse {
-    (StatusCode::OK, info_state.wallet_address.to_string())
+    (StatusCode::OK, info_state.wallet_address)
 }
 
 /// Checks whether a OPRF public-key associated with the [`OprfKeyId`] is registered at the service. If yes, returns the [`oprf_types::api::OprfPublicKeyWithEpoch`] containing the latest epoch currently stored at the service.

--- a/oprf-service/src/lib.rs
+++ b/oprf-service/src/lib.rs
@@ -73,7 +73,7 @@ pub(crate) mod services;
 #[cfg(test)]
 mod tests;
 
-pub use nodes_common::{Environment, StartedServices, web3};
+pub use nodes_common::{Environment, StartedServices};
 pub use semver::VersionReq;
 pub use services::secret_manager;
 
@@ -109,7 +109,7 @@ impl OprfServiceBuilder {
         config: OprfNodeServiceConfig,
         secret_manager: SecretManagerService,
         started_services: StartedServices,
-        node_information: NodeInformation,
+        node_information: &NodeInformation,
         cancellation_token: CancellationToken,
     ) -> Self {
         tracing::info!("init OPRF material-store..");
@@ -130,7 +130,7 @@ impl OprfServiceBuilder {
             ))
             .merge(api::info::routes(
                 oprf_key_material_store.clone(),
-                node_information.address(),
+                node_information.address().to_owned(),
             ));
 
         tokio::task::spawn({

--- a/oprf-service/src/services/secret_manager/postgres/tests.rs
+++ b/oprf-service/src/services/secret_manager/postgres/tests.rs
@@ -111,22 +111,6 @@ async fn load_node_information_empty() -> eyre::Result<()> {
 }
 
 #[tokio::test]
-async fn load_node_information_corrupt() -> eyre::Result<()> {
-    let (secret_manager, connection_string, schema) = postgres_secret_manager().await?;
-
-    let mut conn =
-        oprf_test_utils::open_pg_connection(connection_string, &schema.to_string()).await?;
-    insert_node_information("SomethingThatIsNotAnAddress", 0, 2, &mut conn).await?;
-
-    let report = secret_manager
-        .load_node_information()
-        .await
-        .expect_err("should be an error");
-    assert!(report.to_string().contains("invalid address stored in DB"));
-    Ok(())
-}
-
-#[tokio::test]
 async fn load_node_information_success() -> eyre::Result<()> {
     let (secret_manager, connection_string, schema) = postgres_secret_manager().await?;
 

--- a/oprf-service/src/services/secret_manager/postgres/tests.rs
+++ b/oprf-service/src/services/secret_manager/postgres/tests.rs
@@ -1,7 +1,6 @@
 use std::num::NonZeroU16;
 
 use crate::secret_manager::{SecretManager, SecretManagerError, postgres::PostgresSecretManager};
-use alloy::primitives::U160;
 use ark_serialize::CanonicalSerialize;
 use nodes_common::postgres::{PostgresConfig, SanitizedSchema};
 use oprf_core::ddlog_equality::shamir::DLogShareShamir;
@@ -11,6 +10,7 @@ use oprf_types::{
     crypto::{OprfPublicKey, PartyId},
     service::NodeInformation,
 };
+use ruint::aliases::U160;
 use secrecy::SecretString;
 use sqlx::PgConnection;
 
@@ -151,7 +151,7 @@ async fn load_node_information_success() -> eyre::Result<()> {
         is_node_information,
         NodeInformation::new(
             should_party_id,
-            should_address,
+            should_address.to_string(),
             NonZeroU16::try_from(should_threshold).expect("is non-zero")
         )
     );

--- a/oprf-service/src/tests/setup.rs
+++ b/oprf-service/src/tests/setup.rs
@@ -129,9 +129,9 @@ impl TestNode {
             config,
             secret_manager.clone(),
             started_services.clone(),
-            NodeInformation::new(
+            &NodeInformation::new(
                 PartyId(u16::try_from(party_id).expect("party id must be u16")),
-                OPRF_PEER_ADDRESS_0,
+                OPRF_PEER_ADDRESS_0.to_string(),
                 setup.setup.threshold(),
             ),
             child_token.clone(),

--- a/oprf-types/Cargo.toml
+++ b/oprf-types/Cargo.toml
@@ -31,6 +31,6 @@ sqlx = { workspace = true, features = [
 uuid = { workspace = true, features = ["serde", "v4"] }
 
 [features]
-default = ["chain"]
+default = []
 chain = ["dep:alloy", "dep:circom-types", "dep:groth16-sol"]
-service = ["dep:alloy", "dep:sqlx"]
+service = ["dep:sqlx"]

--- a/oprf-types/src/service.rs
+++ b/oprf-types/src/service.rs
@@ -1,16 +1,15 @@
 //! Types for communication between key-gen and nodes.
 use std::num::NonZeroU16;
 
-use alloy::primitives::Address;
 use sqlx::{Row, postgres::PgRow};
 
 use crate::crypto::PartyId;
 
 /// All information necessary for an OPRF node provided by the key-gen instance.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NodeInformation {
     party_id: PartyId,
-    address: Address,
+    address: String,
     threshold: NonZeroU16,
 }
 
@@ -23,12 +22,6 @@ impl<'r> sqlx::FromRow<'r, PgRow> for NodeInformation {
             return Err(sqlx::Error::ColumnDecode {
                 index: "party_id".to_owned(),
                 source: "party_id does not fit into u16".into(),
-            });
-        };
-        let Ok(address) = Address::parse_checksummed(address, None) else {
-            return Err(sqlx::Error::ColumnDecode {
-                index: "eth_address".to_owned(),
-                source: "invalid address stored in DB".into(),
             });
         };
         let Ok(threshold_u16) = u16::try_from(threshold) else {
@@ -54,7 +47,7 @@ impl<'r> sqlx::FromRow<'r, PgRow> for NodeInformation {
 impl NodeInformation {
     /// Creates a new instance.
     #[must_use]
-    pub fn new(party_id: PartyId, address: Address, threshold: NonZeroU16) -> Self {
+    pub fn new(party_id: PartyId, address: String, threshold: NonZeroU16) -> Self {
         Self {
             party_id,
             address,
@@ -68,10 +61,10 @@ impl NodeInformation {
         self.party_id
     }
 
-    /// The EVM address of the node operator.
+    /// The EVM address of the node operator as `String`.
     #[must_use]
-    pub fn address(&self) -> Address {
-        self.address
+    pub fn address(&self) -> &str {
+        &self.address
     }
 
     /// The threshold for the OPRF MPC instance.

--- a/oprf/Cargo.toml
+++ b/oprf/Cargo.toml
@@ -33,11 +33,6 @@ postgres = ["oprf-service?/postgres"]
 # oprf-types
 chain = ["oprf-types?/chain"]
 
-# `full` restores the historical defaults for all sub-crates:
-#   oprf-core defaults: server
-#   oprf-service defaults: postgres
-#   oprf-types defaults: chain
-# `additive` and `types-service` are intentionally excluded — they were never default.
 full = [
   "client", "core", "dev-client", "service", "types",
   "postgres", "chain",

--- a/oprf/Cargo.toml
+++ b/oprf/Cargo.toml
@@ -13,18 +13,32 @@ publish = true
 
 [dependencies]
 oprf-client = { package = "taceo-oprf-client", path = "../oprf-client", version = "0.10.0", optional = true }
-oprf-core = { package = "taceo-oprf-core", path = "../oprf-core", version = "0.6.0", optional = true }
+oprf-core = { package = "taceo-oprf-core", path = "../oprf-core", version = "0.6.0", default-features = false, optional = true }
 oprf-dev-client = { package = "taceo-oprf-dev-client", path = "../oprf-dev-client", version = "0.10.0", optional = true }
-oprf-service = { package = "taceo-oprf-service", path = "../oprf-service", version = "0.17.0", optional = true }
-oprf-types = { package = "taceo-oprf-types", path = "../oprf-types", version = "0.14.0", optional = true }
+oprf-service = { package = "taceo-oprf-service", path = "../oprf-service", version = "0.17.0", default-features = false, optional = true }
+oprf-types = { package = "taceo-oprf-types", path = "../oprf-types", version = "0.14.0", default-features = false, optional = true }
 
 [features]
 default = ["full"]
+
 client = ["dep:oprf-client"]
 core = ["dep:oprf-core"]
 dev-client = ["client", "dep:oprf-dev-client"]
-full = ["client", "core", "dev-client", "service", "types"]
-service = [
-  "dep:oprf-service",
-]
+service = ["dep:oprf-service"]
 types = ["dep:oprf-types"]
+
+# --- forwarded transitive features ---
+# oprf-service
+postgres = ["oprf-service?/postgres"]
+# oprf-types
+chain = ["oprf-types?/chain"]
+
+# `full` restores the historical defaults for all sub-crates:
+#   oprf-core defaults: server
+#   oprf-service defaults: postgres
+#   oprf-types defaults: chain
+# `additive` and `types-service` are intentionally excluded — they were never default.
+full = [
+  "client", "core", "dev-client", "service", "types",
+  "postgres", "chain",
+]

--- a/oprf/src/lib.rs
+++ b/oprf/src/lib.rs
@@ -43,7 +43,20 @@
 //! taceo-oprf = { version = "0.7.1", features = ["client", "core"] }
 //! ```
 //!
-//! The default feature `full` enables all modules.
+//! The default feature `full` enables all modules with their transitive deps.
+//!
+//! ### Transitive sub-crate features
+//!
+//! The umbrella forwards each sub-crate feature as its own flag so consumers
+//! can opt in or out without importing the individual crates. All of these use
+//! the weak-dependency syntax (`dep?/feature`) and therefore do **not** activate
+//! the parent crate on their own — the corresponding crate-selection feature
+//! (`core`, `service`, `types`) must also be enabled.
+//!
+//! | Umbrella feature | Forwarded to            | Notes                               |
+//! |------------------|-------------------------|-------------------------------------|
+//! | `postgres`       | `oprf-service/postgres` | On by default via `full`            |
+//! | `chain`          | `oprf-types/chain`      | On by default via `full`            |
 
 #[cfg(feature = "client")]
 /// Re-export of the `taceo-oprf-client` crate.


### PR DESCRIPTION
- **build(deps): add transitve deps for umbrella**
- **refactor(types)!: drop alloy and use address as String**
- **refactor(node)!: drop unused deps and use string for address**
- **refactor(key-gen): use string as address**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking `NodeInformation` and feature-default changes affect downstream crates; wallet identity is no longer validated at DB load time.
> 
> **Overview**
> **Breaking:** `NodeInformation` now stores the operator EVM address as a `String` instead of `alloy::primitives::Address`. SQL loading no longer validates/parses addresses; key-gen persists and returns `to_string()`, and `oprf-service` exposes `/wallet` from that string. `OprfServiceBuilder::init` takes `&NodeInformation` instead of an owned value.
> 
> **Dependencies:** `taceo-oprf-service` drops the `alloy` dependency and trims `nodes-common` to `api` + `postgres` + `serde` (no `web3`). `taceo-oprf-types` `service` feature is sqlx-only; `chain`/`alloy` are opt-in via the `chain` feature (defaults are now empty). The umbrella `taceo-oprf` crate forwards `postgres` and `chain` to sub-crates with `default-features = false` on optional deps, and documents weak `dep?/feature` forwarding in `full`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64c555c886f307fa876934428e20941446005fac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->