### PR TITLE
chore: fix clippy

### DIFF
--- a/oprf-client/src/ws/wasm.rs
+++ b/oprf-client/src/ws/wasm.rs
@@ -38,6 +38,7 @@ impl WebSocketSession {
     /// Expects a valid `ws://` or `wss://` URI
     #[allow(
         clippy::unused_async,
+        clippy::unused_async_trait_impl,
         reason = "Want to have async to have equivalent signature with native"
     )]
     pub(crate) async fn new(

--- a/oprf-key-gen/src/services/secret_gen.rs
+++ b/oprf-key-gen/src/services/secret_gen.rs
@@ -471,7 +471,9 @@ fn compute_keygen_proof(
     let ciphertexts = public_inputs[5..5 + num_parties].iter();
     // parse one affine point (2 elements in inputs) per party
     let comm_plains = public_inputs[5 + num_parties..5 + num_parties * 3]
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|coords| ark_babyjubjub::EdwardsAffine::new(coords[0], coords[1]));
 
     let rp_ciphertexts = izip!(ciphertexts, comm_plains, nonces)

--- a/oprf-key-gen/src/services/secret_gen/tests.rs
+++ b/oprf-key-gen/src/services/secret_gen/tests.rs
@@ -6,7 +6,7 @@
 
 use std::path::PathBuf;
 
-use ark_ec::{CurveGroup as _, PrimeGroup};
+use ark_ec::PrimeGroup;
 use groth16_material::circom::{CircomGroth16MaterialBuilder, Validate};
 use itertools::Itertools;
 use oprf_types::crypto::{EphemeralEncryptionPublicKey, SecretGenCiphertexts};


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Lint and import-only tweaks plus an equivalent slice chunking idiom; no auth, crypto logic, or protocol changes beyond how inputs are iterated.
> 
> **Overview**
> Addresses Clippy warnings without changing runtime behavior.
> 
> In **`oprf-client` WASM WebSocket setup**, the existing `#[allow(clippy::unused_async)]` on `WebSocketSession::new` is extended with **`clippy::unused_async_trait_impl`** so the intentionally async constructor (kept for parity with the native client) stays clean under newer lint rules.
> 
> In **`oprf-key-gen` secret generation**, parsing party affine coordinates from flat `public_inputs` switches from **`.chunks_exact(2)`** to **`.as_chunks::<2>().0.iter()`**, preserving the same pairing logic while satisfying the preferred chunking style.
> 
> Test-only cleanup drops an **unused `CurveGroup` import** in `secret_gen/tests.rs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 331c761754f9ef72bec0be4f33bb03a78125cdde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->