### PR TITLE
feat(service)!: pass version_str to builder to get downstream version instead of service

### DIFF
--- a/oprf-service/examples/taceo-oprf-service-example.rs
+++ b/oprf-service/examples/taceo-oprf-service-example.rs
@@ -118,6 +118,7 @@ pub async fn start_service(
         secret_manager,
         StartedServices::default(),
         &node_information,
+        nodes_common::version_info!(),
     )
     .module("/example", Arc::new(ExampleOprfRequestAuthenticator))
     .build();

--- a/oprf-service/src/lib.rs
+++ b/oprf-service/src/lib.rs
@@ -109,6 +109,7 @@ impl OprfServiceBuilder {
         secret_manager: SecretManagerService,
         started_services: StartedServices,
         node_information: &NodeInformation,
+        version_str: String,
     ) -> Self {
         tracing::info!("init OPRF material-store..");
         let oprf_key_material_store = OprfKeyMaterialStore::new(
@@ -120,7 +121,6 @@ impl OprfServiceBuilder {
 
         tracing::info!("init oprf-service...");
 
-        let version_str = nodes_common::version_info!();
         let info_route = Router::new()
             .merge(nodes_common::api::routes_with_services(
                 started_services,

--- a/oprf-service/src/tests/setup.rs
+++ b/oprf-service/src/tests/setup.rs
@@ -127,6 +127,7 @@ impl TestNode {
                 OPRF_PEER_ADDRESS_0.to_string(),
                 setup.setup.threshold(),
             ),
+            nodes_common::version_info!(),
         )
         .module("/test", Arc::new(ConfigurableTestAuthenticator))
         .build();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Breaking API change for any external `OprfServiceBuilder::init` callers; behavior of `/version` now depends on what each host passes, which is intentional but must be updated at compile time.
> 
> **Overview**
> **Breaking change:** `OprfServiceBuilder::init` now takes a `version_str: String` argument instead of calling `nodes_common::version_info!()` inside the library.
> 
> Callers wire that string into `nodes_common::api::routes_with_services` for `GET /version` (and related info routes). Host binaries can expose **their** release version while still using `oprf-service` as a library.
> 
> The example binary and test setup pass `nodes_common::version_info!()` at the call site; other downstream services can supply a different string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 656849dc28af9e48f45f7c9f2198dccc80d43d82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->