### PR TITLE
themis/backfill from block [TAC-1160]

### DIFF
--- a/oprf-key-gen/src/config.rs
+++ b/oprf-key-gen/src/config.rs
@@ -28,7 +28,7 @@
 //! | `sleep_between_simulation`               | 5 s         |
 //! | `cursor_checkpoint_interval`             | 1 day       |
 
-use std::num::NonZeroU16;
+use std::num::{NonZeroU16, NonZeroU64};
 use std::{path::PathBuf, time::Duration};
 
 use alloy::primitives::Address;
@@ -148,6 +148,12 @@ pub struct OprfKeyGenServiceConfig {
     #[serde(default = "OprfKeyGenServiceConfig::default_cursor_checkpoint_interval")]
     #[serde(with = "humantime_serde")]
     pub cursor_checkpoint_interval: Duration,
+
+    /// If set, the binary will backfill from this block number inclusively.
+    ///
+    /// Ignored if the chain cursor service loads a cursor at or after this block.
+    #[serde(default)]
+    pub explicit_backfill_block: Option<NonZeroU64>,
 }
 
 /// Subset of [`OprfKeyGenServiceConfig`] containing all values that must be
@@ -279,6 +285,7 @@ impl OprfKeyGenServiceConfig {
             event_stream_config: EventStreamConfig::default(),
             cursor_checkpoint_interval: Self::default_cursor_checkpoint_interval(),
             rpc_http_timeout: Self::default_rpc_http_timeout(),
+            explicit_backfill_block: None,
         }
     }
 }

--- a/oprf-key-gen/src/lib.rs
+++ b/oprf-key-gen/src/lib.rs
@@ -202,7 +202,6 @@ pub async fn start(
 ) -> eyre::Result<(axum::Router, KeyGenTasks)> {
     tracing::info!("init oprf key-gen service..");
 
-    tracing::info!("initializing wallet...");
     let private_key = PrivateKeySigner::from_str(config.wallet_private_key.expose_secret())
         .context("while loading wallet private key")?;
     let address = private_key.address();
@@ -295,6 +294,7 @@ pub async fn start(
                 event_stream_config: config.event_stream_config,
                 threshold: config.expected_threshold,
                 cancellation_token,
+                explicit_backfill_block: config.explicit_backfill_block,
             },
         )
     });

--- a/oprf-key-gen/src/services/key_event_watcher.rs
+++ b/oprf-key-gen/src/services/key_event_watcher.rs
@@ -21,7 +21,7 @@
 //! successfully stored position.
 
 use std::{
-    num::NonZeroU16,
+    num::{NonZeroU16, NonZeroU64},
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -134,6 +134,9 @@ pub(crate) struct KeyEventWatcherTaskConfig {
     pub(crate) transaction_handler: TransactionHandler,
     /// Filtering and backfill settings forwarded to the event-stream builder.
     pub(crate) event_stream_config: EventStreamConfig,
+    /// First block to backfill, inclusively. Ignored if `chain_cursor_service` loads a
+    /// cursor at or after this block.
+    pub(crate) explicit_backfill_block: Option<NonZeroU64>,
     /// MPC threshold; passed to [`DLogSecretGenService`] for each round-1 call.
     pub(crate) threshold: NonZeroU16,
     /// Signals the task to shut down cleanly.
@@ -159,12 +162,17 @@ pub(crate) async fn key_event_watcher_task(args: KeyEventWatcherTaskConfig) -> e
         event_stream_config,
         threshold,
         cancellation_token,
+        explicit_backfill_block,
     } = args;
 
-    let chain_cursor = chain_cursor_service
+    let loaded_chain_cursor = chain_cursor_service
         .load_chain_cursor()
         .await
         .context("while loading chain cursor")?;
+
+    // check if there is an explicit block set for backfill
+    let chain_cursor = select_backfill_cursor(loaded_chain_cursor, explicit_backfill_block);
+
     tracing::info!("loaded chain cursor at: {chain_cursor}");
 
     let contract = OprfKeyRegistry::new(contract_address, http_rpc_provider.inner());
@@ -219,6 +227,33 @@ pub(crate) async fn key_event_watcher_task(args: KeyEventWatcherTaskConfig) -> e
 
     tracing::info!("successfully closed key_event_watcher without error");
     Ok(())
+}
+
+/// Chooses the cursor passed to the event stream.
+///
+/// Event streams emit logs strictly after their cursor. Positioning the cursor at the end of the
+/// preceding block therefore includes every log in `explicit_backfill_block`, including index 0.
+fn select_backfill_cursor(
+    loaded_chain_cursor: ChainCursor,
+    explicit_backfill_block: Option<NonZeroU64>,
+) -> ChainCursor {
+    match explicit_backfill_block {
+        Some(block) if loaded_chain_cursor.block() < block.get() => {
+            tracing::info!(
+                old_chain_cursor = %loaded_chain_cursor,
+                "updating chain cursor to backfill from explicit block: {block}"
+            );
+            ChainCursor::new(block.get() - 1, u64::MAX)
+        }
+        Some(block) => {
+            tracing::info!(
+                chain_cursor = %loaded_chain_cursor,
+                "ignoring explicit block: {block}. ChainCursor is at or after it"
+            );
+            loaded_chain_cursor
+        }
+        None => loaded_chain_cursor,
+    }
 }
 
 /// Decode a single chain log, dispatch it to the event handler, apply the soft-error policy,

