### PR TITLE
docs(client): highlight security conisderations for delegate [TAC-1013]

### DIFF
--- a/oprf-client/src/lib.rs
+++ b/oprf-client/src/lib.rs
@@ -577,9 +577,9 @@ where
 /// Executes the distributed OPRF protocol via a single delegate node over HTTP.
 ///
 /// Instead of the client directly contacting every OPRF node and driving [`distributed_oprf_core`]
-/// itself, this function sends the (blinded) [`OprfRequest`] to a single delegate service. That
-/// delegate acts as the client of the distributed OPRF protocol on our behalf: it runs
-/// [`distributed_oprf_core`] against the OPRF nodes and forwards the combined result back to us
+/// itself, this function sends the (blinded) [`OprfRequest`] to a single delegate service (proxy). That
+/// proxy acts as the client of the distributed OPRF protocol on the client's behalf: it runs
+/// [`distributed_oprf_core`] against the OPRF nodes and forwards the combined result back to the client
 /// as a [`DelegateOprfResponse`].
 ///
 /// This function performs the following steps:
@@ -588,6 +588,15 @@ where
 /// 3. Verifies the combined `DLog` equality proof from the services.
 /// 4. Unblinds the combined OPRF response using the blinding factor.
 /// 5. Computes the final OPRF output by hashing the original query and the unblinded response.
+///
+/// # Security Considerations
+/// The proxy learns the same information as the nodes: the blinded query and authentication material.
+/// If the proxy is untrusted a client should verify its returned public key against a trusted source - either by
+/// fetching it directly from the contract or querying threshold-many nodes (see [`fetch_oprf_public_key`]).
+///
+/// If the public key does not match, a client _MUST_ abort the request. Generally, a diligent client should always verify the
+/// created upstream proof with the expected public inputs. This ensures a malicious proxy cannot
+/// produce an incorrect result undetected.
 ///
 /// # Returns
 /// The final [`VerifiableOprfOutput`] containing the OPRF output, the `DLog` equality proof, and the blinded and unblinded responses.

--- a/oprf-service/src/services/secret_manager/postgres/tests.rs
+++ b/oprf-service/src/services/secret_manager/postgres/tests.rs
@@ -72,7 +72,7 @@ async fn delete_row(oprf_key_id: OprfKeyId, connection: &mut PgConnection) -> ey
     .bind(oprf_key_id.to_le_bytes())
     .execute(connection)
     .await?;
-    assert!(success.rows_affected() == 1);
+    assert_eq!(success.rows_affected(), 1);
     Ok(())
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and a test-style assertion only; no runtime behavior changes.
> 
> **Overview**
> Documents **security expectations** for [`delegate_distributed_oprf`]: the HTTP delegate is described as a **proxy** that sees the same blinded query and auth material as OPRF nodes.
> 
> A new **Security Considerations** section tells clients to **cross-check the proxy’s OPRF public key** (via on-chain contract or threshold agreement through [`fetch_oprf_public_key`]), **abort** on mismatch, and **verify the returned DLog proof** against trusted public inputs so a malicious proxy cannot pass off a wrong result.
> 
> Minor doc wording shifts (“client” vs “our”) and a postgres secret-manager test assertion change from `assert!` to `assert_eq!` for `rows_affected()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55128108202a564e9f7fa38b0a1fde110e3c305d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->