### PR TITLE
ci: disable publishing test crate

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -70,4 +70,5 @@ link_parsers = [
 [[package]]
 name = "taceo-oprf-test"
 release = false
+publish = false
 changelog_update = false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Release-plz configuration only; no runtime or library behavior changes.
> 
> **Overview**
> Sets **`publish = false`** for **`taceo-oprf-test`** in `release-plz.toml`, alongside the existing `release = false` and `changelog_update = false`.
> 
> This tells release-plz not to publish that integration-test crate during release workflows, matching the crate’s non-publishable role in the workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e757c68aa971bcd8273feb3b163addddea40f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->