### PR TITLE
themis/fix/dev client/chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6211,7 +6211,7 @@ dependencies = [
 
 [[package]]
 name = "taceo-oprf"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "taceo-oprf-client",
  "taceo-oprf-core",

--- a/oprf-dev-client/Cargo.toml
+++ b/oprf-dev-client/Cargo.toml
@@ -25,7 +25,9 @@ eyre.workspace = true
 humantime.workspace = true
 oprf-client = { package = "taceo-oprf-client", path = "../oprf-client", version = "0.10" }
 oprf-core = { package = "taceo-oprf-core", path = "../oprf-core", version = "0.6" }
-oprf-types = { package = "taceo-oprf-types", path = "../oprf-types", version = "0.15" }
+oprf-types = { package = "taceo-oprf-types", path = "../oprf-types", version = "0.15", features = [
+  "chain"
+] }
 rand.workspace = true
 rand_chacha.workspace = true
 reqwest = { workspace = true }

--- a/oprf-key-gen/Cargo.toml
+++ b/oprf-key-gen/Cargo.toml
@@ -47,6 +47,7 @@ nodes-common = { workspace = true, features = [
 ] }
 oprf-core = { package = "taceo-oprf-core", path = "../oprf-core", version = "0.6" }
 oprf-types = { package = "taceo-oprf-types", path = "../oprf-types", version = "0.15", features = [
+  "chain",
   "service"
 ] }
 rand.workspace = true


### PR DESCRIPTION
- **build(deps): fix key-gen deps**
- **chore: fix dev-client deps**
- **chore: cargo lock**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and lockfile-only changes with no application logic; risk is limited to build/feature resolution.
> 
> **Overview**
> Fixes missing **`oprf-types` feature flags** so dev tooling and key generation compile against the chain-related types they already use.
> 
> **`taceo-oprf-dev-client`** now depends on `taceo-oprf-types` with the **`chain`** feature (pulls in `alloy`, `circom-types`, and `groth16-sol`). **`taceo-oprf-key-gen`** adds **`chain`** alongside its existing **`service`** feature on the same crate.
> 
> **`Cargo.lock`** updates the workspace **`taceo-oprf`** meta-package from **0.16.1** to **0.17.0** to match the resolved dependency graph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f98338aa9358292d083df0afff8bbc31b36417a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->