### PR TITLE
refactor(key-gen): fix key-gen metrics key

### DIFF
--- a/oprf-key-gen/src/metrics.rs
+++ b/oprf-key-gen/src/metrics.rs
@@ -9,7 +9,7 @@
 //! Every metric emitted by this crate follows the schema
 //!
 //! ```text
-//! taceo.oprf.key-gen.lib.METRICS_KEY
+//! taceo.oprf.key_gen.lib.METRICS_KEY
 //! ```
 //!
 //! where `lib` is the sub-project slot reserved for keys emitted by this crate. Keys are
@@ -18,7 +18,7 @@
 
 macro_rules! oprf_metrics_key {
     ($key:expr) => {
-        concat!("taceo.oprf.key-gen.lib.", $key)
+        concat!("taceo.oprf.key_gen.lib.", $key)
     };
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Metric name changes break continuity with existing dashboards and alerts until they are updated; no auth or data-path impact.
> 
> **Overview**
> **Metrics key prefix** for OPRF key-gen is updated from `taceo.oprf.key-gen.lib.*` to `taceo.oprf.key_gen.lib.*` in the `oprf_metrics_key!` macro and the module docs.
> 
> Every gauge and counter built through that macro (wallet balance, gas price, chain events, roles, block number) will register under the new names after deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ecdbe7acc529dd2e818d500adeadc13effbf1a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->