### PR TITLE
themis/graceful close ws

### DIFF
--- a/oprf-client/src/ws/native.rs
+++ b/oprf-client/src/ws/native.rs
@@ -36,17 +36,17 @@ pub(crate) struct WebSocketSession {
 
 impl WebSocketSession {
     /// Tries to close the websocket on a best effort basis by sending a close-frame to the server and initiating tear down.
-    async fn best_effort_close(&mut self, code: CloseCode, reason: impl Into<String>) {
+    async fn best_effort_close(&mut self, code: CloseCode) {
         if let Err(err) = self
             .inner
             .close(Some(CloseFrame {
                 code,
-                reason: reason.into().into(),
+                reason: "".into(),
             }))
             .await
         {
             tracing::trace!(
-                "Received an error when trying to best effort close {}: {err:?}",
+                "Received an error when trying to best effort close {}: {err}",
                 self.service
             );
         }
@@ -58,8 +58,7 @@ impl WebSocketSession {
         String: From<T>,
     {
         let reason = String::from(reason);
-        self.best_effort_close(CloseCode::Unsupported, reason.clone())
-            .await;
+        self.best_effort_close(CloseCode::Unsupported).await;
 
         NodeError::UnexpectedMessage { reason }
     }
@@ -90,8 +89,7 @@ impl WebSocketSession {
         let mut buf = Vec::new();
         ciborium::into_writer(&msg, &mut buf).expect("Can serialize msg");
         if let Err(err) = self.inner.send(tungstenite::Message::binary(buf)).await {
-            self.best_effort_close(CloseCode::Error, "error during ws send")
-                .await;
+            self.best_effort_close(CloseCode::Error).await;
             Err(NodeError::WsError(Box::new(err)))
         } else {
             Ok(())
@@ -105,11 +103,12 @@ impl WebSocketSession {
         let msg = match self.inner.next().await {
             Some(Ok(msg)) => msg,
             Some(Err(err)) => {
-                self.best_effort_close(CloseCode::Error, err.to_string())
-                    .await;
+                self.best_effort_close(CloseCode::Error).await;
                 return Err(err.into());
             }
             None => {
+                tracing::trace!("Cannot receive frame - closed without sending close-frame");
+                self.best_effort_close(CloseCode::Error).await;
                 return Err(NodeError::WsError(Box::new(tungstenite::Error::Io(
                     std::io::Error::other("server closed connection without sending close-frame"),
                 ))));
@@ -128,12 +127,14 @@ impl WebSocketSession {
                 if let Some(frame) = frame
                     && frame.code != CloseCode::Normal
                 {
+                    self.best_effort_close(CloseCode::Normal).await;
                     Err(NodeError::ServiceError(ServiceError {
                         error_code: u16::from(frame.code),
                         msg: (!frame.reason.is_empty()).then(|| frame.reason.to_string()),
                         kind: oprf_types::api::OprfErrorKind::from(u16::from(frame.code)),
                     }))
                 } else {
+                    self.best_effort_close(CloseCode::Error).await;
                     Err(NodeError::WsError(Box::new(tungstenite::Error::Io(
                         std::io::Error::other(
                             "Server closed websocket without finishing protocol - EOF",
@@ -150,6 +151,6 @@ impl WebSocketSession {
 
     /// Gracefully closes the web-socket by sending a `Close` frame with `CloseCode::Normal`.
     pub(crate) async fn graceful_close(mut self) {
-        self.best_effort_close(CloseCode::Normal, "success").await;
+        self.best_effort_close(CloseCode::Normal).await;
     }
 }

--- a/oprf-service/src/api/oprf.rs
+++ b/oprf-service/src/api/oprf.rs
@@ -158,9 +158,19 @@ async fn oprf_ws_handler<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
                     };
                     if let Some(close_frame) = close_frame {
                         tracing::trace!("sending close frame");
-                        // In their example, axum just sends the frame and ignores the error afterwards and also don't wait for the peers close frame. Therefore we do the same,
-                        #[allow(clippy::let_underscore_must_use, reason="we don't care about this error as we close the connection anyways and only send close frame on best effort")]
-                        let _ = ws.send(ws::Message::Close(Some(close_frame))).await;
+                        if ws.send(ws::Message::Close(Some(close_frame))).await.is_ok() {
+                            // We expect the very next message to be a close frame - we keep the ws connection open so that an honest client can tear down its connection gracefully
+                            match tokio::time::timeout(state.max_connection_lifetime, ws.recv())
+                                .await
+                            {
+                                Ok(Some(Ok(ws::Message::Close(_))) | None) => tracing::trace!("successfully tore down web-socket connection"),
+                                Ok(Some(Ok(frame))) => {
+                                    tracing::debug!("got unexpected frame from client: {frame:?}");
+                                }
+                                Ok(Some(Err(err))) => tracing::trace!("web-socket connection error while waiting for close frame in teardown: {err}"),
+                                Err(_) => tracing::debug!("client did not send close frame in time"),
+                            }
+                        }
                     }
                 }
                 .instrument(parent_span)


### PR DESCRIPTION
- **fix(client): send close frame everytime server sends error**
- **fix(service): wait for close frame after sending one**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection teardown timing and close-frame exchange on live OPRF WebSocket sessions; unlikely to affect crypto logic but could alter behavior under slow or misbehaving clients.
> 
> **Overview**
> Improves **graceful WebSocket shutdown** for OPRF sessions on both sides of the connection.
> 
> On the **client** (`WebSocketSession`), `best_effort_close` no longer carries a close reason (frames use an empty reason). Close frames are sent on more read/send failure paths, including when the stream ends without a close frame. Handling of inbound **Close** frames now always triggers a client close reply: **Normal** when the server signals a service error (non-normal code), **Error** when the server closes normally or the protocol ends unexpectedly.
> 
> On the **service**, after sending its session-ending close frame (success, error, or timeout), the handler **keeps the connection open** and waits up to `max_connection_lifetime` for the client’s close frame, with trace/debug logging for success, unexpected frames, errors, or client timeout—replacing the previous send-and-ignore teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b74637309aa6d9490d1abd84a97801329c37516. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->