### PR TITLE
test: use debug build for scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - run: cd contracts && forge install && forge build
       - name: E2E test
         env:
-          PROFILE: ci-dev
+          PROFILE: release
         run: bash scripts/run-setup.sh e2e-test
 
   backfill-monkey-test:
@@ -106,7 +106,7 @@ jobs:
       - run: cd contracts && forge install && forge build
       - name: Backfill Monkey Test
         env:
-          PROFILE: ci-dev
+          PROFILE: release
         run: bash scripts/run-backfill-monkey-test.sh
 
   # Aggregator job — make this the single required check in branch protection.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
       - uses: foundry-rs/foundry-toolchain@v1
       - run: cd contracts && forge install && forge build
       - name: E2E test
+        env:
+          PROFILE: ci-dev
         run: bash scripts/run-setup.sh e2e-test
 
   backfill-monkey-test:
@@ -103,6 +105,8 @@ jobs:
         run: cargo install sqlx-cli --locked --no-default-features --features postgres
       - run: cd contracts && forge install && forge build
       - name: Backfill Monkey Test
+        env:
+          PROFILE: ci-dev
         run: bash scripts/run-backfill-monkey-test.sh
 
   # Aggregator job — make this the single required check in branch protection.

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -16,13 +16,12 @@ COMPOSE_FILE="${COMPOSE_FILE:-./oprf-service/examples/deploy/docker-compose.yml}
 LOG_TAG="${LOG_TAG:-[oprf]}"
 LOG_DIR="${LOG_DIR:-logs}"
 
