### PR TITLE
themis/ws handshake fix

### DIFF
--- a/oprf-client/src/lib.rs
+++ b/oprf-client/src/lib.rs
@@ -161,7 +161,7 @@ pub enum NodeError {
     #[error("Server sent unexpected message: {reason}")]
     UnexpectedMessage {
         /// Reason for closing websocket from our side
-        reason: String,
+        reason: &'static str,
     },
     /// The servers could not agree on a [`ShareEpoch`].
     ///
@@ -257,7 +257,7 @@ pub enum Error {
     #[error("Received an unexpected message from threshold many nodes: {reason}")]
     UnexpectedMessage {
         /// A human-readable explanation why the client rejected the message
-        reason: String,
+        reason: &'static str,
     },
     /// One of the OPRF nodes returned an error during finalize (2nd round of the protocol).
     #[error("One of the nodes failed during finalize: {0}")]
@@ -306,9 +306,7 @@ fn aggregate_error(threshold: usize, errors: Vec<NodeError>) -> Error {
                 let count = unexpected_message.entry(reason).or_insert(0);
                 *count += 1;
                 if *count >= threshold {
-                    return Error::UnexpectedMessage {
-                        reason: reason.to_owned(),
-                    };
+                    return Error::UnexpectedMessage { reason };
                 }
             }
             NodeError::EpochMismatch(epoch) => {
@@ -605,15 +603,9 @@ mod tests {
     #[test]
     fn test_threshold_unexpected_message() {
         let errors = vec![
-            NodeError::UnexpectedMessage {
-                reason: "oops1".into(),
-            },
-            NodeError::UnexpectedMessage {
-                reason: "oops1".into(),
-            },
-            NodeError::UnexpectedMessage {
-                reason: "oops2".into(),
-            },
+            NodeError::UnexpectedMessage { reason: "oops1" },
+            NodeError::UnexpectedMessage { reason: "oops1" },
+            NodeError::UnexpectedMessage { reason: "oops2" },
         ];
 
         if let Error::UnexpectedMessage { reason } = aggregate_error(2, errors) {
@@ -637,9 +629,7 @@ mod tests {
                 kind: OprfErrorKind::Unknown,
             }),
             NodeError::WsError(ws2),
-            NodeError::UnexpectedMessage {
-                reason: "oops".into(),
-            },
+            NodeError::UnexpectedMessage { reason: "oops" },
             NodeError::WsError(ws3),
         ];
 
@@ -667,9 +657,7 @@ mod tests {
                 msg: Some("B".into()),
                 kind: OprfErrorKind::Unknown,
             }),
-            NodeError::UnexpectedMessage {
-                reason: "oops".into(),
-            },
+            NodeError::UnexpectedMessage { reason: "oops" },
             NodeError::WsError(Box::new(std::io::Error::other("ws"))),
             NodeError::Unknown(Box::new(std::io::Error::other("unknown"))),
         ];

--- a/oprf-client/src/sessions.rs
+++ b/oprf-client/src/sessions.rs
@@ -112,7 +112,7 @@ async fn init_session<Auth: Serialize>(
 
 /// Write the `req` request to the provided [`WebSocketSession`].
 ///
-/// On success, returns the parsed [`DLogProofShareShamir`] and gracefully closes the web-socket.
+/// On success, returns the parsed [`DLogProofShareShamir`].
 #[instrument(level = "trace", skip_all)]
 async fn finish_session(
     mut session: WebSocketSession,
@@ -120,7 +120,6 @@ async fn finish_session(
 ) -> Result<DLogProofShareShamir, NodeError> {
     session.send(req).await?;
     let resp = session.read().await?;
-    session.graceful_close().await;
     Ok(resp)
 }
 

--- a/oprf-client/src/ws/native.rs
+++ b/oprf-client/src/ws/native.rs
@@ -2,7 +2,7 @@
 //!
 //! This module exposes functionality for handling a single web-socket connection with tungstenite. The sessions are very thin and handle errors very conservatively. If the implementation encounters anything that is unexpected, the session will be immediately terminated.
 //!
-//! What is more, we implement the closing handshake at a best-effort basis. This means we try to send `Close` frames if we close the connection, but if there are problems with sending the `Close` frame we simply ignore the errors.
+//! The client does not send close frames. The server drives the teardown: after the protocol completes (or on error/timeout) the server sends a close frame and drains the socket until the client drops.
 
 use crate::{NodeError, ServiceError};
 use futures::{SinkExt, StreamExt};
@@ -11,10 +11,7 @@ use serde::{Deserialize, Serialize};
 use tokio::net::TcpStream;
 use tokio_tungstenite::{
     Connector, MaybeTlsStream, WebSocketStream,
-    tungstenite::{
-        self,
-        protocol::{CloseFrame, frame::coding::CloseCode},
-    },
+    tungstenite::{self, protocol::frame::coding::CloseCode},
 };
 use uuid::Uuid;
 
@@ -27,41 +24,12 @@ impl From<tungstenite::Error> for NodeError {
 type WebSocket = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
 /// The opened session. Thin wrapper around tungstenite web-socket stream.
-///
-/// When [`WebSocketSession::send`] or [`WebSocketSession::read`] returns an error, the implementation will try to send a `Close` frame. You don't need to do that at callsite.
 pub(crate) struct WebSocketSession {
     pub(crate) service: String,
     inner: WebSocket,
 }
 
 impl WebSocketSession {
-    /// Tries to close the websocket on a best effort basis by sending a close-frame to the server and initiating tear down.
-    async fn best_effort_close(&mut self, code: CloseCode) {
-        if let Err(err) = self
-            .inner
-            .close(Some(CloseFrame {
-                code,
-                reason: "".into(),
-            }))
-            .await
-        {
-            tracing::trace!(
-                "Received an error when trying to best effort close {}: {err}",
-                self.service
-            );
-        }
-    }
-
-    /// Calls [`Self::best_effort_close`] and returns an [`NodeError::UnexpectedMessage`] with the provided reason.
-    async fn protocol_error<T>(&mut self, reason: T) -> NodeError
-    where
-        String: From<T>,
-    {
-        let reason = String::from(reason);
-        self.best_effort_close(CloseCode::Unsupported).await;
-
-        NodeError::UnexpectedMessage { reason }
-    }
     /// Creates a new session at the provided endpoint.
     pub(crate) async fn new(
         endpoint: Uri,
@@ -83,13 +51,10 @@ impl WebSocketSession {
     }
 
     /// Attempts to send the provided message to the web-socket.
-    ///
-    /// On error tries to send a `Close` frame.
     pub(crate) async fn send<Msg: Serialize>(&mut self, msg: Msg) -> Result<(), NodeError> {
         let mut buf = Vec::new();
         ciborium::into_writer(&msg, &mut buf).expect("Can serialize msg");
         if let Err(err) = self.inner.send(tungstenite::Message::binary(buf)).await {
-            self.best_effort_close(CloseCode::Error).await;
             Err(NodeError::WsError(Box::new(err)))
         } else {
             Ok(())
@@ -97,20 +62,18 @@ impl WebSocketSession {
     }
 
     /// Attempts to read the provided message from the web-socket.
-    ///
-    /// On error tries to send a `Close` frame.
     pub(crate) async fn read<Msg: for<'de> Deserialize<'de>>(&mut self) -> Result<Msg, NodeError> {
         let msg = match self.inner.next().await {
             Some(Ok(msg)) => msg,
             Some(Err(err)) => {
-                self.best_effort_close(CloseCode::Error).await;
                 return Err(err.into());
             }
             None => {
-                tracing::trace!("Cannot receive frame - closed without sending close-frame");
-                self.best_effort_close(CloseCode::Error).await;
+                tracing::trace!(
+                    "Server closed connection during protocol while waiting for another message"
+                );
                 return Err(NodeError::WsError(Box::new(tungstenite::Error::Io(
-                    std::io::Error::other("server closed connection without sending close-frame"),
+                    std::io::Error::other("unexpected connection close by server"),
                 ))));
             }
         };
@@ -118,23 +81,21 @@ impl WebSocketSession {
         match msg {
             tungstenite::Message::Binary(bytes) => match ciborium::from_reader(bytes.as_ref()) {
                 Ok(msg) => Ok(msg),
-                Err(_) => Err(self
-                    .protocol_error("could not parse message from server")
-                    .await),
+                Err(_) => Err(NodeError::UnexpectedMessage {
+                    reason: "could not parse message from server",
+                }),
             },
-
             tungstenite::Message::Close(frame) => {
+                tracing::trace!("server send close frame - tearing down connection");
                 if let Some(frame) = frame
                     && frame.code != CloseCode::Normal
                 {
-                    self.best_effort_close(CloseCode::Normal).await;
                     Err(NodeError::ServiceError(ServiceError {
                         error_code: u16::from(frame.code),
                         msg: (!frame.reason.is_empty()).then(|| frame.reason.to_string()),
                         kind: oprf_types::api::OprfErrorKind::from(u16::from(frame.code)),
                     }))
                 } else {
-                    self.best_effort_close(CloseCode::Error).await;
                     Err(NodeError::WsError(Box::new(tungstenite::Error::Io(
                         std::io::Error::other(
                             "Server closed websocket without finishing protocol - EOF",
@@ -142,15 +103,12 @@ impl WebSocketSession {
                     ))))
                 }
             }
-
-            tungstenite::Message::Text(_) => Err(self.protocol_error("text frame received").await),
-
-            _ => Err(self.protocol_error("non-binary frame received").await),
+            tungstenite::Message::Text(_) => Err(NodeError::UnexpectedMessage {
+                reason: "text frame received",
+            }),
+            _ => Err(NodeError::UnexpectedMessage {
+                reason: "non-binary frame received",
+            }),
         }
-    }
-
-    /// Gracefully closes the web-socket by sending a `Close` frame with `CloseCode::Normal`.
-    pub(crate) async fn graceful_close(mut self) {
-        self.best_effort_close(CloseCode::Normal).await;
     }
 }

--- a/oprf-client/src/ws/wasm.rs
+++ b/oprf-client/src/ws/wasm.rs
@@ -10,8 +10,9 @@
 //! - **Protocol version**: The browser WebSocket API does not support custom HTTP
 //!   headers during the upgrade handshake. The protocol version is sent as a
 //!   query parameter (`?version=<version>`) instead.
-//! - **Close frames**: The browser manages the WebSocket close handshake. Unlike
-//!   the native implementation, we do not explicitly send close frames on errors.
+//! - **Close frames**: Like the native client, this implementation does not send
+//!   close frames on errors. The server drives teardown; the browser manages the
+//!   underlying TCP close.
 
 use crate::{Connector, NodeError, ServiceError};
 use futures::{SinkExt, StreamExt};
@@ -32,19 +33,9 @@ pub(crate) struct WebSocketSession {
 }
 
 impl WebSocketSession {
-    /// Tries to close the sink on a best effort basis.
-    async fn silent_close(&mut self) {
-        if let Err(err) = self.write.close().await {
-            tracing::trace!(
-                "Received an error when trying to best effort close {}: {err:?}",
-                self.service
-            );
-        }
-    }
-
     /// Creates a new session at the provided endpoint.
     ///
-    /// Expects a valid `ws://` or `wss://` URI  
+    /// Expects a valid `ws://` or `wss://` URI
     #[allow(
         clippy::unused_async,
         reason = "Want to have async to have equivalent signature with native"
@@ -75,13 +66,10 @@ impl WebSocketSession {
     }
 
     /// Attempts to send the provided message to the web-socket.
-    ///
-    /// On error tries to close the sink.
     pub(crate) async fn send<Msg: Serialize>(&mut self, msg: Msg) -> Result<(), NodeError> {
         let mut buf = Vec::new();
         ciborium::into_writer(&msg, &mut buf).expect("Can serialize msg");
         if let Err(e) = self.write.send(Message::Bytes(buf)).await {
-            self.silent_close().await;
             Err(NodeError::WsError(Box::new(std::io::Error::other(
                 format!("send failed: {e:?}"),
             ))))
@@ -97,21 +85,16 @@ impl WebSocketSession {
                 if let Ok(msg) = ciborium::from_reader::<Msg, _>(bytes.as_slice()) {
                     Ok(msg)
                 } else {
-                    self.silent_close().await;
                     Err(NodeError::UnexpectedMessage {
-                        reason: "could not parse message from server".to_owned(),
+                        reason: "could not parse message from server",
                     })
                 }
             }
-            Some(Ok(Message::Text(_))) => {
-                self.silent_close().await;
-                Err(NodeError::UnexpectedMessage {
-                    reason: "text frame received".to_owned(),
-                })
-            }
+            Some(Ok(Message::Text(_))) => Err(NodeError::UnexpectedMessage {
+                reason: "text frame received",
+            }),
             Some(Err(WebSocketError::ConnectionClose(event))) => {
                 tracing::trace!("did get close frame: code={}", event.code);
-                self.silent_close().await;
                 if event.code == CLOSE_CODE_NORMAL {
                     Err(NodeError::WsError(Box::new(std::io::Error::other(
                         "Server closed websocket without finishing protocol - EOF",
@@ -124,22 +107,12 @@ impl WebSocketSession {
                     }))
                 }
             }
-            Some(Err(e)) => {
-                self.silent_close().await;
-                Err(NodeError::WsError(Box::new(std::io::Error::other(
-                    format!("read failed: {e:?}"),
-                ))))
-            }
+            Some(Err(e)) => Err(NodeError::WsError(Box::new(std::io::Error::other(
+                format!("read failed: {e:?}"),
+            )))),
             None => Err(NodeError::WsError(Box::new(std::io::Error::other(
                 "server closed connection without sending close-frame",
             )))),
         }
-    }
-
-    /// Gracefully closes the web-socket.
-    pub(crate) async fn graceful_close(mut self) {
-        // Close the sink, which triggers the browser's WebSocket close handshake.
-        // We ignore the result as this is best effort close anyways.
-        let _result = self.write.close().await;
     }
 }

--- a/oprf-service/src/api/oprf.rs
+++ b/oprf-service/src/api/oprf.rs
@@ -43,6 +43,7 @@ pub(crate) struct OprfModuleState<ReqAuth> {
     pub(crate) version_req: VersionReq,
     pub(crate) max_message_size: usize,
     pub(crate) max_connection_lifetime: Duration,
+    pub(crate) websocket_shutdown_timeout: Duration,
 }
 
 impl<ReqAuth> Clone for OprfModuleState<ReqAuth> {
@@ -56,6 +57,7 @@ impl<ReqAuth> Clone for OprfModuleState<ReqAuth> {
             version_req: self.version_req.clone(),
             max_message_size: self.max_message_size,
             max_connection_lifetime: self.max_connection_lifetime,
+            websocket_shutdown_timeout: self.websocket_shutdown_timeout,
         }
     }
 }
@@ -123,57 +125,8 @@ async fn oprf_ws_handler<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
             .on_failed_upgrade(|err| {
                 tracing::warn!(user_error=true, %err, "could not establish websocket connection");
             })
-            .on_upgrade(move |mut ws| {
-                async move {
-                    let close_frame = match tokio::time::timeout(
-                        state.max_connection_lifetime,
-                        partial_oprf::<ReqAuth>(
-                            &mut ws,
-                            state.party_id,
-                            state.threshold,
-                            state.open_sessions,
-                            state.oprf_material_store,
-                            state.req_auth_service,
-                        ),
-                    )
-                    .await
-                    {
-                        Ok(Ok(session_id)) => {
-                            tracing::trace!("successfully created nullifier for {session_id}");
-                            metrics::request::inc_success();
-                            Some(CloseFrame {
-                                code: close_code::NORMAL,
-                                reason: "success".into(),
-                            })
-                        }
-                        Ok(Err(err)) => err.into_close_frame(),
-                        Err(_) => {
-                            tracing::trace!("session ran into timeout");
-                            metrics::request::inc_client_timeout();
-                            Some(CloseFrame {
-                                code: oprf_error_codes::TIMEOUT,
-                                reason: "timeout".into(),
-                            })
-                        }
-                    };
-                    if let Some(close_frame) = close_frame {
-                        tracing::trace!("sending close frame");
-                        if ws.send(ws::Message::Close(Some(close_frame))).await.is_ok() {
-                            // We expect the very next message to be a close frame - we keep the ws connection open so that an honest client can tear down its connection gracefully
-                            match tokio::time::timeout(state.max_connection_lifetime, ws.recv())
-                                .await
-                            {
-                                Ok(Some(Ok(ws::Message::Close(_))) | None) => tracing::trace!("successfully tore down web-socket connection"),
-                                Ok(Some(Ok(frame))) => {
-                                    tracing::debug!("got unexpected frame from client: {frame:?}");
-                                }
-                                Ok(Some(Err(err))) => tracing::trace!("web-socket connection error while waiting for close frame in teardown: {err}"),
-                                Err(_) => tracing::debug!("client did not send close frame in time"),
-                            }
-                        }
-                    }
-                }
-                .instrument(parent_span)
+            .on_upgrade(move |ws| {
+                async move { partial_oprf(ws, state).await }.instrument(parent_span)
             })
     } else {
         let msg = format!(
@@ -186,6 +139,83 @@ async fn oprf_ws_handler<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
     }
 }
 
+async fn partial_oprf<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
+    mut socket: WebSocket,
+    state: OprfModuleState<ReqAuth>,
+) {
+    let close_frame = match tokio::time::timeout(
+        state.max_connection_lifetime,
+        partial_oprf_inner::<ReqAuth>(
+            &mut socket,
+            state.party_id,
+            state.threshold,
+            state.open_sessions,
+            state.oprf_material_store,
+            state.req_auth_service,
+        ),
+    )
+    .await
+    {
+        Ok(Ok(session_id)) => {
+            tracing::trace!("successfully created nullifier for {session_id}");
+            metrics::request::inc_success();
+            Some(CloseFrame {
+                code: close_code::NORMAL,
+                reason: "success".into(),
+            })
+        }
+        Ok(Err(err)) => err.into_close_frame(),
+        Err(_) => {
+            tracing::trace!("session ran into timeout");
+            metrics::request::inc_client_timeout();
+            Some(CloseFrame {
+                code: oprf_error_codes::TIMEOUT,
+                reason: "timeout".into(),
+            })
+        }
+    };
+
+    if tokio::time::timeout(
+        state.websocket_shutdown_timeout,
+        teardown_websocket(socket, close_frame),
+    )
+    .await
+    .is_err()
+    {
+        tracing::trace!("timeout during web-socket teardown");
+    }
+}
+
+#[instrument(level = "info", skip_all)]
+async fn teardown_websocket(mut ws: WebSocket, close_frame: Option<CloseFrame>) {
+    tracing::trace!("initiating teardown websocket");
+
+    if let Some(close_frame) = close_frame {
+        tracing::trace!("sending close frame: {close_frame:?}");
+        if let Err(err) = ws.send(ws::Message::Close(Some(close_frame))).await {
+            tracing::trace!(?err, "received error during sending close frame");
+            return;
+        }
+    }
+
+    while let Some(msg) = ws.recv().await {
+        match msg {
+            Ok(ws::Message::Close(close)) => {
+                tracing::trace!("client send close frame: {close:?}");
+            }
+            Ok(message) => {
+                tracing::debug!("unexpected frame by client during teardown drain: {message:?}");
+            }
+            Err(_) => {
+                tracing::trace!("client went away - web-socket connection closed");
+                return;
+            }
+        }
+    }
+
+    tracing::trace!("successfully tore down web-socket connection");
+}
+
 /// The whole life-cycle of a single user session.
 ///
 /// 1) Read the [`OprfRequest`] of the user. Accepts `Text` and `Binary` frames and deserializes the request with `json` or `cbor` respectively.
@@ -196,7 +226,8 @@ async fn oprf_ws_handler<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
 /// 6) Finalizes the proof share for the session and sends it back to the user (same serialization as the initial request of the user).
 ///
 /// Clients may and will close the connection at any point because they only need `threshold` amount of sessions, therefore it is very much expected that sane clients send a `Close` frame at any point (or simply drop the connection). This method handles this gracefully at any point.
-async fn partial_oprf<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
+#[instrument(level = "info", skip_all, name = "partial_oprf")]
+async fn partial_oprf_inner<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
     socket: &mut WebSocket,
     party_id: PartyId,
     threshold: NonZeroU16,
@@ -244,7 +275,7 @@ async fn partial_oprf<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
     Ok(request_id)
 }
 
-#[instrument(level = "debug", skip_all)]
+#[instrument(level = "info", skip_all)]
 async fn init_session<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
     init_request: OprfRequest<ReqAuth>,
     party_id: PartyId,
@@ -277,7 +308,7 @@ async fn init_session<ReqAuth: for<'de> Deserialize<'de> + Send + 'static>(
     Ok((session, response))
 }
 
-#[instrument(level = "debug", skip_all)]
+#[instrument(level = "info", skip_all)]
 async fn challenge(
     challenge: DLogCommitmentsShamir,
     request_id: Uuid,
@@ -317,7 +348,7 @@ async fn challenge(
 ///
 /// # Errors
 /// Returns the corresponding error if either the peer closes the connection (gracefully with a `Close` frame or not) or if the `Msg` cannot be serialized with the corresponding format.
-#[instrument(level = "debug", skip_all)]
+#[instrument(level = "info", skip_all)]
 async fn read_request<Msg: for<'de> Deserialize<'de>>(
     socket: &mut WebSocket,
 ) -> Result<(Msg, HumanReadable), Error> {
@@ -335,7 +366,7 @@ async fn read_request<Msg: for<'de> Deserialize<'de>>(
 }
 
 /// Attempts to write a `Msg` to the web-socket. Depending on `human_readable` either sends a `Text` (`json`) frame or `Binary` (`cbor`) frame.
-#[instrument(level = "debug", skip_all)]
+#[instrument(level = "info", skip_all)]
 async fn write_response<Msg: Serialize>(
     response: Msg,
     human_readable: HumanReadable,

--- a/oprf-service/src/config.rs
+++ b/oprf-service/src/config.rs
@@ -53,6 +53,15 @@ pub struct OprfNodeServiceConfig {
     #[serde(with = "humantime_serde")]
     pub session_lifetime: Duration,
 
+    /// Max time to wait for a graceful shutdown of the web-socket connection.
+    ///
+    /// This duration defines how long the web-socket connection stays alive until after one of the parties initiated a shutdown.
+    ///
+    /// Defaults to `10 s`.
+    #[serde(default = "OprfNodeServiceConfig::default_websocket_shutdown_timeout")]
+    #[serde(with = "humantime_serde")]
+    pub websocket_shutdown_timeout: Duration,
+
     /// Max time for HTTP requests.
     ///
     /// In contrast to `session_lifetime`, this timeout addresses HTTP requests, e.g. `health`, `info` routes but also the web-socket upgrade requests.
@@ -107,6 +116,11 @@ impl OprfNodeServiceConfig {
         Duration::from_secs(30)
     }
 
+    /// Default websocket shutdown timeout (`10 s`).
+    fn default_websocket_shutdown_timeout() -> Duration {
+        Duration::from_secs(10)
+    }
+
     /// Default http request timeout (`20 s`).
     fn default_http_request_timeout() -> Duration {
         Duration::from_secs(20)
@@ -139,6 +153,7 @@ impl OprfNodeServiceConfig {
             environment,
             version_req,
             ws_max_message_size: Self::default_ws_max_message_size(),
+            websocket_shutdown_timeout: Self::default_websocket_shutdown_timeout(),
             session_lifetime: Self::default_session_lifetime(),
             http_request_timeout: Self::default_http_request_timeout(),
             i_am_alive_interval: Self::default_i_am_alive_interval(),

--- a/oprf-service/src/lib.rs
+++ b/oprf-service/src/lib.rs
@@ -182,6 +182,7 @@ impl OprfServiceBuilder {
                 version_req: self.config.version_req.clone(),
                 max_message_size: self.config.ws_max_message_size,
                 max_connection_lifetime: self.config.session_lifetime,
+                websocket_shutdown_timeout: self.config.websocket_shutdown_timeout,
                 open_sessions: self.open_sessions.clone(),
             }),
         );


### PR DESCRIPTION
- **refactor(node): graceful shutdown fix for web-sockets**
- **refactor(client): native impl for graceful shutdown web-socket**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes distributed OPRF connection lifecycle on both client and server; misaligned deploys or teardown timeouts could affect connection cleanup and error reporting, though crypto protocol logic is largely unchanged.
> 
> **Overview**
> **Shifts OPRF WebSocket shutdown so the server owns the close handshake** instead of clients sending close frames on errors or after the second protocol round.
> 
> On **oprf-service**, session handling is split into protocol work (`partial_oprf_inner`) and post-session **`teardown_websocket`**: the server sends a close frame (success, error, or timeout), then **drains** incoming frames until the peer closes or the connection errors. That drain is capped by a new config field **`websocket_shutdown_timeout`** (default **10s**), wired through `OprfModuleState` and `OprfNodeServiceConfig`.
> 
> On **oprf-client** (native and WASM), **best-effort / graceful client close** is removed from `WebSocketSession`; **`finish_session`** no longer closes sockets after the finalize read. Unexpected-message reasons use **`&'static str`** so threshold aggregation can return consensus without allocating. Docs and log messages reflect **server-driven teardown**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ac385afb0d3f75fd7c02e5ac08d03032f93476e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->