### PR TITLE
build(deps): bump to arkworks 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,35 +867,38 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ark-bn254"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
 dependencies = [
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "ark-r1cs-std",
- "ark-std 0.5.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
 name = "ark-crypto-primitives"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0c292754729c8a190e50414fd1a37093c786c709899f29c9f7daccecfa855e"
+checksum = "31b3409b1846fe459d19c95df039481575ac6d5842ae63858ad75cc31219bfc1"
 dependencies = [
  "ahash",
  "ark-crypto-primitives-macros",
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-r1cs-std",
  "ark-relations",
- "ark-serialize 0.5.0",
+ "ark-serialize 0.6.0",
  "ark-snark",
- "ark-std 0.5.0",
+ "ark-std 0.6.0",
  "blake2",
+ "blake3",
  "derivative",
  "digest 0.10.7",
  "fnv",
  "merlin",
+ "num-bigint",
  "rayon",
  "sha2 0.10.9",
 ]
@@ -913,19 +916,19 @@ dependencies = [
 
 [[package]]
 name = "ark-ec"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
 dependencies = [
  "ahash",
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "ark-poly",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
  "educe",
  "fnv",
- "hashbrown 0.15.5",
- "itertools 0.13.0",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -988,7 +991,6 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "paste",
- "rayon",
  "zeroize",
 ]
 
@@ -1006,6 +1008,7 @@ dependencies = [
  "educe",
  "num-bigint",
  "num-traits",
+ "rayon",
  "zeroize",
 ]
 
@@ -1102,47 +1105,49 @@ dependencies = [
 
 [[package]]
 name = "ark-groth16"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88f1d0f3a534bb54188b8dcc104307db6c56cdae574ddc3212aec0625740fc7e"
+checksum = "a293328aa422e65527e285614ce5d1dceb0bd7b8b18d18b1b63191ee1f74cb41"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "ark-poly",
  "ark-relations",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-serialize 0.6.0",
+ "ark-snark",
+ "ark-std 0.6.0",
  "rayon",
 ]
 
 [[package]]
 name = "ark-poly"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
 dependencies = [
  "ahash",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
  "educe",
  "fnv",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "rayon",
 ]
 
 [[package]]
 name = "ark-r1cs-std"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
+checksum = "291f1c6628bfcac79b0dc2adbe401aa9100e2e96daa971645e0b18fc94de9a98"
 dependencies = [
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "ark-relations",
- "ark-std 0.5.0",
+ "ark-std 0.6.0",
  "educe",
+ "itertools 0.14.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1151,14 +1156,19 @@ dependencies = [
 
 [[package]]
 name = "ark-relations"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
+checksum = "fe4c11c797a64b8a23e22bf4e77bf582ac27bb21395e3183a9a506ba2561e9f9"
 dependencies = [
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-poly",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "foldhash 0.1.5",
+ "indexmap 2.12.1",
+ "rayon",
  "tracing",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1188,12 +1198,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive 0.5.0",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
  "num-bigint",
- "rayon",
 ]
 
 [[package]]
@@ -1202,22 +1210,12 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
 dependencies = [
- "ark-serialize-derive 0.6.0",
+ "ark-serialize-derive",
  "ark-std 0.6.0",
  "digest 0.10.7",
  "num-bigint",
+ "rayon",
  "serde_with",
-]
-
-[[package]]
-name = "ark-serialize-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -1233,14 +1231,14 @@ dependencies = [
 
 [[package]]
 name = "ark-snark"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d368e2848c2d4c129ce7679a7d0d2d612b6a274d3ea6a13bad4445d61b381b88"
+checksum = "5bdb461d2be9b2bd6f303c79fffc89f5858790a7b4d33257bca3178e2c071fb9"
 dependencies = [
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "ark-relations",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
@@ -1271,7 +1269,6 @@ checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
- "rayon",
 ]
 
 [[package]]
@@ -1282,6 +1279,7 @@ checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
+ "rayon",
 ]
 
 [[package]]
@@ -2062,13 +2060,13 @@ dependencies = [
 
 [[package]]
 name = "circom-witness-rs"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35778373aee12ef3d04966187eeae7a04f1451c9226058311f21488df6f28780"
+checksum = "3c282d3ae295c07c9bab925c76bae6d1b2726c7b0b4fc6cce5ad0d616152147b"
 dependencies = [
  "ark-bn254",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
  "byteorder",
  "cxx-build",
  "eyre",
@@ -3327,6 +3325,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -6216,26 +6215,26 @@ dependencies = [
 
 [[package]]
 name = "taceo-ark-babyjubjub"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b5a2cc31c90e79778c4f6375e5d9828171d320db3f8c911a8ad47af4a70069"
+checksum = "14ecf2df99fec8b65be444d27f4ac20d75486be15423b4cd507517683312a4b0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
 name = "taceo-ark-serde-compat"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fcd6f55fec9dd131019bdc0319db2271915056607b75bf8b8bc0a6ec496347"
+checksum = "5f7a255d21a01f083cf373ff6b4903f9dafad1e0a2a1a2119a4cee971d1bb995"
 dependencies = [
  "ark-bn254",
  "ark-ec",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
  "num-bigint",
  "serde",
  "taceo-ark-babyjubjub",
@@ -6243,34 +6242,35 @@ dependencies = [
 
 [[package]]
 name = "taceo-circom-types"
-version = "0.2.5"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae56552ed9a44722d293640d5aedd90b9940284bf1f1bf4df727b3ce5bc34b"
+checksum = "f26809b64b4b3f1540eef51b7f5a8d3d3df837db9fc7bd620eac9a99875a6e4a"
 dependencies = [
  "ark-bn254",
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "ark-groth16",
  "ark-poly",
  "ark-relations",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
  "byteorder",
  "serde",
  "serde_json",
  "taceo-ark-serde-compat",
+ "taceo-groth16",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "taceo-groth16"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56b4c2cb727c5e3312f88e0ae5785d4d5c28ccb3afa4ebe297cf9ea32b358262"
+checksum = "875d57ca43e964c44b9c9e462d053d452a0795a9655e84d9cb6113d8c9e7bead"
 dependencies = [
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "ark-groth16",
  "ark-poly",
  "ark-relations",
@@ -6281,14 +6281,14 @@ dependencies = [
 
 [[package]]
 name = "taceo-groth16-material"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3231b9df1847b843a1178e5dfdc6fd4b35b6571adb017408b073db885960f71"
+checksum = "77654b507a79e3a07a79f4138bb03b36577fdfc1de21721445692bda7bbd0e31"
 dependencies = [
  "ark-bn254",
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "ark-groth16",
- "ark-serialize 0.5.0",
+ "ark-serialize 0.6.0",
  "circom-witness-rs",
  "eyre",
  "hex",
@@ -6303,14 +6303,14 @@ dependencies = [
 
 [[package]]
 name = "taceo-groth16-sol"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d590d9ef92eee2cf8930ba4732bfbbd56d98b42545b0611b7c4ec7f112adc908"
+checksum = "b288177f2bf8c346d2a067f2c4be94661554fe66f8aa69db4cfceb8c63dd3f74"
 dependencies = [
  "alloy-primitives",
  "ark-bn254",
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "ark-groth16",
  "eyre",
  "ruint",
@@ -6390,9 +6390,9 @@ version = "0.6.2"
 dependencies = [
  "ark-bn254",
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "ark-groth16",
- "ark-serialize 0.5.0",
+ "ark-serialize 0.6.0",
  "blake3",
  "criterion",
  "itertools 0.15.0",
@@ -6415,7 +6415,7 @@ version = "0.11.1"
 dependencies = [
  "alloy",
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "clap",
  "eyre",
  "humantime",
@@ -6443,8 +6443,8 @@ dependencies = [
  "alloy",
  "ark-bn254",
  "ark-ec",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
  "async-trait",
  "axum",
  "axum-test 18.5.0",
@@ -6482,8 +6482,8 @@ name = "taceo-oprf-service"
 version = "0.19.1"
 dependencies = [
  "ark-ec",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
  "async-trait",
  "axum",
  "axum-extra",
@@ -6531,8 +6531,8 @@ dependencies = [
  "alloy",
  "ark-bn254",
  "ark-ec",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
  "askama",
  "axum",
  "axum-test 18.5.0",
@@ -6566,8 +6566,8 @@ name = "taceo-oprf-types"
 version = "0.16.0"
 dependencies = [
  "alloy",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
  "async-trait",
  "eyre",
  "http",
@@ -6584,13 +6584,13 @@ dependencies = [
 
 [[package]]
 name = "taceo-poseidon2"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbf106fb8682ee4e057872a18f431828bd467c28d2ead469e4c84dbf6ce5ec6"
+checksum = "c167df5e799207335a7acfec5404aa8fae59fad877c6cd20205815d690ba7157"
 dependencies = [
  "ark-bn254",
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-std 0.6.0",
  "num-bigint",
  "num-traits",
 ]
@@ -6638,7 +6638,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-opentelemetry-instrumentation-sdk",
  "tracing-serde 0.1.3",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -7085,7 +7085,7 @@ dependencies = [
  "symlink",
  "thiserror 2.0.18",
  "time",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -7132,7 +7132,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "web-time",
 ]
 
@@ -7166,15 +7166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
  "tracing-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,13 @@ publish = false
 
 [workspace.dependencies]
 alloy = { version = "2", default-features = false }
-ark-babyjubjub = { package = "taceo-ark-babyjubjub", version = "^0.5.3" }
-ark-bn254 = { version = "0.5" }
-ark-ec = "0.5"
-ark-ff = "0.5"
-ark-groth16 = "0.5"
-ark-serde-compat = { package = "taceo-ark-serde-compat", version = "0.5", default-features = false }
-ark-serialize = "0.5"
+ark-babyjubjub = { package = "taceo-ark-babyjubjub", version = "0.6" }
+ark-bn254 = { version = "0.6" }
+ark-ec = "0.6"
+ark-ff = "0.6"
+ark-groth16 = "0.6"
+ark-serde-compat = { package = "taceo-ark-serde-compat", version = "0.6.1", default-features = false }
+ark-serialize = "0.6"
 async-trait = "0.1"
 axum = "=0.8.8"  # We pin this version because alloy pins a tokio-tungstenite version that needs 0.8.8
 axum-extra = "0.12"
@@ -36,14 +36,14 @@ axum-test = "18"
 backon = { version = "1.6", default-features = false }
 blake3 = "1"
 ciborium = "0.2"
-circom-types = { package = "taceo-circom-types", version = "0.2.2", default-features = false }
+circom-types = { package = "taceo-circom-types", version = "0.3.1", default-features = false }
 clap = "4"
 config = { version = "0.15", default-features = false }
 criterion = "0.8"
 eyre = { version = "0.6" }
 futures = "0.3"
-groth16-material = { package = "taceo-groth16-material", version = "0.3", default-features = false }
-groth16-sol = { package = "taceo-groth16-sol", version = "0.3", default-features = false }
+groth16-material = { package = "taceo-groth16-material", version = "0.4", default-features = false }
+groth16-sol = { package = "taceo-groth16-sol", version = "0.4", default-features = false }
 http = "1"
 humantime = "2"
 humantime-serde = "1.1.1"
@@ -54,7 +54,7 @@ moka = { version = "0.12", features = ["future"] }
 nodes-common = { package = "taceo-nodes-common", version = "0.9", default-features = false }
 num-bigint = "0.4"
 parking_lot = "0.12"
-poseidon2 = { package = "taceo-poseidon2", version = "0.2", default-features = false }
+poseidon2 = { package = "taceo-poseidon2", version = "0.3", default-features = false }
 rand = { version = "0.8" }
 rand_chacha = { version = "0.3" }
 reqwest = { version = "0.13", default-features = false, features = [

--- a/oprf-service/Cargo.toml
+++ b/oprf-service/Cargo.toml
@@ -16,6 +16,7 @@ ignored = ["humantime-serde"]
 
 [dependencies]
 ark-babyjubjub = { workspace = true }
+ark-ec.workspace = true
 ark-serialize.workspace = true
 async-trait = { workspace = true }
 axum = { workspace = true, features = ["ws"] }
@@ -66,7 +67,6 @@ uuid = { workspace = true, features = ["serde", "v4"] }
 zeroize.workspace = true
 
 [dev-dependencies]
-ark-ec = { workspace = true }
 ark-ff = { workspace = true }
 axum-test = { workspace = true, features = ["ws"] }
 config = { workspace = true }

--- a/oprf-service/src/api/oprf.rs
+++ b/oprf-service/src/api/oprf.rs
@@ -1,6 +1,7 @@
 use std::num::NonZeroU16;
 use std::time::{Duration, Instant};
 
+use ark_ec::AffineRepr;
 use axum::{
     Router,
     extract::{


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core cryptographic dependencies (Groth16, BN254, OPRF stack); behavior should match 0.5 but regression risk is in proof/serialization paths across the workspace.
> 
> **Overview**
> Upgrades the workspace from **arkworks 0.5** to **0.6** across `ark-bn254`, `ark-ec`, `ark-ff`, `ark-groth16`, `ark-serialize`, and related **Taceo** crates (`taceo-ark-babyjubjub`, `taceo-ark-serde-compat`, `taceo-circom-types`, `taceo-groth16-*`, `taceo-poseidon2`, `circom-witness-rs`). `Cargo.lock` reflects the new dependency graph (including consolidated `tracing-subscriber` references).
> 
> In **`oprf-service`**, **`ark-ec`** moves from dev-dependencies to runtime dependencies so **`AffineRepr`** is available for the existing **`blinded_query.is_zero()`** identity check in the OPRF websocket handler—required under ark 0.6’s trait layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c716893825564030c5406b06da5baaad275e9f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->