### PR TITLE
build(deps): bump reqwest to 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3453,7 +3453,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -5000,21 +4999,16 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
  "tower",
  "tower-http 0.6.11",
  "tower-service",
@@ -5022,7 +5016,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -6282,7 +6275,7 @@ dependencies = [
  "humantime",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "rustls",
  "secrecy",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,9 +57,9 @@ parking_lot = "0.12"
 poseidon2 = { package = "taceo-poseidon2", version = "0.2", default-features = false }
 rand = { version = "0.8" }
 rand_chacha = { version = "0.3" }
-reqwest = { version = "0.12", default-features = false, features = [
+reqwest = { version = "0.13", default-features = false, features = [
+  "default-tls",
   "json",
-  "rustls-tls",
 ] }
 ruint = { version = "1", features = ["serde"] }
 rustls = "0.23"

--- a/oprf-dev-client/Cargo.toml
+++ b/oprf-dev-client/Cargo.toml
@@ -16,7 +16,8 @@ alloy = { workspace = true, features = [
   "contract",
   "provider-http",
   "provider-ws",
-  "signer-local"
+  "reqwest-rustls-tls",
+  "signer-local",
 ] }
 ark-babyjubjub.workspace = true
 ark-ff.workspace = true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Workspace HTTP clients move from rustls to native TLS via default-tls, which can change TLS behavior by platform; chain traffic in dev-client still targets rustls through alloy’s feature.
> 
> **Overview**
> Upgrades workspace **reqwest** from **0.12** to **0.13** and updates **Cargo.lock** so **oprf-dev-client** pins **reqwest 0.13.2**.
> 
> For the shared **reqwest** dependency, TLS is switched from **`rustls-tls`** to **`default-tls`** (native TLS backend in 0.13’s slimmer default feature set), while keeping **`json`**.
> 
> **`oprf-dev-client`** enables alloy’s **`reqwest-rustls-tls`** feature (alongside existing HTTP/WebSocket provider features) so alloy’s HTTP transport still uses **rustls** after the reqwest upgrade, matching the pattern used elsewhere (e.g. **oprf-key-gen**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6ed5a8d23ba3f3e0d0f5beb5011a07dd98e4766. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->