-if [[ -n "${RELEASE:-}" ]]; then
-    CARGO_BUILD_ARGS=(--release)
-    BUILD_TARGET_DIR="release"
-else
-    CARGO_BUILD_ARGS=()
-    BUILD_TARGET_DIR="debug"
-fi
+PROFILE="${PROFILE:-dev}"
+case "$PROFILE" in
+    dev)     CARGO_BUILD_ARGS=();                    BUILD_TARGET_DIR="debug" ;;
+    release) CARGO_BUILD_ARGS=(--release);           BUILD_TARGET_DIR="release" ;;
+    *)       CARGO_BUILD_ARGS=(--profile "$PROFILE"); BUILD_TARGET_DIR="$PROFILE" ;;
+esac
 
 node_private_keys=(
     "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -16,12 +16,12 @@ COMPOSE_FILE="${COMPOSE_FILE:-./oprf-service/examples/deploy/docker-compose.yml}
 LOG_TAG="${LOG_TAG:-[oprf]}"
 LOG_DIR="${LOG_DIR:-logs}"
 
-if [[ -n "${DEBUG_KEYGEN:-}" ]]; then
-    KEYGEN_CARGO_BUILD_ARGS=()
-    KEYGEN_BUILD_TARGET_DIR="debug"
+if [[ -n "${RELEASE:-}" ]]; then
+    CARGO_BUILD_ARGS=(--release)
+    BUILD_TARGET_DIR="release"
 else
-    KEYGEN_CARGO_BUILD_ARGS=(--release)
-    KEYGEN_BUILD_TARGET_DIR="release"
+    CARGO_BUILD_ARGS=()
+    BUILD_TARGET_DIR="debug"
 fi
 
 node_private_keys=(
@@ -343,7 +343,7 @@ start_keygen_node() {
     TACEO_OPRF_KEY_GEN__POSTGRES__CONNECTION_STRING="$POSTGRES_URL" \
     TACEO_OPRF_KEY_GEN__POSTGRES__SCHEMA="$schema" \
     "${dd_env[@]+"${dd_env[@]}"}" \
-    ./target/${KEYGEN_BUILD_TARGET_DIR}/taceo-oprf-key-gen >>"$LOG_DIR/key-gen${i}.log" 2>&1 &
+    ./target/${BUILD_TARGET_DIR}/taceo-oprf-key-gen >>"$LOG_DIR/key-gen${i}.log" 2>&1 &
     keygen_pids[$i]="$!"
     log "started key-gen${i} with PID ${keygen_pids[$i]}"
 }
@@ -401,7 +401,7 @@ start_oprf_service_nodes() {
         TACEO_OPRF_NODE__SERVICE__STORE_TTI=0s \
         TACEO_OPRF_NODE__BIND_ADDR="0.0.0.0:${port}" \
         "${dd_env[@]+"${dd_env[@]}"}" \
-        ./target/release/examples/taceo-oprf-service-example >"$LOG_DIR/node${i}.log" 2>&1 &
+        ./target/${BUILD_TARGET_DIR}/examples/taceo-oprf-service-example >"$LOG_DIR/node${i}.log" 2>&1 &
         nodes_pids[$i]="$!"
         log "started node${i} with PID ${nodes_pids[$i]} (wallet $wallet)"
     done
@@ -417,7 +417,16 @@ docker_psql() {
 
 build_keygen_binary() {
     log "Building taceo-oprf-key-gen"
-    cargo build "${KEYGEN_CARGO_BUILD_ARGS[@]+"${KEYGEN_CARGO_BUILD_ARGS[@]}"}" --bin taceo-oprf-key-gen >"$LOG_DIR/build-keygen.log" 2>&1
+    cargo build "${CARGO_BUILD_ARGS[@]+"${CARGO_BUILD_ARGS[@]}"}" --bin taceo-oprf-key-gen >"$LOG_DIR/build-keygen.log" 2>&1
+}
+
+build_setup_binaries() {
+    log "Building OPRF binaries (${BUILD_TARGET_DIR})"
+    cargo build "${CARGO_BUILD_ARGS[@]+"${CARGO_BUILD_ARGS[@]}"}" \
+        -p taceo-oprf-key-gen --bin taceo-oprf-key-gen \
+        -p taceo-oprf-service --example taceo-oprf-service-example \
+        -p taceo-oprf-dev-client --example dev-client-example \
+        >"$LOG_DIR/build.log" 2>&1
 }
 
 prepare_keygen_db() {

--- a/scripts/run-setup.sh
+++ b/scripts/run-setup.sh
@@ -16,10 +16,7 @@ RUN_MODE="${1:-sleep}"
 run_deploy() {
     deploy_key_registry
 
-    cargo clean --workspace
-    cargo build --release --example taceo-oprf-service-example
-    cargo build --release --example dev-client-example
-    build_keygen_binary
+    build_setup_binaries
 
     log "starting keygen"
     # need to start key-gen before nodes because they run DB migrations
@@ -44,11 +41,11 @@ main() {
     if [[ "$RUN_MODE" == "e2e-test" ]]; then
         log "Running dev-client tests"
         export OPRF_DEV_CLIENT_OPRF_KEY_REGISTRY_CONTRACT=$DEPLOYED_ADDRESS
-        export RUST_LOG="taceo=trace,dev_client_example=trace,warn"
-        ./target/release/examples/dev-client-example reshare-test
-        ./target/release/examples/dev-client-example stress-test-oprf
-        ./target/release/examples/dev-client-example stress-test-key-gen
-        ./target/release/examples/dev-client-example delete-test
+        export RUST_LOG="taceo=info,dev_client_example=info,warn"
+        ./target/${BUILD_TARGET_DIR}/examples/dev-client-example reshare-test
+        ./target/${BUILD_TARGET_DIR}/examples/dev-client-example stress-test-oprf
+        ./target/${BUILD_TARGET_DIR}/examples/dev-client-example stress-test-key-gen
+        ./target/${BUILD_TARGET_DIR}/examples/dev-client-example delete-test
         log "Dev-client tests completed successfully"
     else
         log "No dev-client tests requested, entering sleep mode. Press Ctrl+C to stop"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI and local tooling only; behavior change is faster local debug defaults with CI still on release—no production service logic changes.
> 
> **Overview**
> Introduces a **`PROFILE`** environment variable in `scripts/lib.sh` (default **`dev`** → debug builds) that replaces the old **`DEBUG_KEYGEN`** toggle and separate key-gen build paths. **`dev`**, **`release`**, and custom Cargo profiles all map to shared **`CARGO_BUILD_ARGS`** / **`BUILD_TARGET_DIR`**, which key-gen, OPRF service example, and dev-client binaries now use consistently instead of hardcoding **`target/release`**.
> 
> **`run-setup.sh`** drops **`cargo clean`** and separate release example builds in favor of **`build_setup_binaries`**, a single workspace build for key-gen, service example, and dev-client. E2E runs use **`./target/${BUILD_TARGET_DIR}/...`** and lower **`RUST_LOG`** from trace to info for dev-client tests.
> 
> **CI** sets **`PROFILE: release`** on the E2E and backfill-monkey-test jobs so those pipelines still exercise release artifacts; local script runs default to faster debug builds unless overridden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fa0d191bf96ab2473c7a165865611ae9e53dd2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->