### PR TITLE
Fg/delegate oprf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ checksum = "64b728d511962dda67c1bc7ea7c03736ec275ed2cf4c35d9585298ac9ccf3b73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -630,7 +630,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -648,7 +648,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha3",
- "syn 2.0.111",
+ "syn 2.0.118",
  "syn-solidity",
 ]
 
@@ -666,7 +666,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.111",
+ "syn 2.0.118",
  "syn-solidity",
 ]
 
@@ -775,7 +775,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -845,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ark-bn254"
@@ -892,7 +892,7 @@ checksum = "e7e89fe77d1f0f4fe5b96dfc940923d88d17b6a773808124f21e764dfb063c6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1003,7 +1003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1041,7 +1041,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1148,7 +1148,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1237,7 +1237,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_derive",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1308,7 +1308,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1319,7 +1319,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1365,7 +1365,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1494,7 +1494,7 @@ dependencies = [
  "mime",
  "pretty_assertions",
  "reserve-port",
- "rust-multipart-rfc7578_2",
+ "rust-multipart-rfc7578_2 0.8.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1504,6 +1504,34 @@ dependencies = [
  "tower",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "axum-test"
+version = "20.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a86bfe2ef15bee102ac34912f7f4542b0bb37dc464fa55461763999c4d625e7"
+dependencies = [
+ "anyhow",
+ "axum",
+ "bytes",
+ "bytesize",
+ "cookie",
+ "expect-json",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "mime",
+ "pretty_assertions",
+ "reserve-port",
+ "rust-multipart-rfc7578_2 0.9.0",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tower",
+ "url",
 ]
 
 [[package]]
@@ -1771,7 +1799,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1794,7 +1822,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1891,10 +1919,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chrono"
-version = "0.4.42"
+name = "chacha20"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1984,7 +2023,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2309,7 +2348,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2343,7 +2382,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2357,7 +2396,7 @@ dependencies = [
  "quote",
  "serde",
  "strsim",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2368,7 +2407,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2379,7 +2418,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2453,7 +2492,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.111",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -2524,7 +2563,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2580,7 +2619,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2650,7 +2689,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2724,9 +2763,9 @@ dependencies = [
 
 [[package]]
 name = "expect-json"
-version = "1.8.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf3355a7ef83e52c9383ab0c7719acd1da54be5fed7c6572d87ddc4d8589753"
+checksum = "5e80819dbfe83c8a651f5344b08910d0037dac72988aef27ee4e6bedd7ae2e33"
 dependencies = [
  "chrono",
  "email_address",
@@ -2742,13 +2781,13 @@ dependencies = [
 
 [[package]]
 name = "expect-json-macros"
-version = "1.8.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ff9262e5b5f9760f60c57ada4fffd25201ae9fefd426f29f097dcc573d86e6"
+checksum = "c0637949cd816934f3b7aab44ff98e7ec1fb903c379e07dcb9eac943ec33499e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2906,9 +2945,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2916,9 +2955,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
@@ -2944,38 +2983,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2985,7 +3024,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -3042,6 +3080,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -3069,7 +3108,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3121,9 +3160,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3376,9 +3415,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3391,7 +3430,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -3443,14 +3481,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -3635,7 +3672,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3771,7 +3808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3937,7 +3974,7 @@ checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4183,7 +4220,7 @@ checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4345,7 +4382,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4399,7 +4436,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "structmeta",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4466,7 +4503,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4596,7 +4633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4638,7 +4675,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4689,7 +4726,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4765,9 +4802,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -4808,6 +4845,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4845,6 +4893,12 @@ dependencies = [
  "getrandom 0.3.4",
  "serde",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -4921,14 +4975,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4949,9 +5003,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -5024,9 +5078,9 @@ dependencies = [
 
 [[package]]
 name = "reserve-port"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21918d6644020c6f6ef1993242989bf6d4952d2e025617744f184c02df51c356"
+checksum = "71ea98a177596a4579881992bd2bd4af27772fc95d0e5f5668a8f9535eca6380"
 dependencies = [
  "thiserror 2.0.18",
 ]
@@ -5140,6 +5194,21 @@ dependencies = [
  "http",
  "mime",
  "rand 0.9.4",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rust-multipart-rfc7578_2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdaa068902270ca7fa8619775e1838e23a63620abac0947ce0f715819b8cec"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "mime",
+ "rand 0.10.2",
  "thiserror 2.0.18",
 ]
 
@@ -5493,7 +5562,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5528,7 +5597,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5571,7 +5640,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5774,7 +5843,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5797,7 +5866,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.111",
+ "syn 2.0.118",
  "tokio",
  "url",
 ]
@@ -5943,7 +6012,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5954,7 +6023,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5975,7 +6044,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6003,9 +6072,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6021,7 +6090,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6041,7 +6110,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6148,19 +6217,23 @@ dependencies = [
 
 [[package]]
 name = "taceo-nodes-common"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f588f7f9a52606e62ec32f75d8a01f8e43b85eca0e1744303503a9dbd21e4969"
+checksum = "15af1a54071def0649b8e55c8d87afff9cd537565345e939264313aeb7031fc1"
 dependencies = [
  "alloy",
  "axum",
+ "axum-test 20.0.0",
  "backon",
+ "eyre",
  "futures",
  "git-version",
  "humantime-serde",
+ "reserve-port",
  "secrecy",
  "serde",
  "sqlx",
+ "testcontainers-modules",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -6186,13 +6259,14 @@ version = "0.10.3"
 dependencies = [
  "ark-ec",
  "axum",
- "axum-test",
+ "axum-test 18.5.0",
  "ciborium",
  "futures",
  "getrandom 0.2.16",
  "gloo-net",
  "http",
  "rand 0.8.6",
+ "reqwest 0.13.2",
  "serde",
  "taceo-ark-babyjubjub",
  "taceo-oprf-core",
@@ -6202,6 +6276,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tracing",
+ "url",
  "uuid",
 ]
 
@@ -6268,7 +6343,7 @@ dependencies = [
  "ark-serialize 0.5.0",
  "async-trait",
  "axum",
- "axum-test",
+ "axum-test 18.5.0",
  "backon",
  "config",
  "eyre",
@@ -6302,12 +6377,13 @@ dependencies = [
 name = "taceo-oprf-service"
 version = "0.18.2"
 dependencies = [
+ "ark-ec",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "async-trait",
  "axum",
  "axum-extra",
- "axum-test",
+ "axum-test 18.5.0",
  "backon",
  "ciborium",
  "config",
@@ -6319,6 +6395,7 @@ dependencies = [
  "moka",
  "parking_lot",
  "rand 0.8.6",
+ "reqwest 0.13.2",
  "ruint",
  "rustls",
  "secrecy",
@@ -6339,6 +6416,7 @@ dependencies = [
  "tower-http 0.7.0",
  "tracing",
  "tungstenite",
+ "url",
  "uuid",
  "zeroize",
 ]
@@ -6539,7 +6617,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6550,7 +6628,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6681,7 +6759,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6807,9 +6885,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -6905,7 +6983,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7047,9 +7125,9 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "typetag"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf"
+checksum = "c5a897b12c6c1151ad0b138b8db50252dc301f93bc3b027db05eec82aeed298c"
 dependencies = [
  "erased-serde",
  "inventory",
@@ -7060,13 +7138,13 @@ dependencies = [
 
 [[package]]
 name = "typetag-impl"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
+checksum = "cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7174,14 +7252,15 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -7332,7 +7411,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -7502,7 +7581,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7513,7 +7592,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7817,7 +7896,7 @@ dependencies = [
  "heck",
  "indexmap 2.12.1",
  "prettyplease",
- "syn 2.0.111",
+ "syn 2.0.118",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -7833,7 +7912,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -7944,7 +8023,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -7965,7 +8044,7 @@ checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7985,7 +8064,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -8006,7 +8085,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8039,7 +8118,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ tokio-util = "0.7"
 tower-http = "0.7"
 tracing = { version = "0.1" }
 tungstenite = { version = "0.28" }
+url = { version = "2" }
 uuid = { version = "1" }
 webpki-roots = { version = "1.0" }
 zeroize = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ ark-groth16 = "0.5"
 ark-serde-compat = { package = "taceo-ark-serde-compat", version = "0.5", default-features = false }
 ark-serialize = "0.5"
 async-trait = "0.1"
-axum = "0.8"
+axum = "=0.8.8" # We pin this version because alloy pins a tokio-tungstenite version that needs 0.8.8
 axum-extra = "0.12"
 axum-test = "18"
 backon = { version = "1.6", default-features = false }
@@ -51,7 +51,7 @@ itertools = "0.15"
 k256 = "0.13"
 metrics = "0.24"
 moka = { version = "0.12", features = ["future"] }
-nodes-common = { package = "taceo-nodes-common", version = "0.7.3", default-features = false }
+nodes-common = { package = "taceo-nodes-common", version = "0.7.4", default-features = false }
 num-bigint = "0.4"
 parking_lot = "0.12"
 poseidon2 = { package = "taceo-poseidon2", version = "0.2", default-features = false }

--- a/oprf-client/Cargo.toml
+++ b/oprf-client/Cargo.toml
@@ -20,9 +20,11 @@ http = { workspace = true }
 oprf-core = { package = "taceo-oprf-core", path = "../oprf-core", version = "0.6" }
 oprf-types = { package = "taceo-oprf-types", path = "../oprf-types", version = "0.15", default-features = false }
 poseidon2 = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+url = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/oprf-client/src/lib.rs
+++ b/oprf-client/src/lib.rs
@@ -22,27 +22,34 @@
 
 //! This crate provides utility functions for clients of the distributed OPRF protocol.
 //!
-//! Most implementations will only need the [`distributed_oprf`] method. For more fine-grained workflows, we expose all necessary functions.
+//! Most implementations will only need the [`distributed_oprf`] method, or [`delegate_distributed_oprf`] if a single
+//! delegate node should perform the distributed OPRF protocol on the client's behalf. For more
+//! fine-grained workflows, we expose all necessary functions.
 use core::fmt;
 use std::collections::{HashMap, HashSet};
 
 use ark_ec::AffineRepr as _;
+use futures::stream::{FuturesUnordered, StreamExt as _};
 use oprf_core::{
     ddlog_equality::shamir::{DLogCommitmentsShamir, DLogProofShareShamir},
     dlog_equality::DLogEqualityProof,
     oprf::{BlindedOprfRequest, BlindedOprfResponse, BlindingFactor},
 };
 use oprf_types::{
-    ShareEpoch,
-    api::{OprfErrorKind, OprfRequest},
+    OprfKeyId, ShareEpoch,
+    api::{DelegateOprfResponse, OprfErrorKind, OprfPublicKeyWithEpoch, OprfRequest},
     crypto::OprfPublicKey,
 };
 use serde::Serialize;
 use tracing::instrument;
+use url::Url;
 use uuid::Uuid;
 
 mod sessions;
 mod ws;
+
+/// The version of this crate.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub use http::Uri;
 pub use http::uri::InvalidUri;
@@ -144,6 +151,108 @@ where
     services
         .into_iter()
         .map(|s| to_oprf_uri(s.as_ref(), &auth))
+        .collect()
+}
+
+/// Builds the delegate OPRF endpoint [`Url`].
+///
+/// Builds the URL for the delegate OPRF endpoint:
+/// - Normalizes trailing slashes
+/// - Appends `/api/{auth}/delegate`
+///
+/// # Arguments
+/// - `service`: Base URL of the service (e.g., `"https://example.com"`)
+/// - `auth`: Authentication module (e.g., `"issuer"`)
+///
+/// # Returns
+/// `Result<Url, url::ParseError>`
+///
+/// # Errors
+/// Returns `url::ParseError` when it is not possible to convert to [`Url`].
+///
+/// # Example
+/// ```
+/// # use url::Url;
+/// # use url::ParseError;
+/// # use taceo_oprf_client::to_delegate_oprf_url;
+/// let url = to_delegate_oprf_url("https://example.com", "issuer")?;
+/// assert_eq!(url.to_string(), "https://example.com/api/issuer/delegate");
+/// # Ok::<(), ParseError>(())
+/// ```
+pub fn to_delegate_oprf_url<Auth: fmt::Display>(
+    service: &str,
+    auth: Auth,
+) -> Result<Url, url::ParseError> {
+    // Remove trailing slash if any
+    let http_base = service.trim_end_matches('/');
+
+    let uri_str = format!("{http_base}/api/{auth}/delegate");
+    uri_str.parse::<Url>()
+}
+
+/// Builds the OPRF public-key info endpoint [`Url`].
+///
+/// Builds the URL for the endpoint exposing the [`OprfPublicKeyWithEpoch`].
+/// - Normalizes trailing slashes
+/// - Appends `/oprf_pub`
+///
+/// # Arguments
+/// - `service`: Base URL of the service (e.g., `"https://example.com"`)
+///
+/// # Returns
+/// `Result<Url, url::ParseError>`
+///
+/// # Errors
+/// Returns `url::ParseError` when it is not possible to convert to [`Url`].
+///
+/// # Example
+/// ```
+/// # use url::Url;
+/// # use url::ParseError;
+/// # use taceo_oprf_client::to_oprf_pub_key_url;
+/// let url = to_oprf_pub_key_url("https://example.com")?;
+/// assert_eq!(url.to_string(), "https://example.com/oprf_pub");
+/// # Ok::<(), ParseError>(())
+/// ```
+pub fn to_oprf_pub_key_url(service: &str) -> Result<Url, url::ParseError> {
+    // Remove trailing slash if any
+    let http_base = service.trim_end_matches('/');
+
+    let uri_str = format!("{http_base}/oprf_pub");
+    uri_str.parse::<Url>()
+}
+
+/// Builds the OPRF public-key info endpoint [`Url`]s for multiple services.
+///
+/// Calls [`to_oprf_pub_key_url`] for each service and collects the results. Returns the first encountered error if any service URL is invalid.
+///
+/// # Arguments
+/// - `services`: Iterable of service base URLs
+///
+/// # Returns
+/// `Result<Vec<Url>, url::ParseError>`
+///
+/// # Errors
+/// Returns `url::ParseError` when one of the service cannot be converted to URL.
+///
+/// # Example
+/// ```
+/// # use url::Url;
+/// # use url::ParseError;
+/// # use taceo_oprf_client::to_oprf_pub_key_url_many;
+/// let services = vec!["https://a.example.com", "https://b.example.com"];
+/// let urls = to_oprf_pub_key_url_many(services)?;
+/// assert_eq!(urls.len(), 2);
+/// # Ok::<(), ParseError>(())
+/// ```
+pub fn to_oprf_pub_key_url_many<S, I>(services: I) -> Result<Vec<Url>, url::ParseError>
+where
+    S: AsRef<str>,
+    I: IntoIterator<Item = S>,
+{
+    services
+        .into_iter()
+        .map(|s| to_oprf_pub_key_url(s.as_ref()))
         .collect()
 }
 
@@ -272,6 +381,20 @@ pub enum Error {
     /// Primarily included for forward compatibility and future-proofing.
     #[error("Unknown error: {0}")]
     Unknown(#[source] Box<dyn core::error::Error + Send + Sync + 'static>),
+    /// Represents a `reqwest` error when sending the request to the delegate service.
+    #[error(transparent)]
+    DelegateRequest(#[from] reqwest::Error),
+    /// Error that happened during the delegate request.
+    ///
+    /// If the nodes agreed on a [`ServiceError`] and returned it, the delegate service will forward that error to the client.
+    /// In that case, the client will return a [`Error::ThresholdServiceError`] instead.
+    #[error("Delegate service returned a error: status: {status}, reason: {reason}")]
+    DelegateServerError {
+        /// The HTTP status code returned by the delegate service.
+        status: reqwest::StatusCode,
+        /// The body of the response returned by the delegate service.
+        reason: String,
+    },
 }
 
 /// Aggregates errors returned by nodes.
@@ -421,20 +544,7 @@ pub async fn distributed_oprf<OprfRequestAuth>(
 where
     OprfRequestAuth: Clone + Serialize + 'static,
 {
-    tracing::trace!(
-        "starting distributed oprf. my version: {}",
-        env!("CARGO_PKG_VERSION")
-    );
-    if threshold == 0 || threshold > services.len() {
-        return Err(Error::InvalidThreshold {
-            num_peers: services.len(),
-            threshold,
-        });
-    }
-    let services_dedup = services.iter().collect::<HashSet<_>>();
-    if services_dedup.len() != services.len() {
-        return Err(Error::NonUniqueServices);
-    }
+    tracing::trace!("starting distributed oprf. my version: {}", VERSION);
 
     let request_id = Uuid::new_v4();
     let distributed_oprf_span = tracing::Span::current();
@@ -448,8 +558,193 @@ where
         auth,
     };
 
+    let (oprf_public_key, epoch, challenge, responses) =
+        distributed_oprf_core(services, threshold, oprf_req, connector).await?;
+
+    finalize_distributed_oprf(FinalizeDistributedOprfArgs {
+        request_id,
+        query,
+        blinding_factor,
+        domain_separator,
+        blinded_request,
+        challenge,
+        responses,
+        oprf_public_key,
+        epoch,
+    })
+}
+
+/// Executes the distributed OPRF protocol via a single delegate node over HTTP.
+///
+/// Instead of the client directly contacting every OPRF node and driving [`distributed_oprf_core`]
+/// itself, this function sends the (blinded) [`OprfRequest`] to a single delegate service. That
+/// delegate acts as the client of the distributed OPRF protocol on our behalf: it runs
+/// [`distributed_oprf_core`] against the OPRF nodes and forwards the combined result back to us
+/// as a [`DelegateOprfResponse`].
+///
+/// This function performs the following steps:
+/// 1. Blinds the input query using the provided blinding factor.
+/// 2. Sends the blinded query and authentication information to the delegate service via a single HTTP POST request.
+/// 3. Verifies the combined `DLog` equality proof from the services.
+/// 4. Unblinds the combined OPRF response using the blinding factor.
+/// 5. Computes the final OPRF output by hashing the original query and the unblinded response.
+///
+/// # Returns
+/// The final [`VerifiableOprfOutput`] containing the OPRF output, the `DLog` equality proof, and the blinded and unblinded responses.
+///
+/// # Arguments
+/// - `service`: URL of the delegate service that will run the distributed OPRF protocol on our behalf
+/// - `query`: The OPRF input value to evaluate
+/// - `blinding_factor`: The blinding factor used to blind the query
+/// - `domain_separator`: Domain separator used in the final Poseidon hash to derive the output
+/// - `auth`: Implementation specific authentication request forwarded to the delegate service as part of the request
+/// - `client`: The [`reqwest::Client`] used to send the request to the delegate service
+///
+/// # Timeout and Cancellation
+///
+/// This method does not implement any timeout policy. Callers are expected to
+/// enforce timeouts at a higher level (e.g., via `tokio::time::timeout`, by setting
+/// timeouts in `reqwest::Client` or equivalent mechanisms).
+///
+/// For more details on cancellation and side effects, see the documentation of [`distributed_oprf`].
+///
+/// # Errors
+/// See the [`Error`] enum for all potential errors of this function.
+#[instrument(level = "debug", skip_all, fields(request_id = tracing::field::Empty))]
+pub async fn delegate_distributed_oprf<OprfRequestAuth>(
+    service: &Url,
+    query: ark_babyjubjub::Fq,
+    blinding_factor: BlindingFactor,
+    domain_separator: ark_babyjubjub::Fq,
+    auth: OprfRequestAuth,
+    client: &reqwest::Client,
+) -> Result<VerifiableOprfOutput, Error>
+where
+    OprfRequestAuth: Clone + Serialize + 'static,
+{
+    tracing::trace!("starting distributed oprf. my version: {}", VERSION);
+
+    let request_id = Uuid::new_v4();
+    let distributed_oprf_span = tracing::Span::current();
+    distributed_oprf_span.record("request_id", request_id.to_string());
+    tracing::debug!("starting with request id: {request_id}");
+
+    let blinded_request = oprf_core::oprf::client::blind_query(query, blinding_factor);
+    let oprf_req = OprfRequest {
+        request_id,
+        blinded_query: blinded_request.blinded_query(),
+        auth,
+    };
+
+    // add client version to query params so the delegate service can check for compatibility
+    let mut service = service.clone();
+    service.query_pairs_mut().append_pair("version", VERSION);
+
+    let response = client.post(service).json(&oprf_req).send().await?;
+    let status = response.status();
+    tracing::debug!("delegate service returned status: {status}");
+
+    let response = if status.is_success() {
+        response.json::<DelegateOprfResponse>().await?
+    } else {
+        let body = response.text().await?;
+
+        // If the delegate service returned a `ServiceError` (with a code), we wrap it in a `ThresholdServiceError`.
+        // If the nodes disagreed on an error, or if a unexpected (e.g. Networking) error occurred, the delegate service will return a generic error. We wrap that in a `DelegateServerError`.
+        if let Ok(error_code) = body.parse::<u16>() {
+            return Err(Error::ThresholdServiceError(ServiceError {
+                error_code,
+                msg: None,
+                kind: error_code.into(),
+            }));
+        }
+
+        return Err(Error::DelegateServerError {
+            status,
+            reason: body,
+        });
+    };
+
+    finalize_distributed_oprf(FinalizeDistributedOprfArgs {
+        request_id,
+        query,
+        blinding_factor,
+        domain_separator,
+        blinded_request,
+        challenge: response.challenge,
+        responses: response.responses,
+        oprf_public_key: response.oprf_pub_key_with_epoch.key,
+        epoch: response.oprf_pub_key_with_epoch.epoch,
+    })
+}
+
+/// Executes the core, network-facing part of the distributed OPRF protocol against a set of nodes.
+///
+/// This is the lower-level building block used by [`distributed_oprf`] and by [`delegate_distributed_oprf`]'s
+/// delegate node. Unlike [`distributed_oprf`], it does not blind the query itself (the caller supplies
+/// an already-built [`OprfRequest`]) and it does not unblind the response or derive the final OPRF
+/// output; it stops right after the combined `DLog` equality proof has been verified.
+///
+/// Concretely, this function:
+/// 1. Initializes sessions with the specified OPRF services, sending the blinded query and authentication information.
+/// 2. Checks that all responding nodes agree on the same [`OprfPublicKey`].
+/// 3. Generates the `DLog` equality challenge based on the commitments received from the services.
+/// 4. Finishes the sessions by sending the challenge to the services and collecting their responses.
+/// 5. Combines and verifies the `DLog` equality proof from the services.
+///
+/// # Returns
+/// A tuple of the [`OprfPublicKey`] used, the [`ShareEpoch`] the nodes agreed on, the combined [`BlindedOprfResponse`], and the verified [`DLogEqualityProof`].
+///
+/// # Arguments
+/// - `services`: List of WebSocket URIs of the OPRF nodes to contact (must be unique). See the helper functions [`to_oprf_uri`] and [`to_oprf_uri_many`].
+/// - `threshold`: Number of nodes required to complete the protocol
+/// - `request_id`: The UUID identifying this OPRF request, forwarded to all nodes
+/// - `req`: The already-blinded [`OprfRequest`] to send to every node
+/// - `connector`: TLS connector configuration for the WebSocket connections
+///
+/// # Timeout and Cancellation
+/// Same considerations as [`distributed_oprf`] apply: no timeout is enforced internally, and dropping
+/// the returned future drops all in-flight requests, but work already processed by a node cannot be undone.
+///
+/// # Errors
+/// See the [`Error`] enum for all potential errors of this function.
+#[instrument(level = "debug", skip_all, fields(request_id = %req.request_id))]
+#[allow(
+    clippy::missing_panics_doc,
+    reason = "Can't really panic due to promises from called method"
+)]
+pub async fn distributed_oprf_core<OprfRequestAuth>(
+    services: &[Uri],
+    threshold: usize,
+    req: OprfRequest<OprfRequestAuth>,
+    connector: Connector,
+) -> Result<
+    (
+        OprfPublicKey,
+        ShareEpoch,
+        DLogCommitmentsShamir,
+        Vec<DLogProofShareShamir>,
+    ),
+    Error,
+>
+where
+    OprfRequestAuth: Clone + Serialize + 'static,
+{
+    if threshold == 0 || threshold > services.len() {
+        return Err(Error::InvalidThreshold {
+            num_peers: services.len(),
+            threshold,
+        });
+    }
+    let services_dedup = services.iter().collect::<HashSet<_>>();
+    if services_dedup.len() != services.len() {
+        return Err(Error::NonUniqueServices);
+    }
+
+    let request_id = req.request_id;
+
     tracing::debug!("initializing sessions at {} services", services.len());
-    let sessions = sessions::init_sessions(request_id, services, threshold, oprf_req, connector)
+    let sessions = sessions::init_sessions(request_id, services, threshold, req, connector)
         .await
         .map_err(|errors| aggregate_error(threshold, errors))?;
 
@@ -477,6 +772,62 @@ where
         .await
         .map_err(Error::CannotFinishSession)?;
 
+    Ok((oprf_public_key, epoch, challenge, responses))
+}
+
+/// Arguments required to finalize the distributed OPRF protocol after the network-facing part has completed.
+pub struct FinalizeDistributedOprfArgs {
+    /// The UUID identifying this OPRF request.
+    pub request_id: Uuid,
+    /// The OPRF input value to evaluate.
+    pub query: ark_babyjubjub::Fq,
+    /// The blinding factor used to blind the query.
+    pub blinding_factor: BlindingFactor,
+    /// Domain separator used in the final Poseidon hash to derive the output.
+    pub domain_separator: ark_babyjubjub::Fq,
+    /// The blinded query sent to the OPRF nodes.
+    pub blinded_request: BlindedOprfRequest,
+    /// The combined `DLog` commitments used to generate the challenge.
+    pub challenge: DLogCommitmentsShamir,
+    /// The proof shares collected from each node.
+    pub responses: Vec<DLogProofShareShamir>,
+    /// The public key of the OPRF, must be consistent across all nodes.
+    pub oprf_public_key: OprfPublicKey,
+    /// The `ShareEpoch` the nodes agreed on.
+    pub epoch: ShareEpoch,
+}
+
+/// Finalizes the distributed OPRF protocol after the network-facing part has completed.
+///
+/// Unblinds the combined blinded response using the blinding factor, verifies the combined
+/// `DLog` equality proof against the collected proof shares, and derives the final OPRF output
+/// by hashing the domain separator, the original query, and the unblinded response.
+///
+/// # Returns
+/// The final [`VerifiableOprfOutput`] containing the OPRF output, the `DLog` equality proof, and the blinded and unblinded responses.
+///
+/// # Arguments
+/// - `args`: The [`FinalizeDistributedOprfArgs`] collected from the network-facing part of the protocol.
+///
+/// # Errors
+/// Returns [`Error::InvalidDLogProof`] if the combined `DLog` equality proof fails verification.
+pub fn finalize_distributed_oprf(
+    FinalizeDistributedOprfArgs {
+        request_id,
+        query,
+        blinding_factor,
+        domain_separator,
+        blinded_request,
+        challenge,
+        responses,
+        oprf_public_key,
+        epoch,
+    }: FinalizeDistributedOprfArgs,
+) -> Result<VerifiableOprfOutput, Error> {
+    let blinding_factor_prepared = blinding_factor.prepare();
+    let blinded_response = BlindedOprfResponse::new(challenge.blinded_response());
+    let unblinded_response = blinded_response.unblind_response(&blinding_factor_prepared);
+
     let dlog_proof = verify_dlog_equality(
         request_id,
         oprf_public_key,
@@ -484,11 +835,6 @@ where
         &responses,
         challenge.clone(),
     )?;
-
-    let blinded_response = challenge.blinded_response();
-    let blinding_factor_prepared = blinding_factor.prepare();
-    let oprf_blinded_response = BlindedOprfResponse::new(blinded_response);
-    let unblinded_response = oprf_blinded_response.unblind_response(&blinding_factor_prepared);
 
     let digest = poseidon2::bn254::t4::permutation(&[
         domain_separator,
@@ -502,7 +848,7 @@ where
     Ok(VerifiableOprfOutput {
         output,
         blinded_request: blinded_request.blinded_query(),
-        blinded_response,
+        blinded_response: blinded_response.response(),
         dlog_proof,
         unblinded_response,
         oprf_public_key,
@@ -559,6 +905,108 @@ pub fn generate_challenge_request(sessions: &OprfSessions) -> DLogCommitmentsSha
         .collect::<Vec<_>>();
     // Combine commitments from all sessions and create a single challenge
     DLogCommitmentsShamir::combine_commitments(&sessions.commitments, contributing_parties)
+}
+
+/// Fetches the [`OprfPublicKeyWithEpoch`] for the given [`OprfKeyId`] from a single service.
+async fn fetch_oprf_public_key_from_service(
+    url: &Url,
+    oprf_key_id: OprfKeyId,
+    client: &reqwest::Client,
+) -> Result<Option<OprfPublicKeyWithEpoch>, reqwest::Error> {
+    // Get rid of existing trailing slash, if any, and append a trailing slash to the path segments.
+    let mut url = url.clone();
+    url.path_segments_mut()
+        .expect("url should not be cannot-be-a-base")
+        .pop_if_empty()
+        .push("");
+
+    let response = client
+        .get(
+            url.join(oprf_key_id.to_string().as_str())
+                .expect("OprfKeyId to_string() should produce a valid URL"),
+        )
+        .send()
+        .await?;
+
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+
+    let response = response.error_for_status()?;
+
+    Ok(Some(response.json::<OprfPublicKeyWithEpoch>().await?))
+}
+
+/// Fetches the [`OprfPublicKeyWithEpoch`] for a given [`OprfKeyId`] from a set of OPRF nodes,
+/// returning it if `threshold` many nodes agree on the same value.
+/// If `threshold` many nodes return `404 Not Found`, returns `Ok(None)`.
+///
+/// Nodes are queried concurrently via `GET {service}/oprf_pub/{key_id}` (see [`to_oprf_pub_key_url`]).
+///
+/// # Arguments
+/// - `services`: Base URLs (up to `/oprf_pub`) of the OPRF nodes to query (must be unique)
+/// - `threshold`: Number of nodes required to agree on the same [`OprfPublicKeyWithEpoch`]
+/// - `key_id`: The [`OprfKeyId`] to fetch the public key for
+/// - `client`: The [`reqwest::Client`] used to send the requests
+///
+/// # Errors
+/// - [`Error::InvalidThreshold`] if `threshold` is `0` or greater than `services.len()`.
+/// - [`Error::NonUniqueServices`] if `services` contains duplicate URLs.
+/// - [`Error::Networking`] if `threshold` many nodes could not be reached, or returned an unexpected response.
+/// - [`Error::InconsistentOprfPublicKeys`] if no single response reached `threshold` agreement.
+#[instrument(level = "debug", skip(client))]
+pub async fn fetch_oprf_public_key(
+    urls: &[Url],
+    threshold: usize,
+    key_id: OprfKeyId,
+    client: &reqwest::Client,
+) -> Result<Option<OprfPublicKeyWithEpoch>, Error> {
+    if threshold == 0 || threshold > urls.len() {
+        return Err(Error::InvalidThreshold {
+            num_peers: urls.len(),
+            threshold,
+        });
+    }
+
+    let urls_dedup = urls.iter().collect::<HashSet<_>>();
+    if urls_dedup.len() != urls.len() {
+        return Err(Error::NonUniqueServices);
+    }
+
+    let mut futures: FuturesUnordered<_> = urls
+        .iter()
+        .map(|url| fetch_oprf_public_key_from_service(url, key_id, client))
+        .collect();
+
+    let mut agreement: HashMap<OprfPublicKeyWithEpoch, usize> = HashMap::new();
+    let mut not_found_count = 0usize;
+    let mut network_errors = Vec::new();
+
+    while let Some(result) = futures.next().await {
+        match result {
+            Ok(Some(response)) => {
+                let count = agreement.entry(response.clone()).or_insert(0);
+                *count += 1;
+                if *count >= threshold {
+                    return Ok(Some(response));
+                }
+            }
+            Ok(None) => {
+                not_found_count += 1;
+                if not_found_count >= threshold {
+                    return Ok(None);
+                }
+            }
+            Err(err) => {
+                network_errors.push(Box::new(err).into());
+                if network_errors.len() >= threshold {
+                    return Err(Error::Networking(network_errors));
+                }
+            }
+        }
+    }
+
+    Err(Error::InconsistentOprfPublicKeys)
 }
 
 #[cfg(test)]

--- a/oprf-client/src/ws/mod.rs
+++ b/oprf-client/src/ws/mod.rs
@@ -11,13 +11,12 @@ use uuid::Uuid;
 pub(crate) use wasm::WebSocketSession;
 
 pub(crate) fn append_client_version_to_query(endpoint: &Uri, request_id: Uuid) -> String {
-    let version = env!("CARGO_PKG_VERSION");
     let has_query = endpoint.query().is_some();
     let mut endpoint = endpoint.to_string();
 
     endpoint.push(if has_query { '&' } else { '?' });
     endpoint.push_str("version=");
-    endpoint.push_str(version);
+    endpoint.push_str(crate::VERSION);
     endpoint.push_str("&request_id=");
     endpoint.push_str(&request_id.to_string());
     endpoint

--- a/oprf-core/src/keys/mod.rs
+++ b/oprf-core/src/keys/mod.rs
@@ -1,1 +1,0 @@
-pub mod keygen;

--- a/oprf-core/src/shamir.rs
+++ b/oprf-core/src/shamir.rs
@@ -65,7 +65,7 @@ pub fn single_lagrange_from_coeff<F: PrimeField + From<T>, T: Copy + Eq>(
 ///
 /// # Panics
 /// If the provided polynomial is empty.
-pub(crate) fn evaluate_poly<F: PrimeField>(poly: &[F], x: F) -> F {
+pub fn evaluate_poly<F: PrimeField>(poly: &[F], x: F) -> F {
     assert!(!poly.is_empty(), "Poly must not be empty");
     let mut iter = poly.iter().rev();
     let mut eval = iter.next().expect("Checked that not empty").to_owned();

--- a/oprf-dev-client/examples/dev-client-example.rs
+++ b/oprf-dev-client/examples/dev-client-example.rs
@@ -1,7 +1,7 @@
 use alloy::{primitives::U160, providers::DynProvider};
 use ark_ff::{PrimeField as _, UniformRand as _};
 use clap::Parser;
-use eyre::Context;
+use eyre::{Context, ContextCompat};
 use oprf_client::Connector;
 use oprf_core::oprf::BlindingFactor;
 use oprf_types::{
@@ -113,6 +113,52 @@ impl DevClient for ExampleDevClient {
             connector,
         )
         .await?;
+
+        Ok(verifiable_oprf_output.epoch)
+    }
+
+    async fn run_delegate_oprf(
+        &self,
+        config: &DevClientConfig,
+        setup: Self::Setup,
+        delegate_service: Option<String>,
+        client: &reqwest::Client,
+    ) -> eyre::Result<ShareEpoch> {
+        let mut rng = rand_chacha::ChaCha12Rng::from_entropy();
+
+        let query = ark_babyjubjub::Fq::rand(&mut rng);
+        let blinding_factor = BlindingFactor::rand(&mut rng);
+        let domain_separator = ark_babyjubjub::Fq::from_be_bytes_mod_order(b"OPRF");
+        let auth = ExampleOprfRequestAuth(setup.oprf_key_id);
+        let node_urls = oprf_client::to_oprf_pub_key_url_many(&config.nodes)?;
+        let should_key = oprf_client::fetch_oprf_public_key(
+            &node_urls,
+            config.threshold,
+            setup.oprf_key_id,
+            client,
+        )
+        .await?
+        .context("while fetching OPRF public key from nodes")?;
+
+        let delegate_service = delegate_service
+            .as_deref()
+            .unwrap_or(config.nodes[0].as_str());
+        let url = oprf_client::to_delegate_oprf_url(delegate_service, EXAMPLE_MODULE)?;
+
+        let verifiable_oprf_output = oprf_client::delegate_distributed_oprf(
+            &url,
+            query,
+            blinding_factor,
+            domain_separator,
+            auth,
+            client,
+        )
+        .await?;
+
+        eyre::ensure!(
+            verifiable_oprf_output.oprf_public_key == should_key.key,
+            "Delegate service returned a different OPRF public key than the one fetched from the nodes"
+        );
 
         Ok(verifiable_oprf_output.epoch)
     }

--- a/oprf-dev-client/src/config.rs
+++ b/oprf-dev-client/src/config.rs
@@ -33,10 +33,20 @@ pub struct ReshareTest {
     pub acceptance_num: usize,
 }
 
+#[derive(Clone, Parser, Debug)]
+pub struct DelegateTestCommand {
+    /// The URL of the delegate service used for `DelegateTest`.
+    ///
+    /// Defaults to the first of `nodes` if not set.
+    #[clap(long, env = "OPRF_DEV_CLIENT_DELEGATE_SERVICE")]
+    pub delegate_service: Option<String>,
+}
+
 #[derive(Clone, Debug, Subcommand)]
 pub enum Command {
     Test,
     DeleteTest,
+    DelegateTest(DelegateTestCommand),
     StressTestOprf(StressTestOprfCommand),
     StressTestKeyGen(StressTestKeyGenCommand),
     ReshareTest(ReshareTest),

--- a/oprf-dev-client/src/lib.rs
+++ b/oprf-dev-client/src/lib.rs
@@ -51,6 +51,14 @@ pub trait DevClient: Send + Sync + 'static {
         connector: Connector,
     ) -> eyre::Result<ShareEpoch>;
 
+    async fn run_delegate_oprf(
+        &self,
+        config: &DevClientConfig,
+        setup: Self::Setup,
+        delegate_service: Option<String>,
+        client: &reqwest::Client,
+    ) -> eyre::Result<ShareEpoch>;
+
     async fn prepare_stress_test_item<R: Rng + CryptoRng + Send>(
         &self,
         setup: &Self::Setup,
@@ -306,6 +314,19 @@ async fn stress_test_key_gen(
     Ok(())
 }
 
+async fn delegate_test<T: DevClient>(
+    dev_client: T,
+    config: DevClientConfig,
+    cmd: DelegateTestCommand,
+    setup: T::Setup,
+) -> eyre::Result<()> {
+    let client = reqwest::Client::new();
+    dev_client
+        .run_delegate_oprf(&config, setup, cmd.delegate_service, &client)
+        .await?;
+    Ok(())
+}
+
 async fn stress_test<T: DevClient>(
     dev_client: T,
     config: DevClientConfig,
@@ -505,6 +526,14 @@ pub async fn run<T: DevClient>(config: DevClientConfig, dev_client: T) -> eyre::
             tracing::info!("running delete-test");
             delete_test(config, provider).await?;
             tracing::info!("oprf delete test successful");
+        }
+        Command::DelegateTest(cmd) => {
+            tracing::info!("running delegate-test");
+            let setup = dev_client
+                .setup_oprf_test(&config, provider.clone())
+                .await?;
+            delegate_test(dev_client, config, cmd, setup).await?;
+            tracing::info!("oprf delegate test successful");
         }
         Command::StressTestOprf(cmd) => {
             tracing::info!("running oprf stress-test");

--- a/oprf-service/Cargo.toml
+++ b/oprf-service/Cargo.toml
@@ -27,11 +27,8 @@ http = { workspace = true }
 humantime-serde = { workspace = true }
 metrics = { workspace = true }
 moka.workspace = true
-nodes-common = { workspace = true, features = [
-  "api",
-  "postgres",
-  "serde"
-] }
+nodes-common = { workspace = true, features = ["api", "postgres", "serde"] }
+oprf-client = { package = "taceo-oprf-client", path = "../oprf-client", version = "0.10" }
 oprf-core = { package = "taceo-oprf-core", path = "../oprf-core", version = "0.6" }
 oprf-types = { package = "taceo-oprf-types", path = "../oprf-types", version = "0.15", features = [
   "service"
@@ -57,25 +54,39 @@ tokio = { workspace = true, features = [
   "tokio-macros",
 ] }
 tokio-util = { workspace = true }
-tower-http = { workspace = true, features = ["set-header", "timeout", "trace", "cors"] }
+tower-http = { workspace = true, features = [
+  "cors",
+  "set-header",
+  "timeout",
+  "trace"
+] }
 tracing.workspace = true
 tungstenite = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }
 zeroize.workspace = true
 
 [dev-dependencies]
+ark-ec = { workspace = true }
 ark-ff = { workspace = true }
 axum-test = { workspace = true, features = ["ws"] }
 config = { workspace = true }
 itertools = { workspace = true }
+nodes-common = { workspace = true, features = [
+  "api",
+  "postgres",
+  "serde",
+  "test-utils"
+] }
 oprf-client = { package = "taceo-oprf-client", path = "../oprf-client", version = "0.10" }
 oprf-test-utils = { package = "taceo-oprf-test-utils", path = "../oprf-test-utils", version = "0.14", default-features = false, features = [
   "deploy-anvil",
   "postgres-test-container"
 ] }
-ruint.workspace = true
+reqwest = { workspace = true, features = ["json"] }
+ruint = { workspace = true, features = ["rand"] }
 rustls = { workspace = true }
 telemetry-batteries = { workspace = true, features = ["metrics-statsd"] }
+url = { workspace = true }
 
 [features]
 default = ["postgres"]

--- a/oprf-service/examples/taceo-oprf-service-example.rs
+++ b/oprf-service/examples/taceo-oprf-service-example.rs
@@ -3,12 +3,14 @@ use std::{net::SocketAddr, process::ExitCode, sync::Arc, time::Duration};
 use config::{Config, Environment};
 use eyre::Context;
 use nodes_common::postgres::PostgresConfig;
+use oprf_client::Connector;
 use serde::Deserialize;
 use taceo_oprf_service::{
     OprfServiceBuilder, StartedServices,
     config::OprfNodeServiceConfig,
     secret_manager::{SecretManagerService, postgres::PostgresSecretManager},
 };
+use url::Url;
 
 use crate::simple_authenticator::ExampleOprfRequestAuthenticator;
 
@@ -35,6 +37,9 @@ pub struct ExampleOprfNodeConfig {
     /// The postgres config for the secret-manager
     #[serde(rename = "postgres")]
     pub postgres_config: PostgresConfig,
+
+    /// The http base urls of the other OPRF nodes to delegate requests to.
+    pub node_urls: Vec<Url>,
 }
 
 fn default_bind_addr() -> SocketAddr {
@@ -51,6 +56,7 @@ pub fn load_example_config() -> eyre::Result<ExampleOprfNodeConfig> {
             .separator("__")
             .list_separator(",")
             .with_list_parse_key("rpc.http_urls")
+            .with_list_parse_key("node_urls")
             .try_parsing(true),
     );
 
@@ -120,7 +126,12 @@ pub async fn start_service(
         &node_information,
         nodes_common::version_info!(),
     )
-    .module("/example", Arc::new(ExampleOprfRequestAuthenticator))
+    .module_with_delegate(
+        "/example",
+        Arc::new(ExampleOprfRequestAuthenticator),
+        oprf_client::to_oprf_uri_many(config.node_urls, "example")?,
+        Connector::Plain,
+    )
     .build();
 
     let listener = tokio::net::TcpListener::bind(config.bind_addr).await?;

--- a/oprf-service/src/api.rs
+++ b/oprf-service/src/api.rs
@@ -5,9 +5,11 @@
 //! - [`errors`] – Defines API error types and conversions from internal service errors.
 //! - [`info`] – Info about the service (`/version`, `/wallet` and `/oprf_pub/{id}`).
 //! - [`oprf`] – The implementation of the OPRF WebSocket endpoint `/oprf`.
+//! - [`oprf_delegate`] – The implementation of the OPRF delegate endpoint `/delegate`.
 //! - [`version_header`] – Serialization for the custom [`version_header::ProtocolVersion`] header the clients needs to send.
 
 pub(crate) mod errors;
 pub(crate) mod info;
 pub(crate) mod oprf;
+pub(crate) mod oprf_delegate;
 pub(crate) mod version_header;

--- a/oprf-service/src/api/oprf_delegate.rs
+++ b/oprf-service/src/api/oprf_delegate.rs
@@ -1,0 +1,145 @@
+use std::num::NonZeroU16;
+
+use axum::{
+    Json, Router,
+    extract::{Query, State},
+    response::IntoResponse,
+    routing::post,
+};
+use http::{StatusCode, Uri};
+use oprf_client::Connector;
+use oprf_types::api::{DelegateOprfResponse, OprfPublicKeyWithEpoch, OprfRequest};
+use semver::VersionReq;
+use serde::{Deserialize, Serialize};
+use tracing::instrument;
+
+use crate::{
+    api::version_header::{ProtocolVersion, ProtocolVersionQuery},
+    metrics,
+};
+
+#[derive(Clone)]
+pub(crate) struct DelegateOprfState {
+    pub(crate) threshold: NonZeroU16,
+    pub(crate) services: Vec<Uri>,
+    pub(crate) version_req: VersionReq,
+    pub(crate) connector: Connector,
+}
+
+/// # Delegate Handler
+///
+/// Handles a single `POST /delegate` request by running the distributed OPRF protocol on
+/// behalf of the client against the configured threshold-signing services, so that clients
+/// that cannot talk to the services directly can delegate the whole flow to this endpoint.
+///
+/// ## Client Protocol Version Requirement
+///
+/// Clients are required to announce the protocol version they implement using [Semantic
+/// Versioning (semver)] as a query parameter of the request URL. Requests without a version,
+/// or with a version that does not satisfy `state.version_req`, are rejected with `400 Bad
+/// Request` before any work is done.
+///
+/// ## Delegation
+///
+/// The request body is forwarded as-is to [`oprf_client::distributed_oprf_core`], which talks
+/// to `state.services` and collects `state.threshold` responses. On success, the OPRF public
+/// key/epoch, challenge, and per-service responses are returned to the client as `200 OK` so it
+/// can finish the protocol itself.
+///
+/// ## Error Handling
+///
+/// - A [`oprf_client::Error::ThresholdServiceError`] is surfaced to the client as `400 Bad
+///   Request`, since it indicates a problem with the request itself.
+/// - Networking, session, epoch-mismatch, and node-disagreement errors are treated as transient
+///   and returned as `503 Service Unavailable`.
+/// - Any other error is unexpected and returned as `500 Internal Server Error`.
+///
+/// Error responses do not use a JSON body. The version-check and threshold-service errors above
+/// carry a plain-text body: a human-readable message for the missing/invalid version case, and
+/// the stringified numeric `error_code` reported by the failing service for the threshold-service
+/// case. The `503` and `500` responses have no body at all; details are only available in the
+/// server logs.
+#[instrument(level = "info", skip_all, fields(request_id = %req.request_id))]
+async fn delegate_oprf_handler<ReqAuth>(
+    State(state): State<DelegateOprfState>,
+    Query(query_version): Query<ProtocolVersionQuery>,
+    Json(req): Json<OprfRequest<ReqAuth>>,
+) -> impl IntoResponse
+where
+    ReqAuth: Serialize + for<'de> Deserialize<'de> + Clone + Send + 'static,
+{
+    if let Some(ProtocolVersion(client_version)) = query_version.version {
+        tracing::trace!(%client_version, "received delegate OPRF request with version");
+        if !state.version_req.matches(&client_version) {
+            let msg = format!(
+                "invalid version, expected: {} got: {client_version}",
+                state.version_req
+            );
+            tracing::warn!(user_error = true, "{msg}");
+            metrics::request::inc_client_version_mismatch();
+            return (StatusCode::BAD_REQUEST, msg).into_response();
+        }
+    } else {
+        tracing::warn!(user_error = true, "missing client version");
+        return (StatusCode::BAD_REQUEST, "missing client version").into_response();
+    }
+
+    tracing::trace!("received delegate OPRF request");
+    metrics::request::inc_delegate_request();
+    match oprf_client::distributed_oprf_core(
+        &state.services,
+        u16::from(state.threshold) as usize,
+        req,
+        state.connector,
+    )
+    .await
+    {
+        Ok((oprf_public_key, epoch, challenge, responses)) => {
+            tracing::trace!("delegate OPRF request successful");
+            metrics::request::inc_delegate_success();
+            let response = DelegateOprfResponse {
+                challenge,
+                responses,
+                oprf_pub_key_with_epoch: OprfPublicKeyWithEpoch {
+                    key: oprf_public_key,
+                    epoch,
+                },
+            };
+            (StatusCode::OK, Json(response)).into_response()
+        }
+        Err(oprf_client::Error::ThresholdServiceError(service_error)) => {
+            tracing::warn!(
+                ?service_error,
+                "delegate OPRF request failed: {service_error}"
+            );
+            (
+                StatusCode::BAD_REQUEST,
+                service_error.error_code.to_string(),
+            )
+                .into_response()
+        }
+        Err(
+            err @ (oprf_client::Error::Networking(_)
+            | oprf_client::Error::CannotFinishSession(_)
+            | oprf_client::Error::EpochMismatch(_)
+            | oprf_client::Error::NodeErrorDisagreement(_)),
+        ) => {
+            tracing::warn!(?err, "delegate OPRF request failed: {err}");
+            StatusCode::SERVICE_UNAVAILABLE.into_response()
+        }
+        Err(err) => {
+            // This is an unexpected error, log it as an error instead of a warning
+            tracing::error!(?err, "delegate OPRF request failed: {err}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+pub fn routes<ReqAuth>(state: DelegateOprfState) -> Router
+where
+    ReqAuth: Serialize + for<'de> Deserialize<'de> + Clone + Send + 'static,
+{
+    Router::new()
+        .route("/delegate", post(delegate_oprf_handler::<ReqAuth>))
+        .with_state(state)
+}

--- a/oprf-service/src/lib.rs
+++ b/oprf-service/src/lib.rs
@@ -50,16 +50,18 @@ use std::fmt;
 use std::num::NonZeroU16;
 
 use crate::api::oprf::OprfModuleState;
+use crate::api::oprf_delegate::DelegateOprfState;
 use crate::services::open_sessions::OpenSessions;
 use crate::services::oprf_key_material_store::OprfKeyMaterialStore;
 use crate::{config::OprfNodeServiceConfig, services::secret_manager::SecretManagerService};
 use axum::Router;
-use axum::extract::MatchedPath;
-use http::{HeaderMap, HeaderName, Method, StatusCode};
+use axum::extract::{DefaultBodyLimit, MatchedPath};
+use http::{HeaderMap, HeaderName, Method, StatusCode, Uri};
+use oprf_client::Connector;
 use oprf_types::api::OprfRequestAuthService;
 use oprf_types::crypto::PartyId;
 use oprf_types::service::NodeInformation;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::{MakeSpan, TraceLayer};
@@ -190,6 +192,51 @@ impl OprfServiceBuilder {
         self
     }
 
+    /// Like [`OprfServiceBuilder::module`], but adds a delegate OPRF module that can forward requests to other OPRF services.
+    ///
+    /// # Parameters
+    ///
+    /// - `path`: The URL path where the OPRF module will be accessible (`/api/{path}`).
+    /// - `service`: An instance of `OprfRequestAuthService` that will handle authentication for this module.
+    /// - `services`: A list of URIs of other OPRF services to which requests can be delegated.
+    /// - `connector`: A connector used to establish connections to the delegate OPRF services
+    #[must_use]
+    pub fn module_with_delegate<
+        RequestAuth: Serialize + for<'de> Deserialize<'de> + Clone + Send + 'static,
+    >(
+        mut self,
+        path: &str,
+        service: OprfRequestAuthService<RequestAuth>,
+        services: Vec<Uri>,
+        connector: Connector,
+    ) -> Self {
+        let args = Router::new().merge(self.api).nest(
+            path,
+            Router::new()
+                .merge(api::oprf::routes(OprfModuleState {
+                    party_id: self.party_id,
+                    threshold: self.threshold,
+                    oprf_material_store: self.oprf_key_material_store.clone(),
+                    req_auth_service: service,
+                    version_req: self.config.version_req.clone(),
+                    max_message_size: self.config.ws_max_message_size,
+                    max_connection_lifetime: self.config.session_lifetime,
+                    websocket_shutdown_timeout: self.config.websocket_shutdown_timeout,
+                    open_sessions: self.open_sessions.clone(),
+                }))
+                .merge(api::oprf_delegate::routes::<RequestAuth>(
+                    DelegateOprfState {
+                        threshold: self.threshold,
+                        services,
+                        version_req: self.config.version_req.clone(),
+                        connector,
+                    },
+                )),
+        );
+        self.api = args;
+        self
+    }
+
     /// Build the `axum` [`Router`] with all added oprf modules.
     ///
     /// # Panics
@@ -203,12 +250,18 @@ impl OprfServiceBuilder {
             .layer(TraceLayer::new_for_http().make_span_with(OprfAuthModulesMakeSpan));
 
         Router::new()
-            .merge(self.info_routes)
-            .nest("/api", auth_modules)
-            .layer(TimeoutLayer::with_status_code(
+            .merge(self.info_routes.layer(TimeoutLayer::with_status_code(
                 StatusCode::REQUEST_TIMEOUT,
                 self.config.http_request_timeout,
-            ))
+            )))
+            .nest(
+                "/api",
+                auth_modules.layer(TimeoutLayer::with_status_code(
+                    StatusCode::REQUEST_TIMEOUT,
+                    self.config.session_lifetime, // use session lifetime align with ws timeout
+                )),
+            )
+            .layer(DefaultBodyLimit::max(self.config.ws_max_message_size))
     }
 }
 

--- a/oprf-service/src/metrics.rs
+++ b/oprf-service/src/metrics.rs
@@ -35,6 +35,12 @@ pub(crate) mod request {
     /// Metrics key for how often we terminated user connection due to timeout.
     const METRICS_CLIENT_TIMEOUT: &str = "taceo.oprf.node.request.timeout";
 
+    /// Metrics key for counting all OPRF delegate requests
+    const METRICS_ID_NODE_DELEGATE_REQUESTS: &str = "taceo.oprf.node.delegate";
+
+    /// Metrics key for counting successful OPRF delegate evaluations
+    const METRICS_ID_NODE_DELEGATE_SUCCESS: &str = "taceo.oprf.node.delegate.success";
+
     pub(super) fn describe_metrics() {
         params::describe_metrics();
         metrics::describe_counter!(
@@ -78,6 +84,18 @@ pub(crate) mod request {
             metrics::Unit::Count,
             "How often we terminated user connection due to timeout"
         );
+
+        metrics::describe_counter!(
+            METRICS_ID_NODE_DELEGATE_REQUESTS,
+            metrics::Unit::Count,
+            "Number of OPRF delegate requests observed. Includes successes and failures."
+        );
+
+        metrics::describe_counter!(
+            METRICS_ID_NODE_DELEGATE_SUCCESS,
+            metrics::Unit::Count,
+            "Number of successful OPRF delegate evaluations"
+        );
     }
 
     pub(crate) fn inc_client_version_mismatch() {
@@ -107,6 +125,14 @@ pub(crate) mod request {
 
     pub(crate) fn record_part2_duration(duration: Duration) {
         metrics::histogram!(METRICS_ID_NODE_PART_2_DURATION).record(duration.as_millis() as f64);
+    }
+
+    pub(crate) fn inc_delegate_request() {
+        metrics::counter!(METRICS_ID_NODE_DELEGATE_REQUESTS).increment(1);
+    }
+
+    pub(crate) fn inc_delegate_success() {
+        metrics::counter!(METRICS_ID_NODE_DELEGATE_SUCCESS).increment(1);
     }
 
     pub(crate) mod params {

--- a/oprf-service/src/tests/mod.rs
+++ b/oprf-service/src/tests/mod.rs
@@ -8,7 +8,7 @@ use oprf_core::ddlog_equality::shamir::DLogProofShareShamir;
 use oprf_test_utils::{DeploySetup, OPRF_PEER_ADDRESS_0, TestSetup};
 use oprf_types::{
     OprfKeyId, ShareEpoch,
-    api::{OprfResponse, oprf_error_codes},
+    api::{DelegateOprfResponse, OprfResponse, oprf_error_codes},
 };
 use ruint::aliases::U160;
 use serde::{Deserialize, Serialize};
@@ -17,10 +17,7 @@ use uuid::Uuid;
 
 use crate::secret_manager::SecretManager as _;
 
-use self::setup::{
-    INVALID_AUTH_CODE, INVALID_AUTH_MSG, TEST_PROTOCOL_VERSION, TestNode, WireFormat,
-    wait_until_started,
-};
+use self::setup::{INVALID_AUTH_CODE, INVALID_AUTH_MSG, TestNode, WireFormat, wait_until_started};
 
 mod setup;
 
@@ -129,11 +126,14 @@ async fn wrong_client_version_header() -> eyre::Result<()> {
         .get_websocket("/api/test/oprf")
         .add_header(
             oprf_types::api::OPRF_PROTOCOL_VERSION_HEADER.as_str(),
-            "2.0.0",
+            "0.0.0",
         )
         .await;
     assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-    response.assert_text("invalid version, expected: ^1.0.0 got: 2.0.0");
+    response.assert_text(format!(
+        "invalid version, expected: ^{} got: 0.0.0",
+        oprf_client::VERSION
+    ));
     Ok(())
 }
 
@@ -143,10 +143,13 @@ async fn wrong_client_version_query() -> eyre::Result<()> {
     let node = TestNode::start(0, &setup).await?;
     let response = node
         .server
-        .get_websocket("/api/test/oprf?version=2.0.0")
+        .get_websocket("/api/test/oprf?version=0.0.0")
         .await;
     assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-    response.assert_text("invalid version, expected: ^1.0.0 got: 2.0.0");
+    response.assert_text(format!(
+        "invalid version, expected: ^{} got: 0.0.0",
+        oprf_client::VERSION
+    ));
     Ok(())
 }
 
@@ -176,7 +179,7 @@ async fn corrupt_client_version_query() -> eyre::Result<()> {
         .get_websocket("/api/test/oprf?version=abc")
         .add_header(
             oprf_types::api::OPRF_PROTOCOL_VERSION_HEADER.as_str(),
-            TEST_PROTOCOL_VERSION,
+            oprf_client::VERSION,
         )
         .await;
     assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
@@ -203,7 +206,7 @@ async fn init_with_version_query() -> eyre::Result<()> {
     let node = TestNode::start(0, &setup).await?;
     let mut ws = node
         .server
-        .get_websocket(&format!("/api/test/oprf?version={TEST_PROTOCOL_VERSION}"))
+        .get_websocket(&format!("/api/test/oprf?version={}", oprf_client::VERSION))
         .await
         .into_websocket()
         .await;
@@ -225,10 +228,10 @@ async fn client_version_query_precedence() -> eyre::Result<()> {
     let node = TestNode::start(0, &setup).await?;
     let mut ws = node
         .server
-        .get_websocket(&format!("/api/test/oprf?version={TEST_PROTOCOL_VERSION}"))
+        .get_websocket(&format!("/api/test/oprf?version={}", oprf_client::VERSION))
         .add_header(
             oprf_types::api::OPRF_PROTOCOL_VERSION_HEADER.as_str(),
-            "2.0.0",
+            "0.0.0",
         )
         .await
         .into_websocket()
@@ -264,7 +267,7 @@ async fn session_timeout_no_message() -> eyre::Result<()> {
         .get_websocket("/api/test/oprf")
         .add_header(
             oprf_types::api::OPRF_PROTOCOL_VERSION_HEADER.as_str(),
-            "1.0.0",
+            oprf_client::VERSION,
         )
         .await
         .into_websocket()
@@ -293,7 +296,7 @@ async fn message_too_large_inner(format: WireFormat) -> eyre::Result<()> {
         .get_websocket("/api/test/oprf")
         .add_header(
             oprf_types::api::OPRF_PROTOCOL_VERSION_HEADER.as_str(),
-            setup::TEST_PROTOCOL_VERSION,
+            oprf_client::VERSION,
         )
         .await
         .into_websocket()
@@ -504,7 +507,7 @@ async fn init_bad_request_inner(format: WireFormat) -> eyre::Result<()> {
         .get_websocket("/api/test/oprf")
         .add_header(
             oprf_types::api::OPRF_PROTOCOL_VERSION_HEADER.as_str(),
-            "1.3.101",
+            oprf_client::VERSION,
         )
         .await
         .into_websocket()
@@ -718,4 +721,132 @@ async fn switch_encoding_failed_json_cbor() -> eyre::Result<()> {
 #[tokio::test]
 async fn switch_encoding_failed_cbor_json() -> eyre::Result<()> {
     switch_encoding_failed_inner(WireFormat::Cbor, WireFormat::Json).await
+}
+
+/// Tests that a delegate OPRF request against a real 2-of-3 cluster succeeds end to end.
+#[tokio::test]
+async fn delegate_happy_path() -> eyre::Result<()> {
+    let setup = TestSetup::new(DeploySetup::TwoThree).await?;
+    let connection_string = oprf_test_utils::shared_postgres_testcontainer().await?;
+    let nodes =
+        setup::start_nodes_for_delegate(connection_string, &setup, setup::OPRF_KEY_ID.into())
+            .await?;
+
+    let node_urls = nodes
+        .iter()
+        .map(|n| n.server.server_address().expect("Server has address"))
+        .collect::<Vec<_>>();
+    let node_urls = oprf_client::to_oprf_pub_key_url_many(node_urls)?;
+    let client = reqwest::Client::new();
+    let should_key = oprf_client::fetch_oprf_public_key(
+        &node_urls,
+        u16::from(setup.setup.threshold()) as usize,
+        setup::OPRF_KEY_ID.into(),
+        &client,
+    )
+    .await?
+    .expect("setup should have this key");
+
+    let response = nodes[0]
+        .server
+        .post("/api/test/delegate")
+        .add_query_param("version", oprf_client::VERSION)
+        .json(&setup::request(&mut rand::thread_rng()))
+        .await;
+    response.assert_status_ok();
+    let body: DelegateOprfResponse = response.json();
+    assert_eq!(body.oprf_pub_key_with_epoch, should_key);
+    Ok(())
+}
+
+/// Tests that a delegate request with a wrong OPRF key id is rejected by every node in the
+/// cluster, which the delegator aggregates into a `ThresholdServiceError` -> 400.
+#[tokio::test]
+async fn delegate_auth_failed() -> eyre::Result<()> {
+    let setup = TestSetup::new(DeploySetup::TwoThree).await?;
+    let connection_string = oprf_test_utils::shared_postgres_testcontainer().await?;
+    let nodes =
+        setup::start_nodes_for_delegate(connection_string, &setup, setup::OPRF_KEY_ID.into())
+            .await?;
+
+    let mut request = setup::request(&mut rand::thread_rng());
+    request.auth = setup::ConfigurableTestRequestAuth(OprfKeyId::from(123_usize));
+
+    let response = nodes[0]
+        .server
+        .post("/api/test/delegate")
+        .add_query_param("version", oprf_client::VERSION)
+        .json(&request)
+        .await;
+    response.assert_status(StatusCode::BAD_REQUEST);
+    response.assert_text(INVALID_AUTH_CODE.to_string());
+    Ok(())
+}
+
+/// Tests that a delegate request where the number of reachable nodes drops below the
+/// threshold surfaces as a `Networking` error -> 503.
+#[tokio::test]
+async fn delegate_not_enough_nodes() -> eyre::Result<()> {
+    let setup = TestSetup::new(DeploySetup::TwoThree).await?;
+    let connection_string = oprf_test_utils::shared_postgres_testcontainer().await?;
+    let mut nodes =
+        setup::start_nodes_for_delegate(connection_string, &setup, setup::OPRF_KEY_ID.into())
+            .await?;
+
+    // drop all but one node so the (threshold-2) cluster can no longer reach consensus
+    let delegator = nodes.remove(0);
+    drop(nodes);
+
+    let response = delegator
+        .server
+        .post("/api/test/delegate")
+        .add_query_param("version", oprf_client::VERSION)
+        .json(&setup::request(&mut rand::thread_rng()))
+        .await;
+    response.assert_status(StatusCode::SERVICE_UNAVAILABLE);
+    Ok(())
+}
+
+/// Tests that a delegate request without a client version query param is rejected before any
+/// node in the cluster is contacted.
+#[tokio::test]
+async fn delegate_missing_version() -> eyre::Result<()> {
+    let setup = TestSetup::new(DeploySetup::TwoThree).await?;
+    let connection_string = oprf_test_utils::shared_postgres_testcontainer().await?;
+    let nodes =
+        setup::start_nodes_for_delegate(connection_string, &setup, setup::OPRF_KEY_ID.into())
+            .await?;
+
+    let response = nodes[0]
+        .server
+        .post("/api/test/delegate")
+        .json(&setup::request(&mut rand::thread_rng()))
+        .await;
+    response.assert_status(StatusCode::BAD_REQUEST);
+    response.assert_text("missing client version");
+    Ok(())
+}
+
+/// Tests that a delegate request with a client version the node's `version_req` rejects gets a
+/// 400 before any node in the cluster is contacted.
+#[tokio::test]
+async fn delegate_unsupported_version() -> eyre::Result<()> {
+    let setup = TestSetup::new(DeploySetup::TwoThree).await?;
+    let connection_string = oprf_test_utils::shared_postgres_testcontainer().await?;
+    let nodes =
+        setup::start_nodes_for_delegate(connection_string, &setup, setup::OPRF_KEY_ID.into())
+            .await?;
+
+    let response = nodes[0]
+        .server
+        .post("/api/test/delegate")
+        .add_query_param("version", "0.0.0")
+        .json(&setup::request(&mut rand::thread_rng()))
+        .await;
+    response.assert_status(StatusCode::BAD_REQUEST);
+    response.assert_text(format!(
+        "invalid version, expected: ^{} got: 0.0.0",
+        oprf_client::VERSION
+    ));
+    Ok(())
 }

--- a/oprf-service/src/tests/setup.rs
+++ b/oprf-service/src/tests/setup.rs
@@ -1,15 +1,18 @@
 use core::fmt;
+use std::net::{IpAddr, Ipv4Addr};
 use std::num::NonZeroU32;
 use std::{sync::Arc, time::Duration};
 
+use ark_ec::{AffineRepr as _, CurveGroup as _};
 use ark_ff::UniformRand as _;
 use ark_serialize::CanonicalSerialize;
 use async_trait::async_trait;
 use axum_test::{TestServer, TestWebSocket};
 use eyre::Context as _;
-use http::StatusCode;
+use http::{StatusCode, Uri};
 use nodes_common::postgres::{CreateSchema, PostgresConfig};
 use nodes_common::{Environment, StartedServices};
+use oprf_client::Connector;
 use oprf_core::ddlog_equality::shamir::{
     DLogCommitmentsShamir, DLogProofShareShamir, DLogShareShamir,
 };
@@ -36,7 +39,6 @@ use crate::secret_manager::postgres::PostgresSecretManager;
 use crate::{OprfServiceBuilder, config::OprfNodeServiceConfig};
 
 pub const OPRF_KEY_ID: u32 = 42;
-pub const TEST_PROTOCOL_VERSION: &str = "1.3.101";
 pub const INVALID_AUTH_CODE: u16 = 4500;
 pub const INVALID_AUTH_MSG: &str = "invalid auth";
 
@@ -95,24 +97,30 @@ impl TestNode {
             .get_websocket("/api/test/oprf")
             .add_header(
                 oprf_types::api::OPRF_PROTOCOL_VERSION_HEADER.as_str(),
-                TEST_PROTOCOL_VERSION,
+                oprf_client::VERSION,
             )
             .await
             .into_websocket()
             .await
     }
 
+    /// Starts a test node with the given `secret_manager` and binds it to the specified `bind_port`.
+    ///
+    /// If `services` is provided, it will be used as the delegate services for the node.
+    /// If `services` is `None`, request to `/delegate` will fail.
     pub fn start_with_secret_manager(
         party_id: usize,
         setup: &TestSetup,
         pool: PgPool,
+        bind_port: u16,
+        services: Option<Vec<Uri>>,
         secret_manager: PostgresSecretManager,
     ) -> Self {
         assert!(party_id < 5, "can only spawn 5 nodes");
 
         let mut config = OprfNodeServiceConfig::with_default_values(
             Environment::Dev,
-            "1.0.0".parse().expect("Valid VersionReq"),
+            oprf_client::VERSION.parse().expect("valid semver"),
         );
         config.session_lifetime = Duration::from_secs(10);
 
@@ -129,10 +137,15 @@ impl TestNode {
             ),
             nodes_common::version_info!(),
         )
-        .module("/test", Arc::new(ConfigurableTestAuthenticator))
+        .module_with_delegate(
+            "/test",
+            Arc::new(ConfigurableTestAuthenticator),
+            services.unwrap_or_default(), // we dont care about delegate if services is None
+            Connector::Plain,
+        )
         .build();
         let server = TestServer::builder()
-            .http_transport()
+            .http_transport_with_ip_port(Some(IpAddr::V4(Ipv4Addr::LOCALHOST)), Some(bind_port))
             .build(service)
             .expect("Can build test-server");
         TestNode {
@@ -164,7 +177,9 @@ impl TestNode {
         let pool = nodes_common::postgres::pg_pool_with_schema(&postgres_config, CreateSchema::Yes)
             .await?;
         MIGRATOR.run(&pool).await?;
-        let test_node = Self::start_with_secret_manager(party_id, setup, pool, secret_manager);
+        let port = nodes_common::test_utils::random_port()?;
+        let test_node =
+            Self::start_with_secret_manager(party_id, setup, pool, port, None, secret_manager);
         let key_id = OprfKeyId::from(oprf_key_id);
         test_node
             .add_random_key_material_with_id(key_id, &mut rand::thread_rng())
@@ -286,6 +301,20 @@ impl TestNode {
     ) -> eyre::Result<()> {
         let share = DLogShareShamir::from(ark_babyjubjub::Fr::rand(rng));
         let public_key = OprfPublicKey::new(rng.r#gen());
+        self.add_key_material_with_id_epoch_and_share(key_id, epoch, share, public_key)
+            .await
+    }
+
+    /// Inserts a specific (non-random) share and public key for `key_id`. Used to give
+    /// multiple nodes consistent Shamir shares of the same secret, e.g. via
+    /// [`generate_shamir_shares`], so that a real threshold protocol run across them succeeds.
+    pub async fn add_key_material_with_id_epoch_and_share(
+        &self,
+        key_id: OprfKeyId,
+        epoch: ShareEpoch,
+        share: DLogShareShamir,
+        public_key: OprfPublicKey,
+    ) -> eyre::Result<()> {
         sqlx::query(
             "
                 INSERT INTO shares (id, share, epoch, public_key)
@@ -338,6 +367,87 @@ fn to_db_ark_serialize_uncompressed<T: CanonicalSerialize>(t: &T) -> Vec<u8> {
     let mut bytes = Vec::with_capacity(t.uncompressed_size());
     t.serialize_uncompressed(&mut bytes).expect("Can serialize");
     bytes
+}
+
+/// Generates `n` Shamir shares (for party indices `1..=n`, matching [`PartyId`]'s
+/// `party_id + 1` coefficient convention) of a single random secret, of degree `threshold - 1`,
+/// together with the corresponding OPRF public key. Used to give a cluster of real nodes
+/// consistent key material so a genuine threshold protocol run across them succeeds.
+fn generate_shamir_shares<R: Rng + CryptoRng>(
+    threshold: usize,
+    n: usize,
+    rng: &mut R,
+) -> (OprfPublicKey, Vec<DLogShareShamir>) {
+    let poly: Vec<ark_babyjubjub::Fr> = (0..threshold)
+        .map(|_| ark_babyjubjub::Fr::rand(rng))
+        .collect();
+    let public_key =
+        OprfPublicKey::new((ark_babyjubjub::EdwardsAffine::generator() * poly[0]).into_affine());
+    let shares = (1..=n)
+        .map(|x| {
+            DLogShareShamir::from(oprf_core::shamir::evaluate_poly(
+                &poly,
+                ark_babyjubjub::Fr::from(x as u64),
+            ))
+        })
+        .collect();
+    (public_key, shares)
+}
+
+/// Starts a cluster of `n` real, network-bound nodes (`n` and the threshold taken from
+/// `setup.setup`), each holding a consistent Shamir share of the same OPRF key, and each
+/// exposing both the normal `/oprf` websocket route and the `/delegate` HTTP route pointed
+/// at the whole cluster (including itself). Any of the returned nodes can be used to drive
+/// the delegate OPRF flow.
+pub async fn start_nodes_for_delegate(
+    connection_string: &str,
+    setup: &TestSetup,
+    key_id: OprfKeyId,
+) -> eyre::Result<Vec<TestNode>> {
+    let n = setup.setup.addresses().len();
+    let threshold = usize::from(u16::from(setup.setup.threshold()));
+    let ports: Vec<u16> = (0..n)
+        .map(|_| nodes_common::test_utils::random_port().expect("Can find random port"))
+        .collect();
+    let base_urls: Vec<String> = ports
+        .iter()
+        .map(|port| format!("http://127.0.0.1:{port}"))
+        .collect();
+    let services = oprf_client::to_oprf_uri_many(&base_urls, "test")?;
+
+    let epoch = ShareEpoch::default();
+    let (public_key, shares) = generate_shamir_shares(threshold, n, &mut rand::thread_rng());
+
+    let mut nodes = Vec::with_capacity(n);
+    for (party_id, port) in ports.into_iter().enumerate() {
+        let schema = oprf_test_utils::next_test_schema();
+        let mut postgres_config =
+            PostgresConfig::with_default_values(connection_string.into(), schema);
+        // set low max_connections because many parallel tests connect to the same testcontainer
+        postgres_config.max_connections = NonZeroU32::new(1).expect("1 is non-zero");
+        let secret_manager = PostgresSecretManager::init(&postgres_config).await?;
+        let pool = nodes_common::postgres::pg_pool_with_schema(&postgres_config, CreateSchema::Yes)
+            .await?;
+        MIGRATOR.run(&pool).await?;
+
+        let node = TestNode::start_with_secret_manager(
+            party_id,
+            setup,
+            pool,
+            port,
+            Some(services.clone()),
+            secret_manager,
+        );
+        node.add_key_material_with_id_epoch_and_share(
+            key_id,
+            epoch,
+            shares[party_id].clone(),
+            public_key,
+        )
+        .await?;
+        nodes.push(node);
+    }
+    Ok(nodes)
 }
 
 pub async fn wait_until_started(started_services: &StartedServices) -> eyre::Result<()> {

--- a/oprf-test-utils/Cargo.toml
+++ b/oprf-test-utils/Cargo.toml
@@ -40,7 +40,8 @@ itertools.workspace = true
 nodes-common = { workspace = true, features = ["postgres"], optional = true }
 oprf-core = { package = "taceo-oprf-core", path = "../oprf-core", version = "0.6" }
 oprf-types = { package = "taceo-oprf-types", path = "../oprf-types", version = "0.15", features = [
-  "service"
+  "chain",
+  "service",
 ] }
 rand.workspace = true
 rand_chacha.workspace = true

--- a/oprf-test-utils/src/bin/generate-test-transcript.rs
+++ b/oprf-test-utils/src/bin/generate-test-transcript.rs
@@ -1,4 +1,4 @@
-use ark_ff::{AdditiveGroup, PrimeField};
+use ark_ff::AdditiveGroup;
 use std::{collections::HashMap, path::PathBuf, process::ExitCode};
 
 use alloy::primitives::U256;
@@ -182,17 +182,6 @@ fn sol_call_proof(proof: &Proof<Bn254>) -> String {
         .map(|x| x.to_string())
         .collect::<Vec<String>>()
         .join(",")
-}
-
-pub(crate) fn evaluate_poly<F: PrimeField>(poly: &[F], x: F) -> F {
-    debug_assert!(!poly.is_empty());
-    let mut iter = poly.iter().rev();
-    let mut eval = iter.next().unwrap().to_owned();
-    for coeff in iter {
-        eval *= x;
-        eval += coeff;
-    }
-    eval
 }
 
 fn producer_contributions<R: Rng + CryptoRng>(
@@ -411,17 +400,17 @@ fn check_keygen(
     lagrange12: &[ark_babyjubjub::Fr],
     lagrange23: &[ark_babyjubjub::Fr],
 ) -> [ark_babyjubjub::Fr; 3] {
-    let alice_alice_share = evaluate_poly(alice_poly.coeffs(), 1.into());
-    let alice_bob_share = evaluate_poly(alice_poly.coeffs(), 2.into());
-    let alice_carol_share = evaluate_poly(alice_poly.coeffs(), 3.into());
+    let alice_alice_share = shamir::evaluate_poly(alice_poly.coeffs(), 1.into());
+    let alice_bob_share = shamir::evaluate_poly(alice_poly.coeffs(), 2.into());
+    let alice_carol_share = shamir::evaluate_poly(alice_poly.coeffs(), 3.into());
 
-    let bob_alice_share = evaluate_poly(bob_poly.coeffs(), 1.into());
-    let bob_bob_share = evaluate_poly(bob_poly.coeffs(), 2.into());
-    let bob_carol_share = evaluate_poly(bob_poly.coeffs(), 3.into());
+    let bob_alice_share = shamir::evaluate_poly(bob_poly.coeffs(), 1.into());
+    let bob_bob_share = shamir::evaluate_poly(bob_poly.coeffs(), 2.into());
+    let bob_carol_share = shamir::evaluate_poly(bob_poly.coeffs(), 3.into());
 
-    let carol_alice_share = evaluate_poly(carol_poly.coeffs(), 1.into());
-    let carol_bob_share = evaluate_poly(carol_poly.coeffs(), 2.into());
-    let carol_carol_share = evaluate_poly(carol_poly.coeffs(), 3.into());
+    let carol_alice_share = shamir::evaluate_poly(carol_poly.coeffs(), 1.into());
+    let carol_bob_share = shamir::evaluate_poly(carol_poly.coeffs(), 2.into());
+    let carol_carol_share = shamir::evaluate_poly(carol_poly.coeffs(), 3.into());
 
     let should_public_key =
         alice_poly.get_pk_share() + bob_poly.get_pk_share() + carol_poly.get_pk_share();
@@ -455,13 +444,13 @@ fn check_reshare(
     lagrange23: &[ark_babyjubjub::Fr],
     should_public_key: ark_babyjubjub::EdwardsAffine,
 ) -> [ark_babyjubjub::Fr; 3] {
-    let bob_alice_share = evaluate_poly(poly1.coeffs(), 1.into());
-    let bob_bob_share = evaluate_poly(poly1.coeffs(), 2.into());
-    let bob_carol_share = evaluate_poly(poly1.coeffs(), 3.into());
+    let bob_alice_share = shamir::evaluate_poly(poly1.coeffs(), 1.into());
+    let bob_bob_share = shamir::evaluate_poly(poly1.coeffs(), 2.into());
+    let bob_carol_share = shamir::evaluate_poly(poly1.coeffs(), 3.into());
 
-    let carol_alice_share = evaluate_poly(poly2.coeffs(), 1.into());
-    let carol_bob_share = evaluate_poly(poly2.coeffs(), 2.into());
-    let carol_carol_share = evaluate_poly(poly2.coeffs(), 3.into());
+    let carol_alice_share = shamir::evaluate_poly(poly2.coeffs(), 1.into());
+    let carol_bob_share = shamir::evaluate_poly(poly2.coeffs(), 2.into());
+    let carol_carol_share = shamir::evaluate_poly(poly2.coeffs(), 3.into());
 
     // reconstruct shares
     let alice_share =

--- a/oprf-types/src/api.rs
+++ b/oprf-types/src/api.rs
@@ -10,7 +10,9 @@ use std::{borrow::Cow, fmt, sync::Arc};
 
 use async_trait::async_trait;
 use http::HeaderName;
-use oprf_core::ddlog_equality::shamir::PartialDLogCommitmentsShamir;
+use oprf_core::ddlog_equality::shamir::{
+    DLogCommitmentsShamir, DLogProofShareShamir, PartialDLogCommitmentsShamir,
+};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -42,7 +44,7 @@ macro_rules! close_frame_message {
 }
 
 /// The [`OprfPublicKey`] with its latest [`ShareEpoch`].
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct OprfPublicKeyWithEpoch {
     /// The key
     pub key: OprfPublicKey,
@@ -220,6 +222,17 @@ pub struct OprfResponse {
     pub commitments: PartialDLogCommitmentsShamir,
     /// The party ID of the node
     pub party_id: PartyId,
+    /// The [`OprfPublicKeyWithEpoch`].
+    pub oprf_pub_key_with_epoch: OprfPublicKeyWithEpoch,
+}
+
+/// Server response to a delegate [`OprfRequest`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DelegateOprfResponse {
+    /// The `DLog` equality challenge based on the commitments received from the services.
+    pub challenge: DLogCommitmentsShamir,
+    /// The `DLog` equality proof shares received from the services.
+    pub responses: Vec<DLogProofShareShamir>,
     /// The [`OprfPublicKeyWithEpoch`].
     pub oprf_pub_key_with_epoch: OprfPublicKeyWithEpoch,
 }

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -376,6 +376,13 @@ start_oprf_service_nodes() {
     log "Starting OPRF service nodes"
     mkdir -p "$LOG_DIR"
 
+    local all_node_urls=()
+    for i in $(peer_indices); do
+        all_node_urls+=("http://127.0.0.1:$((10000 + i))")
+    done
+    local node_urls_csv
+    node_urls_csv=$(IFS=,; echo "${all_node_urls[*]}")
+
     for i in $(peer_indices); do
         local port=$((10000 + i))
         local wallet="${participant_addresses[$i]}"
@@ -400,6 +407,7 @@ start_oprf_service_nodes() {
         TACEO_OPRF_NODE__SERVICE__STORE_TTL=0s \
         TACEO_OPRF_NODE__SERVICE__STORE_TTI=0s \
         TACEO_OPRF_NODE__BIND_ADDR="0.0.0.0:${port}" \
+        TACEO_OPRF_NODE__NODE_URLS="$node_urls_csv" \
         "${dd_env[@]+"${dd_env[@]}"}" \
         ./target/release/examples/taceo-oprf-service-example >"$LOG_DIR/node${i}.log" 2>&1 &
         nodes_pids[$i]="$!"

--- a/scripts/run-setup.sh
+++ b/scripts/run-setup.sh
@@ -49,6 +49,7 @@ main() {
         ./target/release/examples/dev-client-example stress-test-oprf
         ./target/release/examples/dev-client-example stress-test-key-gen
         ./target/release/examples/dev-client-example delete-test
+        ./target/release/examples/dev-client-example delegate-test
         log "Dev-client tests completed successfully"
     else
         log "No dev-client tests requested, entering sleep mode. Press Ctrl+C to stop"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New distributed entry point and HTTP error mapping affect client compatibility and operational behavior; core crypto paths are largely refactored rather than rewritten, with substantial integration test coverage.
> 
> **Overview**
> Adds a **delegate OPRF** flow so thin clients can POST a blinded request to one node, which runs the multi-node WebSocket protocol and returns a [`DelegateOprfResponse`] for local finalize/unblind.
> 
> **Client (`oprf-client`)** refactors the full WebSocket path into [`distributed_oprf_core`] plus [`finalize_distributed_oprf`], adds [`delegate_distributed_oprf`], URL helpers (`to_delegate_oprf_url`, `to_oprf_pub_key_url*`), and threshold [`fetch_oprf_public_key`] over HTTP. Protocol version checks use a shared `VERSION` constant.
> 
> **Service (`oprf-service`)** exposes `POST /api/{module}/delegate` via [`module_with_delegate`] and [`oprf_delegate`], with semver query validation, mapped HTTP errors, delegate metrics, and router timeouts/body limits aligned with session lifetime.
> 
> **Tooling & ops**: dev-client `delegate-test`, example config `node_urls`, deploy scripts pass peer HTTP URLs; tests cover delegate happy path, auth, quorum, and version gates. Minor bumps: pin `axum` `=0.8.8`, `nodes-common` `0.7.4`, public `evaluate_poly` in `oprf-core` for Shamir test setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94664468d096f4b6fd411583e69e91b7b647c293. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->