### PR TITLE
ci: specify release Rust toolchain

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,6 +24,8 @@ jobs:
       - &install-rust
         name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # stable
+        with:
+          toolchain: stable
       - name: Run release-plz
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
         with:


### PR DESCRIPTION
The SHA-pinned dtolnay/rust-toolchain action cannot infer stable from the ref. Explicitly configure the stable toolchain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that pins the Rust toolchain for release automation; no application or runtime behavior changes.
> 
> **Overview**
> Fixes the **Release-plz** workflow’s shared Rust install step by adding **`toolchain: stable`** under `dtolnay/rust-toolchain`. The step is SHA-pinned (`# stable` in the comment only), so the action no longer infers the channel from the ref and release jobs could fail or use the wrong toolchain without this explicit input.
> 
> Both **release-plz-release** and **release-plz-pr** reuse the same `&install-rust` anchor, so they pick up the change together—aligned with how **ci.yml** and **audit.yml** already pass `toolchain: stable`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 667cda6cedac9beadab36d84c7501c924992474d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->