### PR TITLE
ci: watch deny.toml over audit.toml in workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,7 +8,7 @@ on:
       - "**/Cargo.toml"
       - "**/Cargo.lock"
       # Run if the configuration file changes
-      - "**/audit.toml"
+      - "**/deny.toml"
   # Rerun periodically to pick up new advisories
   pull_request:
   schedule:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI trigger path only; no runtime or dependency logic changes.
> 
> **Overview**
> Updates the **Audit Dependencies** workflow so `push` path filters watch **`**/deny.toml`** instead of **`**/audit.toml`**.
> 
> Edits to the cargo-deny config file will now trigger the same CI runs as changes to `Cargo.toml` / `Cargo.lock`, aligned with the existing `cargo deny` job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9c5a14f5009aa2e2ccb0a337ff4b50a00934fbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->