--- a/oprf-key-gen/src/services/key_event_watcher/tests.rs
+++ b/oprf-key-gen/src/services/key_event_watcher/tests.rs
@@ -1,4 +1,10 @@
-use std::{num::NonZeroU16, path::PathBuf, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    num::{NonZeroU16, NonZeroU64},
+    path::PathBuf,
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
 
 use alloy::{
     eips::{BlockId, BlockNumberOrTag},
@@ -8,7 +14,10 @@ use alloy::{
 };
 use ark_ff::UniformRand as _;
 use groth16_material::circom::{CircomGroth16Material, CircomGroth16MaterialBuilder};
-use nodes_common::{postgres::PostgresConfig, web3::HttpRpcProvider};
+use nodes_common::{
+    postgres::PostgresConfig,
+    web3::{HttpRpcProvider, event_stream::ChainCursor},
+};
 use oprf_core::ddlog_equality::shamir::DLogShareShamir;
 use oprf_types::{
     OprfKeyId, ShareEpoch,
@@ -28,7 +37,7 @@ use crate::{
     },
 };
 
-use super::events::KeyRegistryEvent;
+use super::{events::KeyRegistryEvent, select_backfill_cursor};
 
 const CONTRACT_ADDRESS: Address = Address::repeat_byte(0x42);
 const WALLET_ADDRESS: Address = Address::repeat_byte(0x24);
@@ -388,4 +397,31 @@ async fn test_abort() -> eyre::Result<()> {
             .is_some()
     );
     Ok(())
+}
+
+#[test]
+fn explicit_backfill_starts_before_configured_block() {
+    let loaded = ChainCursor::new(42, 7);
+    let explicit = NonZeroU64::new(100).expect("100 is non-zero");
+
+    assert_eq!(
+        select_backfill_cursor(loaded, Some(explicit)),
+        ChainCursor::new(99, u64::MAX)
+    );
+}
+
+#[test]
+fn explicit_backfill_preserves_cursor_at_configured_block() {
+    let loaded = ChainCursor::new(100, 7);
+    let explicit = NonZeroU64::new(100).expect("100 is non-zero");
+
+    assert_eq!(select_backfill_cursor(loaded, Some(explicit)), loaded);
+}
+
+#[test]
+fn explicit_backfill_preserves_cursor_after_configured_block() {
+    let loaded = ChainCursor::new(101, 7);
+    let explicit = NonZeroU64::new(100).expect("100 is non-zero");
+
+    assert_eq!(select_backfill_cursor(loaded, Some(explicit)), loaded);
 }

--- a/oprf-test/src/key_gen_setup.rs
+++ b/oprf-test/src/key_gen_setup.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::num::{NonZeroU16, NonZeroUsize};
+use std::num::{NonZeroU16, NonZeroU64, NonZeroUsize};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -48,6 +48,23 @@ impl TestKeyGen {
         secret_manager: PostgresDb,
         pool: PgPool,
     ) -> eyre::Result<Self> {
+        Self::start_with_secret_manager_and_explicit_backfill_block(
+            party_id,
+            test_setup,
+            secret_manager,
+            pool,
+            None,
+        )
+        .await
+    }
+
+    async fn start_with_secret_manager_and_explicit_backfill_block(
+        party_id: usize,
+        test_setup: &TestSetup,
+        secret_manager: PostgresDb,
+        pool: PgPool,
+        explicit_backfill_block: Option<NonZeroU64>,
+    ) -> eyre::Result<Self> {
         let TestSetup {
             anvil,
             oprf_key_registry,
@@ -89,6 +106,7 @@ impl TestKeyGen {
         config.event_stream_config.skip_backfill =
             SkipBackfill::from(*mine_strategy == MineStrategy::Auto);
         config.cursor_checkpoint_interval = Duration::from_secs(2);
+        config.explicit_backfill_block = explicit_backfill_block;
 
         let started_services = StartedServices::new();
         let sm_service: oprf_key_gen::secret_manager::SecretManagerService =
@@ -123,11 +141,35 @@ impl TestKeyGen {
     }
 
     pub async fn start(party_id: usize, test_setup: &TestSetup) -> eyre::Result<Self> {
+        Self::start_with_new_secret_manager(party_id, test_setup, None).await
+    }
+
+    pub async fn start_with_explicit_backfill_block(
+        party_id: usize,
+        test_setup: &TestSetup,
+        explicit_backfill_block: NonZeroU64,
+    ) -> eyre::Result<Self> {
+        Self::start_with_new_secret_manager(party_id, test_setup, Some(explicit_backfill_block))
+            .await
+    }
+
+    async fn start_with_new_secret_manager(
+        party_id: usize,
+        test_setup: &TestSetup,
+        explicit_backfill_block: Option<NonZeroU64>,
+    ) -> eyre::Result<Self> {
         let postgres_config = crate::test_postgres_config().await?;
         let secret_manager = PostgresDb::init(&postgres_config).await?;
         let pool =
             nodes_common::postgres::pg_pool_with_schema(&postgres_config, CreateSchema::No).await?;
-        TestKeyGen::start_with_secret_manager(party_id, test_setup, secret_manager, pool).await
+        TestKeyGen::start_with_secret_manager_and_explicit_backfill_block(
+            party_id,
+            test_setup,
+            secret_manager,
+            pool,
+            explicit_backfill_block,
+        )
+        .await
     }
 
     pub async fn start_three(test_setup: &TestSetup) -> eyre::Result<[Self; 3]> {
@@ -135,6 +177,18 @@ impl TestKeyGen {
             Self::start(0, test_setup),
             Self::start(1, test_setup),
             Self::start(2, test_setup)
+        );
+        Ok([keygen0?, keygen1?, keygen2?])
+    }
+
+    pub async fn start_three_with_explicit_backfill_block(
+        test_setup: &TestSetup,
+        explicit_backfill_block: NonZeroU64,
+    ) -> eyre::Result<[Self; 3]> {
+        let (keygen0, keygen1, keygen2) = tokio::join!(
+            Self::start_with_explicit_backfill_block(0, test_setup, explicit_backfill_block),
+            Self::start_with_explicit_backfill_block(1, test_setup, explicit_backfill_block),
+            Self::start_with_explicit_backfill_block(2, test_setup, explicit_backfill_block)
         );
         Ok([keygen0?, keygen1?, keygen2?])
     }

--- a/oprf-test/tests/keygen.rs
+++ b/oprf-test/tests/keygen.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::large_futures, reason = "doesnt matter for tests")]
-use std::time::Duration;
+use std::{num::NonZeroU64, time::Duration};
 
-use alloy::{primitives::U160, sol_types::SolEvent};
+use alloy::{primitives::U160, providers::Provider as _, sol_types::SolEvent};
 use eyre::Context as _;
 use oprf_key_gen::event_cursor_store::ChainCursorStorage as _;
 use taceo_oprf::{
@@ -49,14 +49,23 @@ async fn test_keygen_works_two_three() -> eyre::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
-async fn test_keygen_works_when_init_before_start() -> eyre::Result<()> {
-    // init happens before any node subscribes, so this can only be caught via
-    // backfill, which requires interval mining (see `MineStrategy`).
+async fn test_keygen_works_with_explicit_backfill_when_init_before_start() -> eyre::Result<()> {
     let setup =
         TestSetup::with_mine_strategy(DeploySetup::TwoThree, MineStrategy::Interval(1)).await?;
+    let first_possible_event_block = setup
+        .provider
+        .get_block_number()
+        .await?
+        .checked_add(1)
+        .ok_or_else(|| eyre::eyre!("chain block number overflowed"))?;
+    let explicit_backfill_block = NonZeroU64::new(first_possible_event_block)
+        .ok_or_else(|| eyre::eyre!("explicit backfill block must be non-zero"))?;
+
     let oprf_key_id = OprfKeyId::new(U160::from(42));
     setup.init_keygen(oprf_key_id).await?;
-    let key_gens = TestKeyGen::start_three(&setup).await?;
+    let key_gens =
+        TestKeyGen::start_three_with_explicit_backfill_block(&setup, explicit_backfill_block)
+            .await?;
     let _oprf_public_key =
         keygen_asserts::all_have_key(&key_gens, oprf_key_id, ShareEpoch::default()).await?;
     Ok(())


### PR DESCRIPTION
- **feat(key-gen): add explicit block to start backfill**
- **test: added explicit backfill block test**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes event replay start position on startup, which can reprocess historical key-gen events if misconfigured; persisted cursor still wins when it is at or after the explicit block.
> 
> **Overview**
> Adds optional **`explicit_backfill_block`** config so key-gen can replay registry events from a chosen block when the persisted chain cursor is still behind that point.
> 
> On startup, **`select_backfill_cursor`** compares the loaded cursor with the configured block: if the cursor is earlier, it rewinds to the end of the preceding block (`block - 1`, `u64::MAX`) so inclusive backfill includes log index 0; if the cursor is already at or past that block, the explicit setting is ignored.
> 
> The option is wired through service config, **`key_event_watcher`**, and test helpers; unit tests cover the three cursor-selection cases, and an integration test verifies keygen when **`init_keygen`** runs before nodes start (interval mining + explicit backfill).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aca5ed58f01fbf41e9d23226131ebce00774c68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->