### PR TITLE
refactor(key-gen,node): update metric keys and exposes macro for downstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3248,9 +3248,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/oprf-key-gen/src/metrics.rs
+++ b/oprf-key-gen/src/metrics.rs
@@ -3,6 +3,24 @@
 //! This module defines all metrics keys used by the key-gen node and
 //! provides a helper [`describe_metrics`] to set metadata for
 //! each metric using the `metrics` crate.
+//!
+//! # Metrics key schema
+//!
+//! Every metric emitted by this crate follows the schema
+//!
+//! ```text
+//! taceo.oprf.key-gen.lib.METRICS_KEY
+//! ```
+//!
+//! where `lib` is the sub-project slot reserved for keys emitted by this crate. Keys are
+//! built with the `oprf_metrics_key!` macro instead of being hand-written, so the schema
+//! stays enforced.
+
+macro_rules! oprf_metrics_key {
+    ($key:expr) => {
+        concat!("taceo.oprf.key-gen.lib.", $key)
+    };
+}
 
 /// Describe all metrics used by the service.
 ///
@@ -14,8 +32,8 @@ pub fn describe_metrics() {
 
 pub(crate) mod wallet {
 
-    const METRICS_ID_KEY_GEN_WALLET_BALANCE: &str = "taceo.oprf.key_gen.wallet.balance";
-    const METRICS_ID_GAS_PRICE: &str = "taceo.oprf.key_gen.wallet.transaction.gas_price";
+    const METRICS_ID_KEY_GEN_WALLET_BALANCE: &str = oprf_metrics_key!("wallet.balance");
+    const METRICS_ID_GAS_PRICE: &str = oprf_metrics_key!("wallet.transaction.gas_price");
 
     pub(super) fn describe_metrics() {
         metrics::describe_gauge!(
@@ -45,7 +63,7 @@ pub(crate) mod wallet {
 pub(crate) mod chain_events {
     use nodes_common::web3::event_stream::ChainCursor;
 
-    const METRIC_EVENT_COUNTER: &str = "taceo.oprf.key_gen.chain.events";
+    const METRIC_EVENT_COUNTER: &str = oprf_metrics_key!("chain.events");
 
     const ATTR_TYPE_EVENT: &str = "type";
     const ATTR_EVENT_KEYGEN_ROUND1: &str = "round1.keygen";
@@ -57,9 +75,9 @@ pub(crate) mod chain_events {
     const ATTR_EVENT_ABORT: &str = "abort";
     const ATTR_EVENT_NOT_ENOUGH_PRODUCERS: &str = "not-enough-producers";
 
-    const METRIC_PRODUCER_ROLE: &str = "taceo.oprf.key_gen.role.producer";
-    const METRIC_CONSUMER_ROLE: &str = "taceo.oprf.key_gen.role.consumer";
-    const METRIC_CURRENT_BLOCK: &str = "taceo.oprf.key_gen.block.number";
+    const METRIC_PRODUCER_ROLE: &str = oprf_metrics_key!("role.producer");
+    const METRIC_CONSUMER_ROLE: &str = oprf_metrics_key!("role.consumer");
+    const METRIC_CURRENT_BLOCK: &str = oprf_metrics_key!("block.number");
 
     pub(super) fn describe_metrics() {
         metrics::describe_counter!(

--- a/oprf-service/src/metrics.rs
+++ b/oprf-service/src/metrics.rs
@@ -3,6 +3,54 @@
 //! This module defines all metrics keys used by the service and
 //! provides a helper [`describe_metrics`] to set metadata for
 //! each metric using the `metrics` crate.
+//!
+//! # Metrics key schema
+//!
+//! Every metric emitted under the TACEO:OPRF umbrella follows the schema
+//!
+//! ```text
+//! taceo.oprf.node.SUB_PROJECT.METRICS_KEY
+//! ```
+//!
+//! where `SUB_PROJECT` identifies the emitting project and `METRICS_KEY` is the
+//! metric-specific suffix. `lib` is reserved for keys emitted by this crate.
+//!
+//! Consumers building their own node metrics MUST go through [`crate::oprf_metrics_key`]
+//! instead of hand-writing the key, so the schema stays enforced:
+//!
+//! ```
+//! use taceo_oprf_service::oprf_metrics_key;
+//!
+//! const MY_KEY: &str = oprf_metrics_key!("my-service", "request.success");
+//! assert_eq!(MY_KEY, "taceo.oprf.node.my-service.request.success");
+//! ```
+
+/// Builds a metrics key following the `taceo.oprf.node.SUB_PROJECT.METRICS_KEY` schema.
+///
+/// `$sub_project` identifies the emitting project (`"lib"` for this crate); `$key` is the
+/// metric-specific suffix.
+///
+/// ```
+/// use taceo_oprf_service::oprf_metrics_key;
+///
+/// assert_eq!(
+///     oprf_metrics_key!("lib", "request.success"),
+///     "taceo.oprf.node.lib.request.success"
+/// );
+/// ```
+#[macro_export]
+macro_rules! oprf_metrics_key {
+    ($sub_project:expr, $key:expr) => {
+        concat!("taceo.oprf.node.", $sub_project, ".", $key)
+    };
+}
+
+/// Internal helper for the library.
+macro_rules! oprf_metrics_key_lib {
+    ($key:expr) => {
+        oprf_metrics_key!("lib", $key)
+    };
+}
 
 /// Describe all metrics used by the service.
 ///
@@ -17,29 +65,30 @@ pub(crate) mod request {
     use std::time::Duration;
 
     /// Metrics key for counting successful OPRF evaluations
-    const METRICS_ID_NODE_OPRF_SUCCESS: &str = "taceo.oprf.node.request.success";
+    const METRICS_ID_NODE_OPRF_SUCCESS: &str = oprf_metrics_key_lib!("request.success");
 
     /// Metrics key for counting all OPRF requests
-    const METRICS_ID_NODE_OPRF_REQUESTS: &str = "taceo.oprf.node.request";
+    const METRICS_ID_NODE_OPRF_REQUESTS: &str = oprf_metrics_key_lib!("request");
 
     /// Metrics key for the duration of successful `OprfRequestAuth` verification
-    const METRICS_ID_NODE_REQUEST_VERIFY_DURATION: &str = "taceo.oprf.node.request.verify.duration";
+    const METRICS_ID_NODE_REQUEST_VERIFY_DURATION: &str =
+        oprf_metrics_key_lib!("request.verify.duration");
     /// Metrics key for the duration of part one of the OPRF computation
-    const METRICS_ID_NODE_PART_1_DURATION: &str = "taceo.oprf.node.request.part1.duration";
+    const METRICS_ID_NODE_PART_1_DURATION: &str = oprf_metrics_key_lib!("request.part1.duration");
     /// Metrics key for the duration of part two of the OPRF computation
-    const METRICS_ID_NODE_PART_2_DURATION: &str = "taceo.oprf.node.request.part2.duration";
+    const METRICS_ID_NODE_PART_2_DURATION: &str = oprf_metrics_key_lib!("request.part2.duration");
 
     /// Metrics key for how often we reject clients due to version mismatch.
-    const METRICS_CLIENT_VERSION_MISMATCH: &str = "taceo.oprf.node.client.invalid_version";
+    const METRICS_CLIENT_VERSION_MISMATCH: &str = oprf_metrics_key_lib!("client.invalid_version");
 
     /// Metrics key for how often we terminated user connection due to timeout.
-    const METRICS_CLIENT_TIMEOUT: &str = "taceo.oprf.node.request.timeout";
+    const METRICS_CLIENT_TIMEOUT: &str = oprf_metrics_key_lib!("request.timeout");
 
     /// Metrics key for counting all OPRF delegate requests
-    const METRICS_ID_NODE_DELEGATE_REQUESTS: &str = "taceo.oprf.node.delegate";
+    const METRICS_ID_NODE_DELEGATE_REQUESTS: &str = oprf_metrics_key_lib!("delegate");
 
     /// Metrics key for counting successful OPRF delegate evaluations
-    const METRICS_ID_NODE_DELEGATE_SUCCESS: &str = "taceo.oprf.node.delegate.success";
+    const METRICS_ID_NODE_DELEGATE_SUCCESS: &str = oprf_metrics_key_lib!("delegate.success");
 
     pub(super) fn describe_metrics() {
         params::describe_metrics();
@@ -138,9 +187,9 @@ pub(crate) mod request {
     pub(crate) mod params {
 
         const METRICS_ID_NODE_CLIENT_VERSION_HEADER: &str =
-            "taceo.oprf.node.request.params.version.header";
+            oprf_metrics_key_lib!("request.params.version.header");
         const METRICS_ID_NODE_CLIENT_VERSION_QUERY: &str =
-            "taceo.oprf.node.request.params.version.query";
+            oprf_metrics_key_lib!("request.params.version.query");
 
         pub(super) fn describe_metrics() {
             metrics::describe_counter!(
@@ -167,7 +216,7 @@ pub(crate) mod request {
 
 pub(crate) mod sessions {
     /// Metrics key for counting currently running sessions.
-    const METRICS_ID_NODE_SESSIONS_OPEN: &str = "taceo.oprf.node.sessions.open";
+    const METRICS_ID_NODE_SESSIONS_OPEN: &str = oprf_metrics_key_lib!("sessions.open");
 
     pub(super) fn describe_metrics() {
         metrics::describe_gauge!(
@@ -193,11 +242,11 @@ pub(crate) mod sessions {
 pub(crate) mod secrets {
 
     /// Metrics key for stored `DLogSecrets` in cache.
-    const METRICS_ID_NODE_OPRF_SECRETS: &str = "taceo.oprf.node.secrets";
+    const METRICS_ID_NODE_OPRF_SECRETS: &str = oprf_metrics_key_lib!("secrets");
     /// Number of misses in the `DLogSecrets` cache.
-    const METRICS_ID_NODE_OPRF_SECRETS_MISSES: &str = "taceo.oprf.node.secrets.misses";
+    const METRICS_ID_NODE_OPRF_SECRETS_MISSES: &str = oprf_metrics_key_lib!("secrets.misses");
     /// Number of hits in the `DLogSecrets` cache.
-    const METRICS_ID_NODE_OPRF_SECRETS_HITS: &str = "taceo.oprf.node.secrets.hits";
+    const METRICS_ID_NODE_OPRF_SECRETS_HITS: &str = oprf_metrics_key_lib!("secrets.hits");
 
     pub(super) fn describe_metrics() {
         metrics::describe_gauge!(


### PR DESCRIPTION
NOTE: this breaks the existing metrics keys

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior is unchanged but metric identity changes break continuity in monitoring; oprf-service’s exported macro affects how downstream nodes name metrics.
> 
> **Overview**
> **This PR renames emitted metrics keys** and introduces macros so future keys follow a fixed schema. Existing dashboards or alerts that query the old names will need updating.
> 
> In **oprf-key-gen**, keys move from `taceo.oprf.key_gen.*` to `taceo.oprf.key-gen.lib.*` (underscore → hyphen, plus a `lib` segment). A crate-local `oprf_metrics_key!` macro builds those strings.
> 
> In **oprf-service**, library metrics gain a `lib` segment (e.g. `taceo.oprf.node.lib.request.success`). An exported `oprf_metrics_key!` macro lets downstream crates emit `taceo.oprf.node.SUB_PROJECT.*` keys; internal code uses `oprf_metrics_key_lib!`.
> 
> `Cargo.lock` bumps **h2** 0.4.15 → 0.4.17 (transitive dependency only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5f1f1181efe0fcb9e946c0f8e6b341860cd93ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->