### PR TITLE
themis/remove i am alive config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,9 +2238,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/oprf-key-gen/src/config.rs
+++ b/oprf-key-gen/src/config.rs
@@ -23,7 +23,6 @@
 //! | `confirmations_for_transaction`          | 5           |
 //! | `max_tries_fetching_receipt`             | 5           |
 //! | `sleep_between_get_receipt`              | 5 s         |
-//! | `i_am_alive_interval`                    | 60 s        |
 //! | `cursor_checkpoint_interval`             | 1 day       |
 
 use std::num::NonZeroU16;
@@ -113,13 +112,6 @@ pub struct OprfKeyGenServiceConfig {
     #[serde(with = "humantime_serde")]
     pub sleep_between_get_receipt: Duration,
 
-    /// Interval in which we emit "I am alive" metric.
-    ///
-    /// Defaults to `60 s`.
-    #[serde(default = "OprfKeyGenServiceConfig::default_i_am_alive_interval")]
-    #[serde(with = "humantime_serde")]
-    pub i_am_alive_interval: Duration,
-
     /// Interval in which we persist a [`ChainCursor`](nodes_common::web3::event_stream::ChainCursor) checkpoint.
     ///
     /// The implementation will fetch the current block number, then sleep for this configured period, and then call [`ChainCursorStorage::store_chain_cursor`](crate::event_cursor_store::ChainCursorStorage::store_chain_cursor) with the fetched block number. This should prevent very large backfills in case of idle key-gens.
@@ -203,11 +195,6 @@ impl OprfKeyGenServiceConfig {
         Duration::from_secs(5)
     }
 
-    /// Default I-am-alive interval (`60 s`).
-    fn default_i_am_alive_interval() -> Duration {
-        Duration::from_mins(1)
-    }
-
     /// Default cursor checkpoint interval (`1 day`).
     fn default_cursor_checkpoint_interval() -> Duration {
         Duration::from_hours(24)
@@ -241,7 +228,6 @@ impl OprfKeyGenServiceConfig {
                 Self::default_max_wait_time_transaction_confirmation(),
             max_gas_per_transaction: Self::default_max_gas_per_transaction(),
             confirmations_for_transaction: Self::default_confirmations_for_transaction(),
-            i_am_alive_interval: Self::default_i_am_alive_interval(),
             max_tries_fetching_receipt: Self::default_max_tries_fetching_receipt(),
             sleep_between_get_receipt: Self::default_sleep_between_get_receipt(),
             event_stream_config: EventStreamConfig::default(),

--- a/oprf-key-gen/src/lib.rs
+++ b/oprf-key-gen/src/lib.rs
@@ -201,8 +201,6 @@ async fn contract_sanity_checks(
 /// - `key_event_watcher` – subscribes to the `OprfKeyRegistry` contract events and
 ///   drives the key generation / resharing protocol. Backfills missed events from the
 ///   last persisted chain cursor.
-/// - `i_am_alive` – periodically emits a metric once all services have started,
-///   used as a basic liveness indicator.
 ///
 /// # Returns
 /// Returns:

--- a/oprf-service/src/config.rs
+++ b/oprf-service/src/config.rs
@@ -14,7 +14,6 @@
 //! |----------------------------------|------------|
 //! | `ws_max_message_size`            | 1024 bytes |
 //! | `session_lifetime`               | 30 s       |
-//! | `i_am_alive_interval`            | 60 s       |
 //! | `store_max_capacity`             | 10_000     |
 //! | `store_ttl`                      | 1 day      |
 //! | `store_tti`                      | 1 h        |
@@ -71,13 +70,6 @@ pub struct OprfNodeServiceConfig {
     #[serde(with = "humantime_serde")]
     pub http_request_timeout: Duration,
 
-    /// Interval in which we emit "I am alive" metric.
-    ///
-    /// Defaults to `60 s`.
-    #[serde(default = "OprfNodeServiceConfig::default_i_am_alive_interval")]
-    #[serde(with = "humantime_serde")]
-    pub i_am_alive_interval: Duration,
-
     /// Max capacity for the key-material store.
     #[serde(default = "OprfNodeServiceConfig::default_store_max_capacity")]
     pub store_max_capacity: u64,
@@ -126,11 +118,6 @@ impl OprfNodeServiceConfig {
         Duration::from_secs(20)
     }
 
-    /// Default I-am-alive interval (`60 s`).
-    fn default_i_am_alive_interval() -> Duration {
-        Duration::from_mins(1)
-    }
-
     /// Default max capacity for share cache (`10_000`).
     fn default_store_max_capacity() -> u64 {
         10_000
@@ -156,7 +143,6 @@ impl OprfNodeServiceConfig {
             websocket_shutdown_timeout: Self::default_websocket_shutdown_timeout(),
             session_lifetime: Self::default_session_lifetime(),
             http_request_timeout: Self::default_http_request_timeout(),
-            i_am_alive_interval: Self::default_i_am_alive_interval(),
             store_max_capacity: Self::default_store_max_capacity(),
             store_ttl: Self::default_store_ttl(),
             store_tti: Self::default_store_tti(),


### PR DESCRIPTION
- **refactor(key-gen)!: remove dead i am alive config**
- **refactor(service)!: remove dead i am alive config**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only cleanup with no runtime behavior change; breaking only for configs that still reference the removed field.
> 
> **Overview**
> Removes the unused **`i_am_alive_interval`** configuration from **`OprfKeyGenServiceConfig`** and **`OprfNodeServiceConfig`**, including serde fields, default helpers, defaults tables in module docs, and **`with_default_values`** wiring.
> 
> Key-gen service docs no longer mention an **`i_am_alive`** background task among spawned work.
> 
> **`Cargo.lock`** bumps **`crossbeam-epoch`** `0.9.18` → `0.9.20` (transitive dependency only).
> 
> **Breaking:** deployments that still set `i_am_alive_interval` in config must drop that key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dfd98563acd1d41e29136f3e5d9a4526455014d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->